### PR TITLE
UTY-370: Link world to a monobehaviour.

### DIFF
--- a/workers/unity/Assets/Playground/Scripts/Player/ProcessLaunchCommandSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/Player/ProcessLaunchCommandSystem.cs
@@ -18,8 +18,7 @@ namespace Playground
             [ReadOnly] public EntityArray Entity;
             public ComponentDataArray<SpatialOSLauncher> Launcher;
 
-            [ReadOnly]
-            public ComponentArray<CommandRequests<Generated.Playground.Launcher.LaunchEntity.Request>> CommandRequests;
+            [ReadOnly] public ComponentArray<CommandRequests<Generated.Playground.Launcher.LaunchEntity.Request>> CommandRequests;
 
             [ReadOnly] public ComponentDataArray<CommandRequestSender<SpatialOSLaunchable>> Sender;
         }
@@ -29,8 +28,7 @@ namespace Playground
             public int Length;
             public ComponentDataArray<SpatialOSLaunchable> Launchable;
 
-            [ReadOnly]
-            public ComponentArray<CommandRequests<Generated.Playground.Launchable.LaunchMe.Request>> CommandRequests;
+            [ReadOnly] public ComponentArray<CommandRequests<Generated.Playground.Launchable.LaunchMe.Request>> CommandRequests;
 
             [ReadOnly] public ComponentArray<Rigidbody> Rigidbody;
         }

--- a/workers/unity/Assets/Playground/Scripts/Spawning/GameObjectInitializationSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/Spawning/GameObjectInitializationSystem.cs
@@ -93,6 +93,7 @@ namespace Playground
             var spatialOSComponent = gameObject.AddComponent<SpatialOSComponent>();
             spatialOSComponent.Entity = entity;
             spatialOSComponent.SpatialEntityId = spatialEntityId;
+            spatialOSComponent.World = World;
 
             foreach (var component in gameObject.GetComponents<Component>())
             {

--- a/workers/unity/Assets/Playground/Scripts/Spawning/SpatialOSComponent.cs
+++ b/workers/unity/Assets/Playground/Scripts/Spawning/SpatialOSComponent.cs
@@ -7,5 +7,6 @@ namespace Playground
     {
         public long SpatialEntityId;
         public Entity Entity;
+        public World World;
     }
 }


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](https://github.com/spatialos/UnityGDK/blob/master/CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](https://github.com/spatialos/UnityGDK/blob/master/README.md#give-us-feedback).

-------

#### Description
Very small change to also add a World to the SpatialOSComponent which links 

#### Tests
N/A

#### Documentation
N/A

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
@samiwh @JonasImprobable 