### PR TITLE
Added an attribute to remove non-codegen components

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -41,5 +41,6 @@ We are currently not accepting public contributions. However, we are accepting i
 * [Creating entities](content/create-entity.md)
 * [Entity checkout process](content/entity-checkout-process.md)
 * [The code generator](content/code-generator.md)
+* [Temporary components](content/temporary-components.md)
 
 &copy; 2018 Improbable

--- a/docs/content/reactive-components.md
+++ b/docs/content/reactive-components.md
@@ -3,7 +3,7 @@
 -----
 
 
-## Receiving updates from SpatialOS: reactive components
+## Receiving entity updates from SpatialOS: reactive components
 
 To represent state changes or messages from SpatialOS, the Unity GDK uses something we're calling "reactive components": ECS components that it adds to the relevant ECS entity for the duration of a tick.
 

--- a/docs/content/temporary-components.md
+++ b/docs/content/temporary-components.md
@@ -1,0 +1,50 @@
+**Warning:** The [pre-alpha](https://docs.improbable.io/reference/latest/shared/release-policy#maturity-stages) release is for evaluation purposes only, with limited documentation - see the guidance on [Recommended use](../../README.md#recommended-use).
+
+-----
+
+
+## Temporary components
+
+The attribute `Improbable.Gdk.Core.RemoveAtEndOfTick`, can be applied to any ECS component, extending either `IComponentData` or `ISharedComponentData`.
+All components with this attribute will be removed from all entities during the `InternalSpatialOSCleanGroup` at the end of `SpatialOSSendGroup`.
+
+Note: The `InternalSpatialOSCleanGroup` runs after both the `SpatialOSUpdateGroup` and the `CustomSpatialOSSendGroup`.
+
+### Example
+```csharp
+[RemoveAtEndOfTick]
+struct SomeTemporaryComponent : IComponentData
+{
+}
+```
+
+If a system, `AddComponentSystem`, adds `SomeTemporaryComponent` to some entities, then `ReadComponentSystem.OnUpdate()` (see the sample below) will run during the same update loop.
+
+```csharp
+[UpdateAfter(typeof(AddComponentSystem))]
+[UpdateInGroup(typeof(SpatialOSUpdateGroup))]
+class ReadComponentSystem : ComponentSystem
+{
+    private struct Data
+    {
+        int Length;
+        [Readonly] ComponentDataArray<SomeTemporaryComponent> TemporaryComponent;
+    }
+
+    [Inject] Data data;
+
+    protected override void OnUpdate()
+    {
+        // perform work related to the temporary component
+    }
+}
+``` 
+
+At the end of the update loop, `SomeTemporaryComponent` will automatically be removed from all entities.
+
+----
+**Give us feedback:** We want your feedback on the Unity GDK and its documentation  - see [How to give us feedback](../../README.md#give-us-feedback).
+
+[//]: # (Editorial review status: Engineer review only)
+[//]: # (Questions to deal with: need to describe what a tick is. Needs to link to a doc on system execution order. Needs to link to docs describing the existing components which use this)
+[//]: # (1. Editorial review  - JIRA TICKET: UTY-628)

--- a/workers/unity/Assets/Gdk/Core/Attributes.meta
+++ b/workers/unity/Assets/Gdk/Core/Attributes.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0a6c8a19ce040a44eb1aeead93a0794f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Assets/Gdk/Core/Attributes/RemoveAtEndOfTick.cs
+++ b/workers/unity/Assets/Gdk/Core/Attributes/RemoveAtEndOfTick.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using Unity.Entities;
+
+namespace Improbable.Gdk.Core
+{
+    /// <summary>
+    ///     Any component with this attribute will be removed from all entities by the CleanReactiveComponentSystem
+    ///     Can be added to components extending <see cref="IComponentData" /> or <see cref="ISharedComponentData" />
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Struct, AllowMultiple = false, Inherited = false)]
+    public class RemoveAtEndOfTick : Attribute
+    {
+    }
+}
+

--- a/workers/unity/Assets/Gdk/Core/Attributes/RemoveAtEndOfTick.cs.meta
+++ b/workers/unity/Assets/Gdk/Core/Attributes/RemoveAtEndOfTick.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9ccc6baaacb1059488f5ffa4e0a358ba
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Assets/Gdk/Core/Components/NewlyAddedSpatialOSEntity.cs
+++ b/workers/unity/Assets/Gdk/Core/Components/NewlyAddedSpatialOSEntity.cs
@@ -7,6 +7,7 @@ namespace Improbable.Gdk.Core
     ///     This component is automatically added to an entity upon its creation and automatically removed at the end of the
     ///     same frame.
     /// </summary>
+    [RemoveAtEndOfTick]
     public struct NewlyAddedSpatialOSEntity : IComponentData
     {
     }

--- a/workers/unity/Assets/Gdk/Core/Components/WorkerEntityComponents.cs
+++ b/workers/unity/Assets/Gdk/Core/Components/WorkerEntityComponents.cs
@@ -1,21 +1,42 @@
+using System.Collections.Generic;
 using Unity.Entities;
 
 namespace Improbable.Gdk.Core
 {
+    /// <summary>
+    ///     Component denoting a worker entity
+    /// </summary>
     public struct WorkerEntityTag : IComponentData
     {
     }
 
+    /// <summary>
+    ///     Component added to the worker entity immediately after establishing a connection to a SpatialOS deployment
+    ///     Removed immediately after disconnecting
+    /// </summary>
     public struct IsConnected : IComponentData
     {
     }
 
+    /// <summary>
+    ///     Component added to the worker entity immediately after establishing a connection to a SpatialOS deployment
+    ///     Removed at the end of the tick it was added
+    /// </summary>
+    [RemoveAtEndOfTick]
     public struct OnConnected : IComponentData
     {
     }
 
+    /// <summary>
+    ///     Component added to the worker entity immediately after disconnecting from SpatialOS
+    ///     Removed at the end of the tick it was added
+    /// </summary>
+    [RemoveAtEndOfTick]
     public struct OnDisconnected : ISharedComponentData
     {
+        /// <summary>
+        ///     The reported reason for disconnecting
+        /// </summary>
         public string ReasonForDisconnect;
     }
 }


### PR DESCRIPTION
#### Description
Currently we hard code in temporary components in the clean system. This makes this generic and opens up the possibility of having auto cleaned components in other features.
#### Tests
There is a clean reactive component test already, which this passes
#### Documentation
temporary-component.md
#### Primary reviewers
@zeroZshadow @jamiebrynes7 @JonasImprobable 