### PR TITLE
Remove `spatial worker build --target=deployment` from /docs.

### DIFF
--- a/docs/setup-and-installing.md
+++ b/docs/setup-and-installing.md
@@ -94,8 +94,8 @@ Currently, you can try this out using the `Playground`.
 <br>The first step of running a cloud deployment is uploading all the files that your game uses. This includes executable files for the clients and workers, and the assets your workers use (like models and textures used by the Unity client to visualise the game). We call that set of game files an assembly.
 <br><br> To build an assembly for your game to use while running in the cloud, either:
     - In the Unity Editor, select **Improbable** > **Build all workers for cloud**
-    - Or, close the Unity Editor and, in the root directory of the project, run `spatial worker build --target=deployment`
-        > If you don’t close Unity before running `spatial worker build`, the command will report an error.
+    - Or, close the Unity Editor and, in the root directory of the project, run `spatial build`
+        > If you don’t close Unity before running `spatial build`, the command will report an error.
     
         **It’s done when:** You see `spatial build UnityClient UnityGameLogic succeeded` printed in your console output.
 


### PR DESCRIPTION
#### Description
Remove `spatial worker build --target=deployment` from /docs, as `--target=deployment` does not function.
#### Tests
I ran `spatial worker build --target=deployment` to confirm that it errors.
I ran `spatial build` to confirm that it succeeds.
I deployed locally and in the [cloud](https://console.improbable.io/projects/demo/deployments/asofbaroihgbo/overview).
#### Documentation
This is documentation.
#### Primary reviewers
@samiwh 