### PR TITLE
UTY-189: Mutable View API Review

### DIFF
--- a/workers/unity/Assets/Gdk/Core/Components/WorldCommandsTranslation.cs
+++ b/workers/unity/Assets/Gdk/Core/Components/WorldCommandsTranslation.cs
@@ -201,8 +201,8 @@ namespace Improbable.Gdk.Core
                 () => new CommandResponses<DeleteEntityResponse>(),
                 (component) => component.Buffer.Clear());
 
-        private static readonly ComponentPool<CommandResponses<ReserveEntityIdsResponse>> reserveEntityIdsResponsesPool =
-            new ComponentPool<CommandResponses<ReserveEntityIdsResponse>>(
+        private static readonly ComponentPool<CommandResponses<ReserveEntityIdsResponse>> reserveEntityIdsResponsesPool
+            = new ComponentPool<CommandResponses<ReserveEntityIdsResponse>>(
                 () => new CommandResponses<ReserveEntityIdsResponse>(),
                 (component) => component.Buffer.Clear());
 

--- a/workers/unity/Assets/Gdk/Core/Components/WorldCommandsTranslation.cs
+++ b/workers/unity/Assets/Gdk/Core/Components/WorldCommandsTranslation.cs
@@ -191,6 +191,26 @@ namespace Improbable.Gdk.Core
         internal List<ReserveEntityIdsRequest> ReserveEntityIdsRequests = new List<ReserveEntityIdsRequest>();
         internal List<EntityQueryRequest> EntityQueryRequests = new List<EntityQueryRequest>();
 
+        private static readonly ComponentPool<CommandResponses<CreateEntityResponse>> createEntityResponsePool =
+            new ComponentPool<CommandResponses<CreateEntityResponse>>(
+                () => new CommandResponses<CreateEntityResponse>(),
+                (component) => component.Buffer.Clear());
+
+        private static readonly ComponentPool<CommandResponses<DeleteEntityResponse>> deleteEntityResponsePool =
+            new ComponentPool<CommandResponses<DeleteEntityResponse>>(
+                () => new CommandResponses<DeleteEntityResponse>(),
+                (component) => component.Buffer.Clear());
+
+        private static readonly ComponentPool<CommandResponses<ReserveEntityIdsResponse>> reserveEntityIdsResponsesPool =
+            new ComponentPool<CommandResponses<ReserveEntityIdsResponse>>(
+                () => new CommandResponses<ReserveEntityIdsResponse>(),
+                (component) => component.Buffer.Clear());
+
+        private static readonly ComponentPool<CommandResponses<EntityQueryResponse>> entityQueryResponsePool =
+            new ComponentPool<CommandResponses<EntityQueryResponse>>(
+                () => new CommandResponses<EntityQueryResponse>(),
+                (component) => component.Buffer.Clear());
+
         public WorldCommandsTranslation(MutableView view) : base(view)
         {
         }
@@ -274,7 +294,7 @@ namespace Improbable.Gdk.Core
             var response =
                 new CreateEntityResponse((CommandStatusCode) op.StatusCode, op.Message, op.EntityId.Value.Id);
 
-            view.AddCommandResponse(entity, response);
+            view.AddCommandResponse(entity, response, createEntityResponsePool);
         }
 
         public void OnDeleteEntityResponse(DeleteEntityResponseOp op)
@@ -288,7 +308,7 @@ namespace Improbable.Gdk.Core
             var response =
                 new DeleteEntityResponse((CommandStatusCode) op.StatusCode, op.Message, op.EntityId.Id);
 
-            view.AddCommandResponse(entity, response);
+            view.AddCommandResponse(entity, response, deleteEntityResponsePool);
         }
 
         public void OnReserveEntityIdResponse(ReserveEntityIdsResponseOp op)
@@ -302,7 +322,7 @@ namespace Improbable.Gdk.Core
             var response = new ReserveEntityIdsResponse((CommandStatusCode) op.StatusCode, op.Message,
                 op.FirstEntityId.Value.Id, op.NumberOfEntityIds);
 
-            view.AddCommandResponse(entity, response);
+            view.AddCommandResponse(entity, response, reserveEntityIdsResponsesPool);
         }
 
         public void OnEntityQueryResponse(EntityQueryResponseOp op)
@@ -322,7 +342,7 @@ namespace Improbable.Gdk.Core
             var response =
                 new EntityQueryResponse((CommandStatusCode) op.StatusCode, op.Message, op.ResultCount, result);
 
