### PR TITLE
UTY-407: Decouple ISpatialComponentData from IComponentData

### DIFF
--- a/code_generator/Templates/UnityComponentDataGenerator.tt
+++ b/code_generator/Templates/UnityComponentDataGenerator.tt
@@ -8,11 +8,12 @@
 <#= generatedHeader #>
 
 using Unity.Mathematics;
+using Unity.Entities;
 using Improbable.Gdk.Core;
 
 namespace <#= qualifiedNamespace #>
 { 
-    public struct <#= componentDetails.TypeName #> : ISpatialComponentData
+    public struct <#= componentDetails.TypeName #> : IComponentData, ISpatialComponentData
     {
         public bool1 DirtyBit { get; set; }
 <# foreach(var fieldDetails in fieldDetailsList) { #>

--- a/code_generator/Templates/UnityComponentGenerator.tt
+++ b/code_generator/Templates/UnityComponentGenerator.tt
@@ -9,10 +9,11 @@
 
 using UnityEngine;
 using Unity.Mathematics;
+using Improbable.Gdk.Core;
 
 namespace <#= qualifiedNamespace #>
 { 
-    public class <#= componentDetails.TypeName #> : Component
+    public class <#= componentDetails.TypeName #> : Component, ISpatialComponentData
     {
         public bool1 DirtyBit { get; set; }
 <# foreach(var fieldDetails in fieldDetailsList) { #>

--- a/docs/content/component-data.md
+++ b/docs/content/component-data.md
@@ -8,17 +8,14 @@ SpatialOS components are generated from `.schema` files into components that the
 
 ### Overview
 
-A `struct`, which implements `Unity.Entities.IComponentData`, by implementing `Improbable.Gdk.Core.ISpatialComponentData`,
+A `struct`, which implements `Unity.Entities.IComponentData` and `Improbable.Gdk.Core.ISpatialComponentData`,
 is generated for each [blittable](https://docs.microsoft.com/en-us/dotnet/framework/interop/blittable-and-non-blittable-types) SpatialOS component.
-A `class`, extending `UnityEngine.Component`, is generated for each non-blittable SpatialOS component.
+A `class`, which extends `UnityEngine.Component` and implements `Improbable.Gdk.Core.ISpatialComponentData` is generated for each non-blittable SpatialOS component.
 
 Each of these structs will be named `SpatialOS[schemalang component name]` and will contain only the schema data fields.
 It will **Not** contain any fields or methods pertaining to [commands](commands.md) or [events](events.md) defined on that component. 
 
-**NOTE** Blittable components actually implement `ISpatialComponentData` which implements `IComponentData`. 
-This is an implementaion detail of the current replication system.
-
-For example, the following component contains only blittable fields, so an `ISpatialComponentData` will be generated, similar to the example below.
+For example, the following component contains only blittable fields, so an `IComponentData` will be generated, similar to the example below.
 
 Schemalang
 ```
@@ -29,7 +26,7 @@ component Blittable {
 ```
 Generated component
 ```	csharp
-struct SpatialOSBlittable : ISpatialComponentData
+struct SpatialOSBlittable : IComponentData, ISpatialComponentData
 {
   public int Value;
 }
@@ -48,7 +45,7 @@ component NonBlittableComponent {
 ```
 Generated component
 ```	csharp
-class SpatialOSNonBlittable : Component
+class SpatialOSNonBlittable : Component, ISpatialComponentData
 {
   public int IntBlittable;
   public Dictionary<int, float> MapNonBlittable;

--- a/workers/unity/Assets/Gdk/Core/Components/ISpatialComponentData.cs
+++ b/workers/unity/Assets/Gdk/Core/Components/ISpatialComponentData.cs
@@ -3,7 +3,7 @@ using Unity.Mathematics;
 
 namespace Improbable.Gdk.Core
 {
-    public interface ISpatialComponentData : IComponentData
+    public interface ISpatialComponentData
     {
         bool1 DirtyBit { get; set; }
     }

--- a/workers/unity/Assets/Gdk/Core/Systems/CustomSpatialOSSendSystem.cs
+++ b/workers/unity/Assets/Gdk/Core/Systems/CustomSpatialOSSendSystem.cs
@@ -3,7 +3,7 @@ using Unity.Entities;
 namespace Improbable.Gdk.Core
 {
     [UpdateInGroup(typeof(SpatialOSSendGroup.CustomSpatialOSSendGroup))]
-    public abstract class CustomSpatialOSSendSystem<T> : ComponentSystem where T : struct, ISpatialComponentData
+    public abstract class CustomSpatialOSSendSystem<T> : ComponentSystem where T : ISpatialComponentData
     {
         private SpatialOSSendSystem spatialOSSendSystem;
 


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](https://github.com/spatialos/UnityGDK/blob/master/CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](https://github.com/spatialos/UnityGDK/blob/master/README.md#give-us-feedback).

-------

#### Description
We have overlooked the fact that all blittable components inherit from `ISpatialComponentData` and non-blittable components have no indication that they are Spatial. 

This PR corrects that by decoupling `ISpatialComponentData` from `IComponentData` and tweaking the `tt` files to extend two interface(s)/base class. 

This allows us to test components for "Spatial-ity" by checking that it implements `ISpatialComponentData`.

Also done a driveby to fix `CustomSendSystem`
#### Tests
Tested locally, compiled and ran as expected.
#### Documentation
Updated `component-data.md` to match the changes.
#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
@samiwh @ElleEss 