### PR TITLE
Implement world cleanup to allow reconnecting.

### DIFF
--- a/workers/unity/Assets/Gdk/Core/Worker/WorkerBase.cs
+++ b/workers/unity/Assets/Gdk/Core/Worker/WorkerBase.cs
@@ -80,6 +80,7 @@ namespace Improbable.Gdk.Core
 
             View = null;
             World = null;
+            Connection = null;
         }
 
         public virtual void RegisterSystems()

--- a/workers/unity/Assets/Gdk/Core/Worker/WorkerRegistry.cs
+++ b/workers/unity/Assets/Gdk/Core/Worker/WorkerRegistry.cs
@@ -32,6 +32,13 @@ namespace Improbable.Gdk.Core
             return worker;
         }
 
+        public static void Clear()
+        {
+            WorkerTypeToInitializationFunction.Clear();
+            WorkerTypeToAttributeSet.Clear();
+            WorldToWorker.Clear();
+        }
+
         public static void RegisterWorkerType<T>() where T : WorkerBase
         {
             string workerType = (string) typeof(T).GetField("WorkerType").GetValue(null);
@@ -46,7 +53,6 @@ namespace Improbable.Gdk.Core
         public static T CreateWorker<T>(string workerId, Vector3 origin) where T : WorkerBase
         {
             var worker = (T) Activator.CreateInstance(typeof(T), workerId, origin);
-            worker.RegisterSystems();
             return worker;
         }
 

--- a/workers/unity/Assets/Playground/Scripts/Bootstrap.cs
+++ b/workers/unity/Assets/Playground/Scripts/Bootstrap.cs
@@ -77,6 +77,15 @@ namespace Playground
 
                 connectionConfig = ConnectionUtility.CreateConnectionConfigFromCommandLine(commandLineArgs);
             }
+        }
+
+        public void Start()
+        {
+            foreach (var worker in Workers)
+            {
+                LoadLevel(worker);
+                worker.Connect(connectionConfig);
+            }
 
             if (World.AllWorlds.Count <= 0)
             {
@@ -90,13 +99,15 @@ namespace Playground
             World.Active = worlds[0];
         }
 
-        public void Start()
+        private void OnDisable()
         {
             foreach (var worker in Workers)
             {
-                LoadLevel(worker);
-                worker.Connect(connectionConfig);
+                worker.Clear();
             }
+
+            WorkerRegistry.Clear();
+            ScriptBehaviourUpdateOrder.UpdatePlayerLoop();
         }
 
         public static void InitializeWorkerTypes()

--- a/workers/unity/Assets/Playground/Scripts/Player/ProcessLaunchCommandSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/Player/ProcessLaunchCommandSystem.cs
@@ -18,8 +18,7 @@ namespace Playground
             [ReadOnly] public EntityArray Entity;
             public ComponentDataArray<SpatialOSLauncher> Launcher;
 
-            [ReadOnly]
-            public ComponentArray<CommandRequests<Generated.Playground.Launcher.LaunchEntity.Request>> CommandRequests;
+            [ReadOnly] public ComponentArray<CommandRequests<Generated.Playground.Launcher.LaunchEntity.Request>> CommandRequests;
 
             [ReadOnly] public ComponentDataArray<CommandRequestSender<SpatialOSLaunchable>> Sender;
         }
@@ -29,8 +28,7 @@ namespace Playground
             public int Length;
             public ComponentDataArray<SpatialOSLaunchable> Launchable;
 
-            [ReadOnly]
-            public ComponentArray<CommandRequests<Generated.Playground.Launchable.LaunchMe.Request>> CommandRequests;
+            [ReadOnly] public ComponentArray<CommandRequests<Generated.Playground.Launchable.LaunchMe.Request>> CommandRequests;
 
             [ReadOnly] public ComponentArray<Rigidbody> Rigidbody;
         }


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](https://github.com/spatialos/UnityGDK/blob/master/CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](https://github.com/spatialos/UnityGDK/blob/master/README.md#give-us-feedback).

-------

#### Description
If you ever try to switch scenes, you will find that you get a whole bunch of null refs due to worlds not being cleaned up properly between runs.

There is an issue that its not possible to reconnect because the ID of the client does not change. This issue is tracked in UTY-483 and won't be fixed here because its out of scope.

#### Tests
Create two scenes and switch between them.

#### Documentation
N/A

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.