### PR TITLE
UTY-329: Automatic disconnect at the start of compilation.

### DIFF
--- a/workers/unity/Assets/Gdk/Core/Components/WorldCommandsTranslation.cs
+++ b/workers/unity/Assets/Gdk/Core/Components/WorldCommandsTranslation.cs
@@ -364,7 +364,8 @@ namespace Improbable.Gdk.Core
             }
             else if (!view.TryGetEntity(entityId, out entity))
             {
-                Debug.LogWarningFormat(TranslationErrors.CannotFindEntityForWorldCommandResponse, entityId, responseName);
+                Debug.LogWarningFormat(TranslationErrors.CannotFindEntityForWorldCommandResponse, entityId,
+                    responseName);
                 return false;
             }
 

--- a/workers/unity/Assets/Gdk/Core/Worker/WorkerBase.cs
+++ b/workers/unity/Assets/Gdk/Core/Worker/WorkerBase.cs
@@ -73,7 +73,7 @@ namespace Improbable.Gdk.Core
                 return;
             }
 
-            View.Disconnect("WorkerBase.Disconnect() called.");
+            View.Disconnect("Disconnect called.");
             ConnectionUtility.Disconnect(Connection);
             Connection = null;
         }

--- a/workers/unity/Assets/Gdk/Core/Worker/WorkerBase.cs
+++ b/workers/unity/Assets/Gdk/Core/Worker/WorkerBase.cs
@@ -66,6 +66,18 @@ namespace Improbable.Gdk.Core
             return true;
         }
 
+        public void Disconnect()
+        {
+            if (Connection == null)
+            {
+                return;
+            }
+
+            View.Disconnect("WorkerBase.Disconnect() called.");
+            ConnectionUtility.Disconnect(Connection);
+            Connection = null;
+        }
+
         public virtual void RegisterSystems()
         {
             RegisterCoreSystems();

--- a/workers/unity/Assets/Gdk/Core/Worker/WorkerBase.cs
+++ b/workers/unity/Assets/Gdk/Core/Worker/WorkerBase.cs
@@ -70,10 +70,11 @@ namespace Improbable.Gdk.Core
         {
             if (Connection == null)
             {
+                Debug.LogError("Attempted to disconnect but connection is already null.");
                 return;
             }
 
-            View.Disconnect("Disconnect called.");
+            View.Disconnect("Disconnect called on worker.");
             ConnectionUtility.Disconnect(Connection);
             Connection = null;
         }

--- a/workers/unity/Assets/Playground/Scripts/Bootstrap.cs
+++ b/workers/unity/Assets/Playground/Scripts/Bootstrap.cs
@@ -97,7 +97,10 @@ namespace Playground
         {
             foreach (var worker in Workers)
             {
-                worker.Disconnect();
+                if (worker.Connection != null && worker.Connection.IsConnected)
+                {
+                    worker.Disconnect();
+                }
             }
         }
 

--- a/workers/unity/Assets/Playground/Scripts/Bootstrap.cs
+++ b/workers/unity/Assets/Playground/Scripts/Bootstrap.cs
@@ -92,7 +92,7 @@ namespace Playground
             World.Active = worlds[0];
         }
 