-            view.AddCommandResponse(entity, response);
+            view.AddCommandResponse(entity, response, entityQueryResponsePool);
         }
 
         private bool TryGetEntityFromRequestId(uint requestId, string responseName, out Entity entity)

--- a/workers/unity/Assets/Gdk/Core/Components/WorldCommandsTranslation.cs
+++ b/workers/unity/Assets/Gdk/Core/Components/WorldCommandsTranslation.cs
@@ -194,22 +194,22 @@ namespace Improbable.Gdk.Core
         private static readonly ComponentPool<CommandResponses<CreateEntityResponse>> createEntityResponsePool =
             new ComponentPool<CommandResponses<CreateEntityResponse>>(
                 () => new CommandResponses<CreateEntityResponse>(),
-                (component) => component.Buffer.Clear());
+                component => component.Buffer.Clear());
 
         private static readonly ComponentPool<CommandResponses<DeleteEntityResponse>> deleteEntityResponsePool =
             new ComponentPool<CommandResponses<DeleteEntityResponse>>(
                 () => new CommandResponses<DeleteEntityResponse>(),
-                (component) => component.Buffer.Clear());
+                component => component.Buffer.Clear());
 
         private static readonly ComponentPool<CommandResponses<ReserveEntityIdsResponse>> reserveEntityIdsResponsesPool
             = new ComponentPool<CommandResponses<ReserveEntityIdsResponse>>(
                 () => new CommandResponses<ReserveEntityIdsResponse>(),
-                (component) => component.Buffer.Clear());
+                component => component.Buffer.Clear());
 
         private static readonly ComponentPool<CommandResponses<EntityQueryResponse>> entityQueryResponsePool =
             new ComponentPool<CommandResponses<EntityQueryResponse>>(
                 () => new CommandResponses<EntityQueryResponse>(),
-                (component) => component.Buffer.Clear());
+                component => component.Buffer.Clear());
 
         public WorldCommandsTranslation(MutableView view) : base(view)
         {

--- a/workers/unity/Assets/Gdk/Core/MutableView/MutableView.cs
+++ b/workers/unity/Assets/Gdk/Core/MutableView/MutableView.cs
@@ -92,14 +92,6 @@ namespace Improbable.Gdk.Core
             return HasComponent<T>(entity) ? GetComponentObject<T>(entity) : pool.GetComponent();
         }
 
-        private void AddReceivedMessageToComponent<TMessagesReceived, TMessage>(Entity entity, TMessage message)
-            where TMessagesReceived : MessagesReceived<TMessage>, new()
-        {
-            TMessagesReceived messageBuffer = GetOrCreateComponent<TMessagesReceived>(entity);
-            messageBuffer.Buffer.Add(message);
-            SetComponentObject(entity, messageBuffer);
-        }
-
         private void AddReceivedMessageToComponent<TMessagesReceived, TMessage>(Entity entity, TMessage message,
             ComponentPool<TMessagesReceived> pool)
             where TMessagesReceived : MessagesReceived<TMessage>, new()

--- a/workers/unity/Assets/Gdk/Core/MutableView/MutableView.cs
+++ b/workers/unity/Assets/Gdk/Core/MutableView/MutableView.cs
@@ -17,7 +17,6 @@ namespace Improbable.Gdk.Core
         public Dictionary<int, ComponentTranslation> TranslationUnits;
         public Action<Entity, long> AddAllCommandRequestSenders;
 
-        public Connection Connection;
         public World World;
 
         public EntityManager EntityManager { get; }
@@ -127,22 +126,6 @@ namespace Improbable.Gdk.Core
             AddComponent(entity, component);
         }
 