-        private static void CompilationStarted(String destination)
+        private static void CompilationStarted(string destination)
         {
             foreach (var worker in Workers)
             {
@@ -136,6 +136,7 @@ namespace Playground
 
         public static void DomainUnloadShutdown()
         {
+            CompilationPipeline.assemblyCompilationStarted -= CompilationStarted;
             World.DisposeAllWorlds();
             ScriptBehaviourUpdateOrder.UpdatePlayerLoop();
         }

--- a/workers/unity/Assets/Playground/Scripts/Bootstrap.cs
+++ b/workers/unity/Assets/Playground/Scripts/Bootstrap.cs
@@ -92,7 +92,7 @@ namespace Playground
             World.Active = worlds[0];
         }
 
-        private static void CompilationStarted(String destination) 
+        private static void CompilationStarted(String destination)
         {
             foreach (var worker in Workers)
             {

--- a/workers/unity/Assets/Playground/Scripts/Bootstrap.cs
+++ b/workers/unity/Assets/Playground/Scripts/Bootstrap.cs
@@ -116,7 +116,7 @@ namespace Playground
             WorkerRegistry.RegisterWorkerType<UnityGameLogic>();
         }
 
-        public static void SetupInjectionHooks() 
+        public static void SetupInjectionHooks()
         {
             // Reflection to get internal hook classes. Doesn't seem to be a proper way to do this.
             var gameObjectArrayInjectionHookType =

--- a/workers/unity/Assets/Playground/Scripts/Bootstrap.cs
+++ b/workers/unity/Assets/Playground/Scripts/Bootstrap.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Improbable.Gdk.Core;
 using Unity.Entities;
+using UnityEditor.Compilation;
 using UnityEngine;
 #if UNITY_EDITOR
 using UnityEditor;
@@ -28,6 +29,7 @@ namespace Playground
             SetupInjectionHooks(); // Register hybrid injection hooks
             PlayerLoopManager.RegisterDomainUnload(DomainUnloadShutdown, 10000); // Clean up worlds and player loop
 
+            CompilationPipeline.assemblyCompilationStarted += CompilationStarted;
             Application.targetFrameRate = TargetFrameRate;
             if (Application.isEditor)
             {
@@ -88,6 +90,14 @@ namespace Playground
             ScriptBehaviourUpdateOrder.UpdatePlayerLoop(worlds);
             // Systems don't tick if World.Active isn't set
             World.Active = worlds[0];
+        }
+
+        private static void CompilationStarted(String destination) 
+        {
+            foreach (var worker in Workers)
+            {
+                worker.Disconnect();
+            }
         }
 
         public void Start()

--- a/workers/unity/Assets/Playground/Scripts/Bootstrap.cs
+++ b/workers/unity/Assets/Playground/Scripts/Bootstrap.cs
@@ -3,10 +3,10 @@ using System.Collections.Generic;
 using System.Linq;
 using Improbable.Gdk.Core;
 using Unity.Entities;
-using UnityEditor.Compilation;
 using UnityEngine;
 #if UNITY_EDITOR
 using UnityEditor;
+using UnityEditor.Compilation;
 
 #endif
 
@@ -29,11 +29,12 @@ namespace Playground
             SetupInjectionHooks(); // Register hybrid injection hooks
             PlayerLoopManager.RegisterDomainUnload(DomainUnloadShutdown, 10000); // Clean up worlds and player loop
 
-            CompilationPipeline.assemblyCompilationStarted += CompilationStarted;
             Application.targetFrameRate = TargetFrameRate;
             if (Application.isEditor)
             {
 #if UNITY_EDITOR
+                CompilationPipeline.assemblyCompilationStarted += CompilationStarted;
+
                 var workerConfigurations =
                     AssetDatabase.LoadAssetAtPath<ScriptableWorkerConfiguration>(ScriptableWorkerConfiguration
                         .AssetPath);
@@ -115,7 +116,7 @@ namespace Playground
             WorkerRegistry.RegisterWorkerType<UnityGameLogic>();
         }
 
-        public static void SetupInjectionHooks()
+        public static void SetupInjectionHooks() 
         {
             // Reflection to get internal hook classes. Doesn't seem to be a proper way to do this.
             var gameObjectArrayInjectionHookType =
@@ -136,7 +137,10 @@ namespace Playground
 
         public static void DomainUnloadShutdown()
         {
+#if UNITY_EDITOR
             CompilationPipeline.assemblyCompilationStarted -= CompilationStarted;
+#endif
+
             World.DisposeAllWorlds();
             ScriptBehaviourUpdateOrder.UpdatePlayerLoop();
         }

--- a/workers/unity/Assets/Playground/Scripts/Player/ProcessLaunchCommandSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/Player/ProcessLaunchCommandSystem.cs
@@ -18,7 +18,8 @@ namespace Playground
             [ReadOnly] public EntityArray Entity;
             public ComponentDataArray<SpatialOSLauncher> Launcher;
 
-            [ReadOnly] public ComponentArray<CommandRequests<Generated.Playground.Launcher.LaunchEntity.Request>> CommandRequests;
+            [ReadOnly]
+            public ComponentArray<CommandRequests<Generated.Playground.Launcher.LaunchEntity.Request>> CommandRequests;
 
             [ReadOnly] public ComponentDataArray<CommandRequestSender<SpatialOSLaunchable>> Sender;
         }
@@ -28,7 +29,8 @@ namespace Playground
             public int Length;
             public ComponentDataArray<SpatialOSLaunchable> Launchable;
 
-            [ReadOnly] public ComponentArray<CommandRequests<Generated.Playground.Launchable.LaunchMe.Request>> CommandRequests;
+            [ReadOnly]
+            public ComponentArray<CommandRequests<Generated.Playground.Launchable.LaunchMe.Request>> CommandRequests;
 
             [ReadOnly] public ComponentArray<Rigidbody> Rigidbody;
         }

--- a/workers/unity/Assets/Playground/Scripts/Player/ProcessLaunchCommandSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/Player/ProcessLaunchCommandSystem.cs
@@ -18,8 +18,7 @@ namespace Playground
             [ReadOnly] public EntityArray Entity;
             public ComponentDataArray<SpatialOSLauncher> Launcher;
 
-            [ReadOnly]
-            public ComponentArray<CommandRequests<Generated.Playground.Launcher.LaunchEntity.Request>> CommandRequests;
+            [ReadOnly] public ComponentArray<CommandRequests<Generated.Playground.Launcher.LaunchEntity.Request>> CommandRequests;
 
             [ReadOnly] public ComponentDataArray<CommandRequestSender<SpatialOSLaunchable>> Sender;
         }
@@ -29,8 +28,7 @@ namespace Playground
             public int Length;
             public ComponentDataArray<SpatialOSLaunchable> Launchable;
 
-            [ReadOnly]
-            public ComponentArray<CommandRequests<Generated.Playground.Launchable.LaunchMe.Request>> CommandRequests;
+            [ReadOnly] public ComponentArray<CommandRequests<Generated.Playground.Launchable.LaunchMe.Request>> CommandRequests;
 
             [ReadOnly] public ComponentArray<Rigidbody> Rigidbody;
         }


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](https://github.com/spatialos/UnityGDK/blob/master/CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](https://github.com/spatialos/UnityGDK/blob/master/README.md#give-us-feedback).

-------

#### Description
Editor hangs frequently if code compiles while the editor is playing and connected to Spatial.

**Do not merge:** This fixes the issue of the editor freezing there are still issues caused by lack of cleanup after disconnect. This is blocked by UTY-339.

#### Tests
Connected to a local deployment, changed some code, recompiled. The editor doesn't hang.

#### Documentation
N/A

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
@JonasImprobable @zeroZshadow @jessicafalk 