-        public void AddSharedComponent<T>(Entity entity, T component) where T : struct, ISharedComponentData
-        {
-            EntityManager.AddSharedComponentData(entity, component);
-        }
-
-        public void AddSharedComponent<T>(long entityId, T component) where T : struct, ISharedComponentData
-        {
-            Entity entity;
-            if (!TryGetEntity(entityId, out entity))
-            {
-                Debug.LogErrorFormat(Errors.NoCorrespondingEntityForEntityId, typeof(T).Name, entityId);
-            }
-
-            AddSharedComponent(entity, component);
-        }
-
         public void RemoveComponent<T>(Entity entity)
         {
             EntityManager.RemoveComponent<T>(entity);
@@ -167,11 +150,6 @@ namespace Improbable.Gdk.Core
         public T GetComponent<T>(Entity entity) where T : struct, IComponentData
         {
             return EntityManager.GetComponentData<T>(entity);
-        }
-
-        public T GetSharedComponent<T>(Entity entity) where T : struct, ISharedComponentData
-        {
-            return EntityManager.GetSharedComponentData<T>(entity);
         }
 
         public T GetComponentObject<T>(Entity entity) where T : Component
@@ -220,12 +198,7 @@ namespace Improbable.Gdk.Core
             where T : struct, IComponentData
         {
             EntityManager.SetComponentData(entity, component);
-            AddReceivedMessageToComponent<ComponentsUpdated<T>, T>(entity, component, pool);
-        }
-
-        public void UpdateSharedComponent<T>(Entity entity, T component) where T : struct, ISharedComponentData
-        {
-            EntityManager.SetSharedComponentData(entity, component);
+            AddReceivedMessageToComponent(entity, component, pool);
         }
 
         public void UpdateComponentObject<T>(Entity entity, T component, ComponentPool<ComponentsUpdated<T>> pool)
@@ -247,11 +220,6 @@ namespace Improbable.Gdk.Core
             AddReceivedMessageToComponent(entity, commandRequest, pool);
         }
 
-        public void AddCommandResponse<T>(Entity entity, T commandResponse) where T : struct, IIncomingCommandResponse
-        {
-            AddReceivedMessageToComponent<CommandResponses<T>, T>(entity, commandResponse);
-        }
-
         public void AddCommandResponse<T>(Entity entity, T commandResponse, ComponentPool<CommandResponses<T>> pool)
             where T : struct, IIncomingCommandResponse
         {
@@ -268,7 +236,7 @@ namespace Improbable.Gdk.Core
             return EntityManager.HasComponent(entity, componentType);
         }
 
-        public void CreateEntity(long entityId)
+        internal void CreateEntity(long entityId)
         {
             if (entityMapping.ContainsKey(entityId))
             {
@@ -295,7 +263,7 @@ namespace Improbable.Gdk.Core
         public void RemoveEntity(long entityId)
         {
             Entity entity;
-            if (!entityMapping.TryGetValue(entityId, out entity))
+            if (!TryGetEntity(entityId, out entity))
             {
                 Debug.LogErrorFormat(Errors.DeleteNonExistantEntity, entityId);
                 return;
@@ -370,7 +338,7 @@ namespace Improbable.Gdk.Core
                 return;
             }
 
-            HandleAuthorityChange<T>(entity, authority, pool);
+            HandleAuthorityChange(entity, authority, pool);
         }
 
         private static class Errors

--- a/workers/unity/Assets/Gdk/Core/Worker/WorkerBase.cs
+++ b/workers/unity/Assets/Gdk/Core/Worker/WorkerBase.cs
@@ -50,8 +50,6 @@ namespace Improbable.Gdk.Core
                 return false;
             }
 
-            View.Connection = Connection;
-
             Application.quitting += () =>
             {
                 ConnectionUtility.Disconnect(Connection);


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](https://github.com/spatialos/UnityGDK/blob/master/CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](https://github.com/spatialos/UnityGDK/blob/master/README.md#give-us-feedback).

-------

#### Description
This PR makes some changes to the `MutableView` API to clean it up by removing unnecessary methods/fields, making things internal where appropriate, and reorganising the methods such that they go in `public` -> `internal` -> `private` order.

List of changes:
* Remove all shared component methods on the `MutableView` as they were not used and a relic of the past.
* Remove the connection on the view and the setting of it in the Worker. Systems now access the connection via the worker abstraction.
* Added component pools to world commands, this allowed me to remove `AddCommandResponse<T>(Entity entity, T commandResponse)` and `private void AddReceivedMessageToComponent<TMessagesReceived, TMessage>(Entity entity, TMessage message)`
* Removed one of the `HandleAuthorityChange` methods as one literally just called the other.
* Removed: `T GetOrCreateComponent<T>(Entity entity)` as it was no longer being used.
* Made `CreateEntity` and `RemoveEntity` internal. These should not be publicly available for use as they are meant for ops coming off the wire.

#### Tests
Built and ran locally.
#### Documentation
N/A
#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
@sami @jessicafalk 
