### PR TITLE
UTY-360: Add Support for Nested Type and Enum Generation

### DIFF
--- a/code_generator/.gitignore
+++ b/code_generator/.gitignore
@@ -328,7 +328,6 @@ ASALocalRun/
 # MFractors (Xamarin productivity tool) working folder 
 .mfractor/
 
-Generated/
+/Generated/
 End2End/schema_json_ast/
-End2End/GeneratedDependencies/Generated/
 End2End/GeneratedDependencies/GeneratedCSharpWorker/

--- a/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/ExhaustiveBlittableSingular.cs
+++ b/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/ExhaustiveBlittableSingular.cs
@@ -1,0 +1,195 @@
+// ===========
+// DO NOT EDIT - this file is automatically regenerated.
+// ===========
+
+using Unity.Mathematics;
+using Unity.Entities;
+using Improbable.Gdk.Core;
+
+namespace Generated.Improbable.TestSchema
+{ 
+    public struct SpatialOSExhaustiveBlittableSingular : IComponentData, ISpatialComponentData
+    {
+        public bool1 DirtyBit { get; set; }
+
+        private bool1 field1;
+
+        public bool1 Field1
+        {
+            get { return field1; }
+            set
+            {
+                DirtyBit = true;
+                field1 = value;
+            }
+        }
+
+        private float field2;
+
+        public float Field2
+        {
+            get { return field2; }
+            set
+            {
+                DirtyBit = true;
+                field2 = value;
+            }
+        }
+
+        private int field4;
+
+        public int Field4
+        {
+            get { return field4; }
+            set
+            {
+                DirtyBit = true;
+                field4 = value;
+            }
+        }
+
+        private long field5;
+
+        public long Field5
+        {
+            get { return field5; }
+            set
+            {
+                DirtyBit = true;
+                field5 = value;
+            }
+        }
+
+        private double field6;
+
+        public double Field6
+        {
+            get { return field6; }
+            set
+            {
+                DirtyBit = true;
+                field6 = value;
+            }
+        }
+
+        private uint field8;
+
+        public uint Field8
+        {
+            get { return field8; }
+            set
+            {
+                DirtyBit = true;
+                field8 = value;
+            }
+        }
+
+        private ulong field9;
+
+        public ulong Field9
+        {
+            get { return field9; }
+            set
+            {
+                DirtyBit = true;
+                field9 = value;
+            }
+        }
+
+        private int field10;
+
+        public int Field10
+        {
+            get { return field10; }
+            set
+            {
+                DirtyBit = true;
+                field10 = value;
+            }
+        }
+
+        private long field11;
+
+        public long Field11
+        {
+            get { return field11; }
+            set
+            {
+                DirtyBit = true;
+                field11 = value;
+            }
+        }
+
+        private uint field12;
+
+        public uint Field12
+        {
+            get { return field12; }
+            set
+            {
+                DirtyBit = true;
+                field12 = value;
+            }
+        }
+
+        private ulong field13;
+
+        public ulong Field13
+        {
+            get { return field13; }
+            set
+            {
+                DirtyBit = true;
+                field13 = value;
+            }
+        }
+
+        private int field14;
+
+        public int Field14
+        {
+            get { return field14; }
+            set
+            {
+                DirtyBit = true;
+                field14 = value;
+            }
+        }
+
+        private long field15;
+
+        public long Field15
+        {
+            get { return field15; }
+            set
+            {
+                DirtyBit = true;
+                field15 = value;
+            }
+        }
+
+        private long field16;
+
+        public long Field16
+        {
+            get { return field16; }
+            set
+            {
+                DirtyBit = true;
+                field16 = value;
+            }
+        }
+
+        private global::Generated.Improbable.TestSchema.SomeType field17;
+
+        public global::Generated.Improbable.TestSchema.SomeType Field17
+        {
+            get { return field17; }
+            set
+            {
+                DirtyBit = true;
+                field17 = value;
+            }
+        }
+    }
+}

--- a/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/ExhaustiveBlittableSingularTranslation.cs
+++ b/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/ExhaustiveBlittableSingularTranslation.cs
@@ -1,0 +1,253 @@
+// ===========
+// DO NOT EDIT - this file is automatically regenerated.
+// ===========
+
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using Unity.Mathematics;
+using Unity.Entities;
+using Improbable.Worker;
+using Improbable.Gdk.Core;
+using Improbable.Gdk.Core.Components;
+using Improbable.TestSchema;
+
+namespace Generated.Improbable.TestSchema
+{
+    public partial class ExhaustiveBlittableSingular
+    {
+        public class Translation : ComponentTranslation, IDispatcherCallbacks<global::Improbable.TestSchema.ExhaustiveBlittableSingular>
+        {
+            public override ComponentType TargetComponentType => targetComponentType;
+            private static readonly ComponentType targetComponentType = typeof(SpatialOSExhaustiveBlittableSingular);
+
+            public override ComponentType[] ReplicationComponentTypes => replicationComponentTypes;
+            private static readonly ComponentType[] replicationComponentTypes = { typeof(SpatialOSExhaustiveBlittableSingular), typeof(Authoritative<SpatialOSExhaustiveBlittableSingular>), typeof(SpatialEntityId)};
+
+            public override ComponentType[] CleanUpComponentTypes => cleanUpComponentTypes;
+            private static readonly ComponentType[] cleanUpComponentTypes = 
+            { 
+                typeof(ComponentsUpdated<SpatialOSExhaustiveBlittableSingular>), typeof(AuthoritiesChanged<SpatialOSExhaustiveBlittableSingular>),
+            };
+
+
+            private static readonly ComponentPool<ComponentsUpdated<SpatialOSExhaustiveBlittableSingular>> UpdatesPool =
+                new ComponentPool<ComponentsUpdated<SpatialOSExhaustiveBlittableSingular>>(
+                    () => new ComponentsUpdated<SpatialOSExhaustiveBlittableSingular>(),
+                    (component) => component.Buffer.Clear());
+
+            private static readonly ComponentPool<AuthoritiesChanged<SpatialOSExhaustiveBlittableSingular>> AuthsPool =
+                new ComponentPool<AuthoritiesChanged<SpatialOSExhaustiveBlittableSingular>>(
+                    () => new AuthoritiesChanged<SpatialOSExhaustiveBlittableSingular>(),
+                    (component) => component.Buffer.Clear());
+
+            public Translation(MutableView view) : base(view)
+            {
+            }
+
+            public override void RegisterWithDispatcher(Dispatcher dispatcher)
+            {
+                dispatcher.OnAddComponent<global::Improbable.TestSchema.ExhaustiveBlittableSingular>(OnAddComponent);
+                dispatcher.OnComponentUpdate<global::Improbable.TestSchema.ExhaustiveBlittableSingular>(OnComponentUpdate);
+                dispatcher.OnRemoveComponent<global::Improbable.TestSchema.ExhaustiveBlittableSingular>(OnRemoveComponent);
+                dispatcher.OnAuthorityChange<global::Improbable.TestSchema.ExhaustiveBlittableSingular>(OnAuthorityChange);
+
+            }
+
+            public override void AddCommandRequestSender(Unity.Entities.Entity entity, long entityId)
+            {
+            }
+
+            public void OnAddComponent(AddComponentOp<global::Improbable.TestSchema.ExhaustiveBlittableSingular> op)
+            {
+                Unity.Entities.Entity entity;
+                if (!view.TryGetEntity(op.EntityId.Id, out entity))
+                {
+                    Debug.LogErrorFormat(TranslationErrors.OpReceivedButNoEntity, op.GetType().Name, op.EntityId.Id);
+                    return;
+                }
+
+                var data = op.Data.Get().Value;
+
+                var spatialOSExhaustiveBlittableSingular = new SpatialOSExhaustiveBlittableSingular();
+                spatialOSExhaustiveBlittableSingular.Field1 = data.field1;
+                spatialOSExhaustiveBlittableSingular.Field2 = data.field2;
+                spatialOSExhaustiveBlittableSingular.Field4 = data.field4;
+                spatialOSExhaustiveBlittableSingular.Field5 = data.field5;
+                spatialOSExhaustiveBlittableSingular.Field6 = data.field6;
+                spatialOSExhaustiveBlittableSingular.Field8 = data.field8;
+                spatialOSExhaustiveBlittableSingular.Field9 = data.field9;
+                spatialOSExhaustiveBlittableSingular.Field10 = data.field10;
+                spatialOSExhaustiveBlittableSingular.Field11 = data.field11;
+                spatialOSExhaustiveBlittableSingular.Field12 = data.field12;
+                spatialOSExhaustiveBlittableSingular.Field13 = data.field13;
+                spatialOSExhaustiveBlittableSingular.Field14 = data.field14;
+                spatialOSExhaustiveBlittableSingular.Field15 = data.field15;
+                spatialOSExhaustiveBlittableSingular.Field16 = data.field16.Id;
+                spatialOSExhaustiveBlittableSingular.Field17 = global::Generated.Improbable.TestSchema.SomeType.ToNative(data.field17);
+                spatialOSExhaustiveBlittableSingular.DirtyBit = false;
+
+                view.AddComponent(entity, spatialOSExhaustiveBlittableSingular);
+                view.AddComponent(entity, new NotAuthoritative<SpatialOSExhaustiveBlittableSingular>());
+            }
+
+            public void OnComponentUpdate(ComponentUpdateOp<global::Improbable.TestSchema.ExhaustiveBlittableSingular> op)
+            {
+                Unity.Entities.Entity entity;
+                if (!view.TryGetEntity(op.EntityId.Id, out entity))
+                {
+                    Debug.LogErrorFormat(TranslationErrors.OpReceivedButNoEntity, op.GetType().Name, op.EntityId.Id);
+                    return;
+                }
+
+                var componentData = view.GetComponent<SpatialOSExhaustiveBlittableSingular>(entity);
+                var update = op.Update.Get();
+
+                if (view.HasComponent<NotAuthoritative<SpatialOSExhaustiveBlittableSingular>>(entity))
+                {
+                    if (update.field1.HasValue)
+                    {
+                        componentData.Field1 = update.field1.Value;
+                    }
+                    if (update.field2.HasValue)
+                    {
+                        componentData.Field2 = update.field2.Value;
+                    }
+                    if (update.field4.HasValue)
+                    {
+                        componentData.Field4 = update.field4.Value;
+                    }
+                    if (update.field5.HasValue)
+                    {
+                        componentData.Field5 = update.field5.Value;
+                    }
+                    if (update.field6.HasValue)
+                    {
+                        componentData.Field6 = update.field6.Value;
+                    }
+                    if (update.field8.HasValue)
+                    {
+                        componentData.Field8 = update.field8.Value;
+                    }
+                    if (update.field9.HasValue)
+                    {
+                        componentData.Field9 = update.field9.Value;
+                    }
+                    if (update.field10.HasValue)
+                    {
+                        componentData.Field10 = update.field10.Value;
+                    }
+                    if (update.field11.HasValue)
+                    {
+                        componentData.Field11 = update.field11.Value;
+                    }
+                    if (update.field12.HasValue)
+                    {
+                        componentData.Field12 = update.field12.Value;
+                    }
+                    if (update.field13.HasValue)
+                    {
+                        componentData.Field13 = update.field13.Value;
+                    }
+                    if (update.field14.HasValue)
+                    {
+                        componentData.Field14 = update.field14.Value;
+                    }
+                    if (update.field15.HasValue)
+                    {
+                        componentData.Field15 = update.field15.Value;
+                    }
+                    if (update.field16.HasValue)
+                    {
+                        componentData.Field16 = update.field16.Value.Id;
+                    }
+                    if (update.field17.HasValue)
+                    {
+                        componentData.Field17 = global::Generated.Improbable.TestSchema.SomeType.ToNative(update.field17.Value);
+                    }
+                }
+
+                componentData.DirtyBit = false;
+                view.UpdateComponent(entity, componentData, UpdatesPool);
+            }
+
+            public void OnRemoveComponent(RemoveComponentOp op)
+            {
+                Unity.Entities.Entity entity;
+                if (!view.TryGetEntity(op.EntityId.Id, out entity))
+                {
+                    Debug.LogErrorFormat(TranslationErrors.OpReceivedButNoEntity, op.GetType().Name, op.EntityId.Id);
+                    return;
+                }
+
+                view.RemoveComponent<SpatialOSExhaustiveBlittableSingular>(entity);
+            }
+
+            public void OnAuthorityChange(AuthorityChangeOp op)
+            {
+                var entityId = op.EntityId.Id;
+                view.HandleAuthorityChange(entityId, op.Authority, AuthsPool);
+            }
+
+            public override void ExecuteReplication(Connection connection)
+            {
+                var componentDataArray = ReplicationComponentGroup.GetComponentDataArray<SpatialOSExhaustiveBlittableSingular>();
+                var spatialEntityIdData = ReplicationComponentGroup.GetComponentDataArray<SpatialEntityId>();
+
+                for (var i = 0; i < componentDataArray.Length; i++)
+                {
+                    var componentData = componentDataArray[i];
+                    var entityId = spatialEntityIdData[i].EntityId;
+                    var hasPendingEvents = false;
+
+                    if (componentData.DirtyBit || hasPendingEvents)
+                    {
+                        var update = new global::Improbable.TestSchema.ExhaustiveBlittableSingular.Update();
+                        update.SetField1(componentData.Field1);
+                        update.SetField2(componentData.Field2);
+                        update.SetField4(componentData.Field4);
+                        update.SetField5(componentData.Field5);
+                        update.SetField6(componentData.Field6);
+                        update.SetField8(componentData.Field8);
+                        update.SetField9(componentData.Field9);
+                        update.SetField10(componentData.Field10);
+                        update.SetField11(componentData.Field11);
+                        update.SetField12(componentData.Field12);
+                        update.SetField13(componentData.Field13);
+                        update.SetField14(componentData.Field14);
+                        update.SetField15(componentData.Field15);
+                        update.SetField16(new global::Improbable.EntityId(componentData.Field16));
+                        update.SetField17(global::Generated.Improbable.TestSchema.SomeType.ToSpatial(componentData.Field17));
+                        SendComponentUpdate(connection, entityId, update);
+
+                        componentData.DirtyBit = false;
+                        componentDataArray[i] = componentData;
+
+                    }
+                }
+            }
+
+            public static void SendComponentUpdate(Connection connection, long entityId, global::Improbable.TestSchema.ExhaustiveBlittableSingular.Update update)
+            {
+                connection.SendComponentUpdate(new global::Improbable.EntityId(entityId), update);
+            }
+
+            public override void CleanUpComponents(ref EntityCommandBuffer entityCommandBuffer)
+            {
+                RemoveComponents(ref entityCommandBuffer, UpdatesPool, groupIndex: 0);
+                RemoveComponents(ref entityCommandBuffer, AuthsPool, groupIndex: 1);
+            }
+
+            public override void SendCommands(Connection connection)
+            {
+            }
+
+            public static ExhaustiveBlittableSingular.Translation GetTranslation(uint internalHandleToTranslation)
+            {
+                return (ExhaustiveBlittableSingular.Translation) ComponentTranslation.HandleToTranslation[internalHandleToTranslation];
+            }
+        }
+    }
+
+
+}

--- a/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/ExhaustiveMapKey.cs
+++ b/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/ExhaustiveMapKey.cs
@@ -1,0 +1,195 @@
+// ===========
+// DO NOT EDIT - this file is automatically regenerated.
+// ===========
+
+using UnityEngine;
+using Unity.Mathematics;
+using Improbable.Gdk.Core;
+
+namespace Generated.Improbable.TestSchema
+{ 
+    public class SpatialOSExhaustiveMapKey : Component, ISpatialComponentData
+    {
+        public bool1 DirtyBit { get; set; }
+
+        private global::System.Collections.Generic.Dictionary<float, string> field2;
+
+        public global::System.Collections.Generic.Dictionary<float, string> Field2
+        {
+            get { return field2; }
+            set
+            {
+                DirtyBit = true;
+                field2 = value;
+            }
+        }
+
+        private global::System.Collections.Generic.Dictionary<int, string> field4;
+
+        public global::System.Collections.Generic.Dictionary<int, string> Field4
+        {
+            get { return field4; }
+            set
+            {
+                DirtyBit = true;
+                field4 = value;
+            }
+        }
+
+        private global::System.Collections.Generic.Dictionary<long, string> field5;
+
+        public global::System.Collections.Generic.Dictionary<long, string> Field5
+        {
+            get { return field5; }
+            set
+            {
+                DirtyBit = true;
+                field5 = value;
+            }
+        }
+
+        private global::System.Collections.Generic.Dictionary<double, string> field6;
+
+        public global::System.Collections.Generic.Dictionary<double, string> Field6
+        {
+            get { return field6; }
+            set
+            {
+                DirtyBit = true;
+                field6 = value;
+            }
+        }
+
+        private global::System.Collections.Generic.Dictionary<string, string> field7;
+
+        public global::System.Collections.Generic.Dictionary<string, string> Field7
+        {
+            get { return field7; }
+            set
+            {
+                DirtyBit = true;
+                field7 = value;
+            }
+        }
+
+        private global::System.Collections.Generic.Dictionary<uint, string> field8;
+
+        public global::System.Collections.Generic.Dictionary<uint, string> Field8
+        {
+            get { return field8; }
+            set
+            {
+                DirtyBit = true;
+                field8 = value;
+            }
+        }
+
+        private global::System.Collections.Generic.Dictionary<ulong, string> field9;
+
+        public global::System.Collections.Generic.Dictionary<ulong, string> Field9
+        {
+            get { return field9; }
+            set
+            {
+                DirtyBit = true;
+                field9 = value;
+            }
+        }
+
+        private global::System.Collections.Generic.Dictionary<int, string> field10;
+
+        public global::System.Collections.Generic.Dictionary<int, string> Field10
+        {
+            get { return field10; }
+            set
+            {
+                DirtyBit = true;
+                field10 = value;
+            }
+        }
+
+        private global::System.Collections.Generic.Dictionary<long, string> field11;
+
+        public global::System.Collections.Generic.Dictionary<long, string> Field11
+        {
+            get { return field11; }
+            set
+            {
+                DirtyBit = true;
+                field11 = value;
+            }
+        }
+
+        private global::System.Collections.Generic.Dictionary<uint, string> field12;
+
+        public global::System.Collections.Generic.Dictionary<uint, string> Field12
+        {
+            get { return field12; }
+            set
+            {
+                DirtyBit = true;
+                field12 = value;
+            }
+        }
+
+        private global::System.Collections.Generic.Dictionary<ulong, string> field13;
+
+        public global::System.Collections.Generic.Dictionary<ulong, string> Field13
+        {
+            get { return field13; }
+            set
+            {
+                DirtyBit = true;
+                field13 = value;
+            }
+        }
+
+        private global::System.Collections.Generic.Dictionary<int, string> field14;
+
+        public global::System.Collections.Generic.Dictionary<int, string> Field14
+        {
+            get { return field14; }
+            set
+            {
+                DirtyBit = true;
+                field14 = value;
+            }
+        }
+
+        private global::System.Collections.Generic.Dictionary<long, string> field15;
+
+        public global::System.Collections.Generic.Dictionary<long, string> Field15
+        {
+            get { return field15; }
+            set
+            {
+                DirtyBit = true;
+                field15 = value;
+            }
+        }
+
+        private global::System.Collections.Generic.Dictionary<long, string> field16;
+
+        public global::System.Collections.Generic.Dictionary<long, string> Field16
+        {
+            get { return field16; }
+            set
+            {
+                DirtyBit = true;
+                field16 = value;
+            }
+        }
+
+        private global::System.Collections.Generic.Dictionary<global::Generated.Improbable.TestSchema.SomeType, string> field17;
+
+        public global::System.Collections.Generic.Dictionary<global::Generated.Improbable.TestSchema.SomeType, string> Field17
+        {
+            get { return field17; }
+            set
+            {
+                DirtyBit = true;
+                field17 = value;
+            }
+        }
+    }
+}

--- a/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/ExhaustiveMapKeyTranslation.cs
+++ b/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/ExhaustiveMapKeyTranslation.cs
@@ -1,0 +1,253 @@
+// ===========
+// DO NOT EDIT - this file is automatically regenerated.
+// ===========
+
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using Unity.Mathematics;
+using Unity.Entities;
+using Improbable.Worker;
+using Improbable.Gdk.Core;
+using Improbable.Gdk.Core.Components;
+using Improbable.TestSchema;
+
+namespace Generated.Improbable.TestSchema
+{
+    public partial class ExhaustiveMapKey
+    {
+        public class Translation : ComponentTranslation, IDispatcherCallbacks<global::Improbable.TestSchema.ExhaustiveMapKey>
+        {
+            public override ComponentType TargetComponentType => targetComponentType;
+            private static readonly ComponentType targetComponentType = typeof(SpatialOSExhaustiveMapKey);
+
+            public override ComponentType[] ReplicationComponentTypes => replicationComponentTypes;
+            private static readonly ComponentType[] replicationComponentTypes = { typeof(SpatialOSExhaustiveMapKey), typeof(Authoritative<SpatialOSExhaustiveMapKey>), typeof(SpatialEntityId)};
+
+            public override ComponentType[] CleanUpComponentTypes => cleanUpComponentTypes;
+            private static readonly ComponentType[] cleanUpComponentTypes = 
+            { 
+                typeof(ComponentsUpdated<SpatialOSExhaustiveMapKey>), typeof(AuthoritiesChanged<SpatialOSExhaustiveMapKey>),
+            };
+
+
+            private static readonly ComponentPool<ComponentsUpdated<SpatialOSExhaustiveMapKey>> UpdatesPool =
+                new ComponentPool<ComponentsUpdated<SpatialOSExhaustiveMapKey>>(
+                    () => new ComponentsUpdated<SpatialOSExhaustiveMapKey>(),
+                    (component) => component.Buffer.Clear());
+
+            private static readonly ComponentPool<AuthoritiesChanged<SpatialOSExhaustiveMapKey>> AuthsPool =
+                new ComponentPool<AuthoritiesChanged<SpatialOSExhaustiveMapKey>>(
+                    () => new AuthoritiesChanged<SpatialOSExhaustiveMapKey>(),
+                    (component) => component.Buffer.Clear());
+
+            public Translation(MutableView view) : base(view)
+            {
+            }
+
+            public override void RegisterWithDispatcher(Dispatcher dispatcher)
+            {
+                dispatcher.OnAddComponent<global::Improbable.TestSchema.ExhaustiveMapKey>(OnAddComponent);
+                dispatcher.OnComponentUpdate<global::Improbable.TestSchema.ExhaustiveMapKey>(OnComponentUpdate);
+                dispatcher.OnRemoveComponent<global::Improbable.TestSchema.ExhaustiveMapKey>(OnRemoveComponent);
+                dispatcher.OnAuthorityChange<global::Improbable.TestSchema.ExhaustiveMapKey>(OnAuthorityChange);
+
+            }
+
+            public override void AddCommandRequestSender(Unity.Entities.Entity entity, long entityId)
+            {
+            }
+
+            public void OnAddComponent(AddComponentOp<global::Improbable.TestSchema.ExhaustiveMapKey> op)
+            {
+                Unity.Entities.Entity entity;
+                if (!view.TryGetEntity(op.EntityId.Id, out entity))
+                {
+                    Debug.LogErrorFormat(TranslationErrors.OpReceivedButNoEntity, op.GetType().Name, op.EntityId.Id);
+                    return;
+                }
+
+                var data = op.Data.Get().Value;
+
+                var spatialOSExhaustiveMapKey = new SpatialOSExhaustiveMapKey();
+                spatialOSExhaustiveMapKey.Field2 = data.field2.ToDictionary(entry => entry.Key, entry => entry.Value);
+                spatialOSExhaustiveMapKey.Field4 = data.field4.ToDictionary(entry => entry.Key, entry => entry.Value);
+                spatialOSExhaustiveMapKey.Field5 = data.field5.ToDictionary(entry => entry.Key, entry => entry.Value);
+                spatialOSExhaustiveMapKey.Field6 = data.field6.ToDictionary(entry => entry.Key, entry => entry.Value);
+                spatialOSExhaustiveMapKey.Field7 = data.field7.ToDictionary(entry => entry.Key, entry => entry.Value);
+                spatialOSExhaustiveMapKey.Field8 = data.field8.ToDictionary(entry => entry.Key, entry => entry.Value);
+                spatialOSExhaustiveMapKey.Field9 = data.field9.ToDictionary(entry => entry.Key, entry => entry.Value);
+                spatialOSExhaustiveMapKey.Field10 = data.field10.ToDictionary(entry => entry.Key, entry => entry.Value);
+                spatialOSExhaustiveMapKey.Field11 = data.field11.ToDictionary(entry => entry.Key, entry => entry.Value);
+                spatialOSExhaustiveMapKey.Field12 = data.field12.ToDictionary(entry => entry.Key, entry => entry.Value);
+                spatialOSExhaustiveMapKey.Field13 = data.field13.ToDictionary(entry => entry.Key, entry => entry.Value);
+                spatialOSExhaustiveMapKey.Field14 = data.field14.ToDictionary(entry => entry.Key, entry => entry.Value);
+                spatialOSExhaustiveMapKey.Field15 = data.field15.ToDictionary(entry => entry.Key, entry => entry.Value);
+                spatialOSExhaustiveMapKey.Field16 = data.field16.ToDictionary(entry => entry.Key.Id, entry => entry.Value);
+                spatialOSExhaustiveMapKey.Field17 = data.field17.ToDictionary(entry => global::Generated.Improbable.TestSchema.SomeType.ToNative(entry.Key), entry => entry.Value);
+                spatialOSExhaustiveMapKey.DirtyBit = false;
+
+                view.SetComponentObject(entity, spatialOSExhaustiveMapKey);
+                view.AddComponent(entity, new NotAuthoritative<SpatialOSExhaustiveMapKey>());
+            }
+
+            public void OnComponentUpdate(ComponentUpdateOp<global::Improbable.TestSchema.ExhaustiveMapKey> op)
+            {
+                Unity.Entities.Entity entity;
+                if (!view.TryGetEntity(op.EntityId.Id, out entity))
+                {
+                    Debug.LogErrorFormat(TranslationErrors.OpReceivedButNoEntity, op.GetType().Name, op.EntityId.Id);
+                    return;
+                }
+
+                var componentData = view.GetComponentObject<SpatialOSExhaustiveMapKey>(entity);
+                var update = op.Update.Get();
+
+                if (view.HasComponent<NotAuthoritative<SpatialOSExhaustiveMapKey>>(entity))
+                {
+                    if (update.field2.HasValue)
+                    {
+                        componentData.Field2 = update.field2.Value.ToDictionary(entry => entry.Key, entry => entry.Value);
+                    }
+                    if (update.field4.HasValue)
+                    {
+                        componentData.Field4 = update.field4.Value.ToDictionary(entry => entry.Key, entry => entry.Value);
+                    }
+                    if (update.field5.HasValue)
+                    {
+                        componentData.Field5 = update.field5.Value.ToDictionary(entry => entry.Key, entry => entry.Value);
+                    }
+                    if (update.field6.HasValue)
+                    {
+                        componentData.Field6 = update.field6.Value.ToDictionary(entry => entry.Key, entry => entry.Value);
+                    }
+                    if (update.field7.HasValue)
+                    {
+                        componentData.Field7 = update.field7.Value.ToDictionary(entry => entry.Key, entry => entry.Value);
+                    }
+                    if (update.field8.HasValue)
+                    {
+                        componentData.Field8 = update.field8.Value.ToDictionary(entry => entry.Key, entry => entry.Value);
+                    }
+                    if (update.field9.HasValue)
+                    {
+                        componentData.Field9 = update.field9.Value.ToDictionary(entry => entry.Key, entry => entry.Value);
+                    }
+                    if (update.field10.HasValue)
+                    {
+                        componentData.Field10 = update.field10.Value.ToDictionary(entry => entry.Key, entry => entry.Value);
+                    }
+                    if (update.field11.HasValue)
+                    {
+                        componentData.Field11 = update.field11.Value.ToDictionary(entry => entry.Key, entry => entry.Value);
+                    }
+                    if (update.field12.HasValue)
+                    {
+                        componentData.Field12 = update.field12.Value.ToDictionary(entry => entry.Key, entry => entry.Value);
+                    }
+                    if (update.field13.HasValue)
+                    {
+                        componentData.Field13 = update.field13.Value.ToDictionary(entry => entry.Key, entry => entry.Value);
+                    }
+                    if (update.field14.HasValue)
+                    {
+                        componentData.Field14 = update.field14.Value.ToDictionary(entry => entry.Key, entry => entry.Value);
+                    }
+                    if (update.field15.HasValue)
+                    {
+                        componentData.Field15 = update.field15.Value.ToDictionary(entry => entry.Key, entry => entry.Value);
+                    }
+                    if (update.field16.HasValue)
+                    {
+                        componentData.Field16 = update.field16.Value.ToDictionary(entry => entry.Key.Id, entry => entry.Value);
+                    }
+                    if (update.field17.HasValue)
+                    {
+                        componentData.Field17 = update.field17.Value.ToDictionary(entry => global::Generated.Improbable.TestSchema.SomeType.ToNative(entry.Key), entry => entry.Value);
+                    }
+                }
+
+                componentData.DirtyBit = false;
+                view.UpdateComponentObject(entity, componentData, UpdatesPool);
+            }
+
+            public void OnRemoveComponent(RemoveComponentOp op)
+            {
+                Unity.Entities.Entity entity;
+                if (!view.TryGetEntity(op.EntityId.Id, out entity))
+                {
+                    Debug.LogErrorFormat(TranslationErrors.OpReceivedButNoEntity, op.GetType().Name, op.EntityId.Id);
+                    return;
+                }
+
+                view.RemoveComponent<SpatialOSExhaustiveMapKey>(entity);
+            }
+
+            public void OnAuthorityChange(AuthorityChangeOp op)
+            {
+                var entityId = op.EntityId.Id;
+                view.HandleAuthorityChange(entityId, op.Authority, AuthsPool);
+            }
+
+            public override void ExecuteReplication(Connection connection)
+            {
+                var componentDataArray = ReplicationComponentGroup.GetComponentArray<SpatialOSExhaustiveMapKey>();
+                var spatialEntityIdData = ReplicationComponentGroup.GetComponentDataArray<SpatialEntityId>();
+
+                for (var i = 0; i < componentDataArray.Length; i++)
+                {
+                    var componentData = componentDataArray[i];
+                    var entityId = spatialEntityIdData[i].EntityId;
+                    var hasPendingEvents = false;
+
+                    if (componentData.DirtyBit || hasPendingEvents)
+                    {
+                        var update = new global::Improbable.TestSchema.ExhaustiveMapKey.Update();
+                        update.SetField2(new global::Improbable.Collections.Map<float,string>(componentData.Field2.ToDictionary(entry => entry.Key, entry => entry.Value)));
+                        update.SetField4(new global::Improbable.Collections.Map<int,string>(componentData.Field4.ToDictionary(entry => entry.Key, entry => entry.Value)));
+                        update.SetField5(new global::Improbable.Collections.Map<long,string>(componentData.Field5.ToDictionary(entry => entry.Key, entry => entry.Value)));
+                        update.SetField6(new global::Improbable.Collections.Map<double,string>(componentData.Field6.ToDictionary(entry => entry.Key, entry => entry.Value)));
+                        update.SetField7(new global::Improbable.Collections.Map<string,string>(componentData.Field7.ToDictionary(entry => entry.Key, entry => entry.Value)));
+                        update.SetField8(new global::Improbable.Collections.Map<uint,string>(componentData.Field8.ToDictionary(entry => entry.Key, entry => entry.Value)));
+                        update.SetField9(new global::Improbable.Collections.Map<ulong,string>(componentData.Field9.ToDictionary(entry => entry.Key, entry => entry.Value)));
+                        update.SetField10(new global::Improbable.Collections.Map<int,string>(componentData.Field10.ToDictionary(entry => entry.Key, entry => entry.Value)));
+                        update.SetField11(new global::Improbable.Collections.Map<long,string>(componentData.Field11.ToDictionary(entry => entry.Key, entry => entry.Value)));
+                        update.SetField12(new global::Improbable.Collections.Map<uint,string>(componentData.Field12.ToDictionary(entry => entry.Key, entry => entry.Value)));
+                        update.SetField13(new global::Improbable.Collections.Map<ulong,string>(componentData.Field13.ToDictionary(entry => entry.Key, entry => entry.Value)));
+                        update.SetField14(new global::Improbable.Collections.Map<int,string>(componentData.Field14.ToDictionary(entry => entry.Key, entry => entry.Value)));
+                        update.SetField15(new global::Improbable.Collections.Map<long,string>(componentData.Field15.ToDictionary(entry => entry.Key, entry => entry.Value)));
+                        update.SetField16(new global::Improbable.Collections.Map<global::Improbable.EntityId,string>(componentData.Field16.ToDictionary(entry => new global::Improbable.EntityId(entry.Key), entry => entry.Value)));
+                        update.SetField17(new global::Improbable.Collections.Map<global::Improbable.TestSchema.SomeType,string>(componentData.Field17.ToDictionary(entry => global::Generated.Improbable.TestSchema.SomeType.ToSpatial(entry.Key), entry => entry.Value)));
+                        SendComponentUpdate(connection, entityId, update);
+
+                        componentData.DirtyBit = false;
+                        view.SetComponentObject(entityId, componentData);
+
+                    }
+                }
+            }
+
+            public static void SendComponentUpdate(Connection connection, long entityId, global::Improbable.TestSchema.ExhaustiveMapKey.Update update)
+            {
+                connection.SendComponentUpdate(new global::Improbable.EntityId(entityId), update);
+            }
+
+            public override void CleanUpComponents(ref EntityCommandBuffer entityCommandBuffer)
+            {
+                RemoveComponents(ref entityCommandBuffer, UpdatesPool, groupIndex: 0);
+                RemoveComponents(ref entityCommandBuffer, AuthsPool, groupIndex: 1);
+            }
+
+            public override void SendCommands(Connection connection)
+            {
+            }
+
+            public static ExhaustiveMapKey.Translation GetTranslation(uint internalHandleToTranslation)
+            {
+                return (ExhaustiveMapKey.Translation) ComponentTranslation.HandleToTranslation[internalHandleToTranslation];
+            }
+        }
+    }
+
+
+}

--- a/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/ExhaustiveMapValue.cs
+++ b/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/ExhaustiveMapValue.cs
@@ -1,0 +1,195 @@
+// ===========
+// DO NOT EDIT - this file is automatically regenerated.
+// ===========
+
+using UnityEngine;
+using Unity.Mathematics;
+using Improbable.Gdk.Core;
+
+namespace Generated.Improbable.TestSchema
+{ 
+    public class SpatialOSExhaustiveMapValue : Component, ISpatialComponentData
+    {
+        public bool1 DirtyBit { get; set; }
+
+        private global::System.Collections.Generic.Dictionary<string, float> field2;
+
+        public global::System.Collections.Generic.Dictionary<string, float> Field2
+        {
+            get { return field2; }
+            set
+            {
+                DirtyBit = true;
+                field2 = value;
+            }
+        }
+
+        private global::System.Collections.Generic.Dictionary<string, int> field4;
+
+        public global::System.Collections.Generic.Dictionary<string, int> Field4
+        {
+            get { return field4; }
+            set
+            {
+                DirtyBit = true;
+                field4 = value;
+            }
+        }
+
+        private global::System.Collections.Generic.Dictionary<string, long> field5;
+
+        public global::System.Collections.Generic.Dictionary<string, long> Field5
+        {
+            get { return field5; }
+            set
+            {
+                DirtyBit = true;
+                field5 = value;
+            }
+        }
+
+        private global::System.Collections.Generic.Dictionary<string, double> field6;
+
+        public global::System.Collections.Generic.Dictionary<string, double> Field6
+        {
+            get { return field6; }
+            set
+            {
+                DirtyBit = true;
+                field6 = value;
+            }
+        }
+
+        private global::System.Collections.Generic.Dictionary<string, string> field7;
+
+        public global::System.Collections.Generic.Dictionary<string, string> Field7
+        {
+            get { return field7; }
+            set
+            {
+                DirtyBit = true;
+                field7 = value;
+            }
+        }
+
+        private global::System.Collections.Generic.Dictionary<string, uint> field8;
+
+        public global::System.Collections.Generic.Dictionary<string, uint> Field8
+        {
+            get { return field8; }
+            set
+            {
+                DirtyBit = true;
+                field8 = value;
+            }
+        }
+
+        private global::System.Collections.Generic.Dictionary<string, ulong> field9;
+
+        public global::System.Collections.Generic.Dictionary<string, ulong> Field9
+        {
+            get { return field9; }
+            set
+            {
+                DirtyBit = true;
+                field9 = value;
+            }
+        }
+
+        private global::System.Collections.Generic.Dictionary<string, int> field10;
+
+        public global::System.Collections.Generic.Dictionary<string, int> Field10
+        {
+            get { return field10; }
+            set
+            {
+                DirtyBit = true;
+                field10 = value;
+            }
+        }
+
+        private global::System.Collections.Generic.Dictionary<string, long> field11;
+
+        public global::System.Collections.Generic.Dictionary<string, long> Field11
+        {
+            get { return field11; }
+            set
+            {
+                DirtyBit = true;
+                field11 = value;
+            }
+        }
+
+        private global::System.Collections.Generic.Dictionary<string, uint> field12;
+
+        public global::System.Collections.Generic.Dictionary<string, uint> Field12
+        {
+            get { return field12; }
+            set
+            {
+                DirtyBit = true;
+                field12 = value;
+            }
+        }
+
+        private global::System.Collections.Generic.Dictionary<string, ulong> field13;
+
+        public global::System.Collections.Generic.Dictionary<string, ulong> Field13
+        {
+            get { return field13; }
+            set
+            {
+                DirtyBit = true;
+                field13 = value;
+            }
+        }
+
+        private global::System.Collections.Generic.Dictionary<string, int> field14;
+
+        public global::System.Collections.Generic.Dictionary<string, int> Field14
+        {
+            get { return field14; }
+            set
+            {
+                DirtyBit = true;
+                field14 = value;
+            }
+        }
+
+        private global::System.Collections.Generic.Dictionary<string, long> field15;
+
+        public global::System.Collections.Generic.Dictionary<string, long> Field15
+        {
+            get { return field15; }
+            set
+            {
+                DirtyBit = true;
+                field15 = value;
+            }
+        }
+
+        private global::System.Collections.Generic.Dictionary<string, long> field16;
+
+        public global::System.Collections.Generic.Dictionary<string, long> Field16
+        {
+            get { return field16; }
+            set
+            {
+                DirtyBit = true;
+                field16 = value;
+            }
+        }
+
+        private global::System.Collections.Generic.Dictionary<string, global::Generated.Improbable.TestSchema.SomeType> field17;
+
+        public global::System.Collections.Generic.Dictionary<string, global::Generated.Improbable.TestSchema.SomeType> Field17
+        {
+            get { return field17; }
+            set
+            {
+                DirtyBit = true;
+                field17 = value;
+            }
+        }
+    }
+}

--- a/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/ExhaustiveMapValueTranslation.cs
+++ b/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/ExhaustiveMapValueTranslation.cs
@@ -1,0 +1,253 @@
+// ===========
+// DO NOT EDIT - this file is automatically regenerated.
+// ===========
+
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using Unity.Mathematics;
+using Unity.Entities;
+using Improbable.Worker;
+using Improbable.Gdk.Core;
+using Improbable.Gdk.Core.Components;
+using Improbable.TestSchema;
+
+namespace Generated.Improbable.TestSchema
+{
+    public partial class ExhaustiveMapValue
+    {
+        public class Translation : ComponentTranslation, IDispatcherCallbacks<global::Improbable.TestSchema.ExhaustiveMapValue>
+        {
+            public override ComponentType TargetComponentType => targetComponentType;
+            private static readonly ComponentType targetComponentType = typeof(SpatialOSExhaustiveMapValue);
+
+            public override ComponentType[] ReplicationComponentTypes => replicationComponentTypes;
+            private static readonly ComponentType[] replicationComponentTypes = { typeof(SpatialOSExhaustiveMapValue), typeof(Authoritative<SpatialOSExhaustiveMapValue>), typeof(SpatialEntityId)};
+
+            public override ComponentType[] CleanUpComponentTypes => cleanUpComponentTypes;
+            private static readonly ComponentType[] cleanUpComponentTypes = 
+            { 
+                typeof(ComponentsUpdated<SpatialOSExhaustiveMapValue>), typeof(AuthoritiesChanged<SpatialOSExhaustiveMapValue>),
+            };
+
+
+            private static readonly ComponentPool<ComponentsUpdated<SpatialOSExhaustiveMapValue>> UpdatesPool =
+                new ComponentPool<ComponentsUpdated<SpatialOSExhaustiveMapValue>>(
+                    () => new ComponentsUpdated<SpatialOSExhaustiveMapValue>(),
+                    (component) => component.Buffer.Clear());
+
+            private static readonly ComponentPool<AuthoritiesChanged<SpatialOSExhaustiveMapValue>> AuthsPool =
+                new ComponentPool<AuthoritiesChanged<SpatialOSExhaustiveMapValue>>(
+                    () => new AuthoritiesChanged<SpatialOSExhaustiveMapValue>(),
+                    (component) => component.Buffer.Clear());
+
+            public Translation(MutableView view) : base(view)
+            {
+            }
+
+            public override void RegisterWithDispatcher(Dispatcher dispatcher)
+            {
+                dispatcher.OnAddComponent<global::Improbable.TestSchema.ExhaustiveMapValue>(OnAddComponent);
+                dispatcher.OnComponentUpdate<global::Improbable.TestSchema.ExhaustiveMapValue>(OnComponentUpdate);
+                dispatcher.OnRemoveComponent<global::Improbable.TestSchema.ExhaustiveMapValue>(OnRemoveComponent);
+                dispatcher.OnAuthorityChange<global::Improbable.TestSchema.ExhaustiveMapValue>(OnAuthorityChange);
+
+            }
+
+            public override void AddCommandRequestSender(Unity.Entities.Entity entity, long entityId)
+            {
+            }
+
+            public void OnAddComponent(AddComponentOp<global::Improbable.TestSchema.ExhaustiveMapValue> op)
+            {
+                Unity.Entities.Entity entity;
+                if (!view.TryGetEntity(op.EntityId.Id, out entity))
+                {
+                    Debug.LogErrorFormat(TranslationErrors.OpReceivedButNoEntity, op.GetType().Name, op.EntityId.Id);
+                    return;
+                }
+
+                var data = op.Data.Get().Value;
+
+                var spatialOSExhaustiveMapValue = new SpatialOSExhaustiveMapValue();
+                spatialOSExhaustiveMapValue.Field2 = data.field2.ToDictionary(entry => entry.Key, entry => entry.Value);
+                spatialOSExhaustiveMapValue.Field4 = data.field4.ToDictionary(entry => entry.Key, entry => entry.Value);
+                spatialOSExhaustiveMapValue.Field5 = data.field5.ToDictionary(entry => entry.Key, entry => entry.Value);
+                spatialOSExhaustiveMapValue.Field6 = data.field6.ToDictionary(entry => entry.Key, entry => entry.Value);
+                spatialOSExhaustiveMapValue.Field7 = data.field7.ToDictionary(entry => entry.Key, entry => entry.Value);
+                spatialOSExhaustiveMapValue.Field8 = data.field8.ToDictionary(entry => entry.Key, entry => entry.Value);
+                spatialOSExhaustiveMapValue.Field9 = data.field9.ToDictionary(entry => entry.Key, entry => entry.Value);
+                spatialOSExhaustiveMapValue.Field10 = data.field10.ToDictionary(entry => entry.Key, entry => entry.Value);
+                spatialOSExhaustiveMapValue.Field11 = data.field11.ToDictionary(entry => entry.Key, entry => entry.Value);
+                spatialOSExhaustiveMapValue.Field12 = data.field12.ToDictionary(entry => entry.Key, entry => entry.Value);
+                spatialOSExhaustiveMapValue.Field13 = data.field13.ToDictionary(entry => entry.Key, entry => entry.Value);
+                spatialOSExhaustiveMapValue.Field14 = data.field14.ToDictionary(entry => entry.Key, entry => entry.Value);
+                spatialOSExhaustiveMapValue.Field15 = data.field15.ToDictionary(entry => entry.Key, entry => entry.Value);
+                spatialOSExhaustiveMapValue.Field16 = data.field16.ToDictionary(entry => entry.Key, entry => entry.Value.Id);
+                spatialOSExhaustiveMapValue.Field17 = data.field17.ToDictionary(entry => entry.Key, entry => global::Generated.Improbable.TestSchema.SomeType.ToNative(entry.Value));
+                spatialOSExhaustiveMapValue.DirtyBit = false;
+
+                view.SetComponentObject(entity, spatialOSExhaustiveMapValue);
+                view.AddComponent(entity, new NotAuthoritative<SpatialOSExhaustiveMapValue>());
+            }
+
+            public void OnComponentUpdate(ComponentUpdateOp<global::Improbable.TestSchema.ExhaustiveMapValue> op)
+            {
+                Unity.Entities.Entity entity;
+                if (!view.TryGetEntity(op.EntityId.Id, out entity))
+                {
+                    Debug.LogErrorFormat(TranslationErrors.OpReceivedButNoEntity, op.GetType().Name, op.EntityId.Id);
+                    return;
+                }
+
+                var componentData = view.GetComponentObject<SpatialOSExhaustiveMapValue>(entity);
+                var update = op.Update.Get();
+
+                if (view.HasComponent<NotAuthoritative<SpatialOSExhaustiveMapValue>>(entity))
+                {
+                    if (update.field2.HasValue)
+                    {
+                        componentData.Field2 = update.field2.Value.ToDictionary(entry => entry.Key, entry => entry.Value);
+                    }
+                    if (update.field4.HasValue)
+                    {
+                        componentData.Field4 = update.field4.Value.ToDictionary(entry => entry.Key, entry => entry.Value);
+                    }
+                    if (update.field5.HasValue)
+                    {
+                        componentData.Field5 = update.field5.Value.ToDictionary(entry => entry.Key, entry => entry.Value);
+                    }
+                    if (update.field6.HasValue)
+                    {
+                        componentData.Field6 = update.field6.Value.ToDictionary(entry => entry.Key, entry => entry.Value);
+                    }
+                    if (update.field7.HasValue)
+                    {
+                        componentData.Field7 = update.field7.Value.ToDictionary(entry => entry.Key, entry => entry.Value);
+                    }
+                    if (update.field8.HasValue)
+                    {
+                        componentData.Field8 = update.field8.Value.ToDictionary(entry => entry.Key, entry => entry.Value);
+                    }
+                    if (update.field9.HasValue)
+                    {
+                        componentData.Field9 = update.field9.Value.ToDictionary(entry => entry.Key, entry => entry.Value);
+                    }
+                    if (update.field10.HasValue)
+                    {
+                        componentData.Field10 = update.field10.Value.ToDictionary(entry => entry.Key, entry => entry.Value);
+                    }
+                    if (update.field11.HasValue)
+                    {
+                        componentData.Field11 = update.field11.Value.ToDictionary(entry => entry.Key, entry => entry.Value);
+                    }
+                    if (update.field12.HasValue)
+                    {
+                        componentData.Field12 = update.field12.Value.ToDictionary(entry => entry.Key, entry => entry.Value);
+                    }
+                    if (update.field13.HasValue)
+                    {
+                        componentData.Field13 = update.field13.Value.ToDictionary(entry => entry.Key, entry => entry.Value);
+                    }
+                    if (update.field14.HasValue)
+                    {
+                        componentData.Field14 = update.field14.Value.ToDictionary(entry => entry.Key, entry => entry.Value);
+                    }
+                    if (update.field15.HasValue)
+                    {
+                        componentData.Field15 = update.field15.Value.ToDictionary(entry => entry.Key, entry => entry.Value);
+                    }
+                    if (update.field16.HasValue)
+                    {
+                        componentData.Field16 = update.field16.Value.ToDictionary(entry => entry.Key, entry => entry.Value.Id);
+                    }
+                    if (update.field17.HasValue)
+                    {
+                        componentData.Field17 = update.field17.Value.ToDictionary(entry => entry.Key, entry => global::Generated.Improbable.TestSchema.SomeType.ToNative(entry.Value));
+                    }
+                }
+
+                componentData.DirtyBit = false;
+                view.UpdateComponentObject(entity, componentData, UpdatesPool);
+            }
+
+            public void OnRemoveComponent(RemoveComponentOp op)
+            {
+                Unity.Entities.Entity entity;
+                if (!view.TryGetEntity(op.EntityId.Id, out entity))
+                {
+                    Debug.LogErrorFormat(TranslationErrors.OpReceivedButNoEntity, op.GetType().Name, op.EntityId.Id);
+                    return;
+                }
+
+                view.RemoveComponent<SpatialOSExhaustiveMapValue>(entity);
+            }
+
+            public void OnAuthorityChange(AuthorityChangeOp op)
+            {
+                var entityId = op.EntityId.Id;
+                view.HandleAuthorityChange(entityId, op.Authority, AuthsPool);
+            }
+
+            public override void ExecuteReplication(Connection connection)
+            {
+                var componentDataArray = ReplicationComponentGroup.GetComponentArray<SpatialOSExhaustiveMapValue>();
+                var spatialEntityIdData = ReplicationComponentGroup.GetComponentDataArray<SpatialEntityId>();
+
+                for (var i = 0; i < componentDataArray.Length; i++)
+                {
+                    var componentData = componentDataArray[i];
+                    var entityId = spatialEntityIdData[i].EntityId;
+                    var hasPendingEvents = false;
+
+                    if (componentData.DirtyBit || hasPendingEvents)
+                    {
+                        var update = new global::Improbable.TestSchema.ExhaustiveMapValue.Update();
+                        update.SetField2(new global::Improbable.Collections.Map<string,float>(componentData.Field2.ToDictionary(entry => entry.Key, entry => entry.Value)));
+                        update.SetField4(new global::Improbable.Collections.Map<string,int>(componentData.Field4.ToDictionary(entry => entry.Key, entry => entry.Value)));
+                        update.SetField5(new global::Improbable.Collections.Map<string,long>(componentData.Field5.ToDictionary(entry => entry.Key, entry => entry.Value)));
+                        update.SetField6(new global::Improbable.Collections.Map<string,double>(componentData.Field6.ToDictionary(entry => entry.Key, entry => entry.Value)));
+                        update.SetField7(new global::Improbable.Collections.Map<string,string>(componentData.Field7.ToDictionary(entry => entry.Key, entry => entry.Value)));
+                        update.SetField8(new global::Improbable.Collections.Map<string,uint>(componentData.Field8.ToDictionary(entry => entry.Key, entry => entry.Value)));
+                        update.SetField9(new global::Improbable.Collections.Map<string,ulong>(componentData.Field9.ToDictionary(entry => entry.Key, entry => entry.Value)));
+                        update.SetField10(new global::Improbable.Collections.Map<string,int>(componentData.Field10.ToDictionary(entry => entry.Key, entry => entry.Value)));
+                        update.SetField11(new global::Improbable.Collections.Map<string,long>(componentData.Field11.ToDictionary(entry => entry.Key, entry => entry.Value)));
+                        update.SetField12(new global::Improbable.Collections.Map<string,uint>(componentData.Field12.ToDictionary(entry => entry.Key, entry => entry.Value)));
+                        update.SetField13(new global::Improbable.Collections.Map<string,ulong>(componentData.Field13.ToDictionary(entry => entry.Key, entry => entry.Value)));
+                        update.SetField14(new global::Improbable.Collections.Map<string,int>(componentData.Field14.ToDictionary(entry => entry.Key, entry => entry.Value)));
+                        update.SetField15(new global::Improbable.Collections.Map<string,long>(componentData.Field15.ToDictionary(entry => entry.Key, entry => entry.Value)));
+                        update.SetField16(new global::Improbable.Collections.Map<string,global::Improbable.EntityId>(componentData.Field16.ToDictionary(entry => entry.Key, entry => new global::Improbable.EntityId(entry.Value))));
+                        update.SetField17(new global::Improbable.Collections.Map<string,global::Improbable.TestSchema.SomeType>(componentData.Field17.ToDictionary(entry => entry.Key, entry => global::Generated.Improbable.TestSchema.SomeType.ToSpatial(entry.Value))));
+                        SendComponentUpdate(connection, entityId, update);
+
+                        componentData.DirtyBit = false;
+                        view.SetComponentObject(entityId, componentData);
+
+                    }
+                }
+            }
+
+            public static void SendComponentUpdate(Connection connection, long entityId, global::Improbable.TestSchema.ExhaustiveMapValue.Update update)
+            {
+                connection.SendComponentUpdate(new global::Improbable.EntityId(entityId), update);
+            }
+
+            public override void CleanUpComponents(ref EntityCommandBuffer entityCommandBuffer)
+            {
+                RemoveComponents(ref entityCommandBuffer, UpdatesPool, groupIndex: 0);
+                RemoveComponents(ref entityCommandBuffer, AuthsPool, groupIndex: 1);
+            }
+
+            public override void SendCommands(Connection connection)
+            {
+            }
+
+            public static ExhaustiveMapValue.Translation GetTranslation(uint internalHandleToTranslation)
+            {
+                return (ExhaustiveMapValue.Translation) ComponentTranslation.HandleToTranslation[internalHandleToTranslation];
+            }
+        }
+    }
+
+
+}

--- a/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/ExhaustiveOptional.cs
+++ b/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/ExhaustiveOptional.cs
@@ -1,0 +1,183 @@
+// ===========
+// DO NOT EDIT - this file is automatically regenerated.
+// ===========
+
+using UnityEngine;
+using Unity.Mathematics;
+using Improbable.Gdk.Core;
+
+namespace Generated.Improbable.TestSchema
+{ 
+    public class SpatialOSExhaustiveOptional : Component, ISpatialComponentData
+    {
+        public bool1 DirtyBit { get; set; }
+
+        private global::System.Nullable<float> field2;
+
+        public global::System.Nullable<float> Field2
+        {
+            get { return field2; }
+            set
+            {
+                DirtyBit = true;
+                field2 = value;
+            }
+        }
+
+        private global::System.Nullable<int> field4;
+
+        public global::System.Nullable<int> Field4
+        {
+            get { return field4; }
+            set
+            {
+                DirtyBit = true;
+                field4 = value;
+            }
+        }
+
+        private global::System.Nullable<long> field5;
+
+        public global::System.Nullable<long> Field5
+        {
+            get { return field5; }
+            set
+            {
+                DirtyBit = true;
+                field5 = value;
+            }
+        }
+
+        private global::System.Nullable<double> field6;
+
+        public global::System.Nullable<double> Field6
+        {
+            get { return field6; }
+            set
+            {
+                DirtyBit = true;
+                field6 = value;
+            }
+        }
+
+        private global::System.Nullable<uint> field8;
+
+        public global::System.Nullable<uint> Field8
+        {
+            get { return field8; }
+            set
+            {
+                DirtyBit = true;
+                field8 = value;
+            }
+        }
+
+        private global::System.Nullable<ulong> field9;
+
+        public global::System.Nullable<ulong> Field9
+        {
+            get { return field9; }
+            set
+            {
+                DirtyBit = true;
+                field9 = value;
+            }
+        }
+
+        private global::System.Nullable<int> field10;
+
+        public global::System.Nullable<int> Field10
+        {
+            get { return field10; }
+            set
+            {
+                DirtyBit = true;
+                field10 = value;
+            }
+        }
+
+        private global::System.Nullable<long> field11;
+
+        public global::System.Nullable<long> Field11
+        {
+            get { return field11; }
+            set
+            {
+                DirtyBit = true;
+                field11 = value;
+            }
+        }
+
+        private global::System.Nullable<uint> field12;
+
+        public global::System.Nullable<uint> Field12
+        {
+            get { return field12; }
+            set
+            {
+                DirtyBit = true;
+                field12 = value;
+            }
+        }
+
+        private global::System.Nullable<ulong> field13;
+
+        public global::System.Nullable<ulong> Field13
+        {
+            get { return field13; }
+            set
+            {
+                DirtyBit = true;
+                field13 = value;
+            }
+        }
+
+        private global::System.Nullable<int> field14;
+
+        public global::System.Nullable<int> Field14
+        {
+            get { return field14; }
+            set
+            {
+                DirtyBit = true;
+                field14 = value;
+            }
+        }
+
+        private global::System.Nullable<long> field15;
+
+        public global::System.Nullable<long> Field15
+        {
+            get { return field15; }
+            set
+            {
+                DirtyBit = true;
+                field15 = value;
+            }
+        }
+
+        private global::System.Nullable<long> field16;
+
+        public global::System.Nullable<long> Field16
+        {
+            get { return field16; }
+            set
+            {
+                DirtyBit = true;
+                field16 = value;
+            }
+        }
+
+        private global::System.Nullable<global::Generated.Improbable.TestSchema.SomeType> field17;
+
+        public global::System.Nullable<global::Generated.Improbable.TestSchema.SomeType> Field17
+        {
+            get { return field17; }
+            set
+            {
+                DirtyBit = true;
+                field17 = value;
+            }
+        }
+    }
+}

--- a/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/ExhaustiveOptionalTranslation.cs
+++ b/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/ExhaustiveOptionalTranslation.cs
@@ -1,0 +1,247 @@
+// ===========
+// DO NOT EDIT - this file is automatically regenerated.
+// ===========
+
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using Unity.Mathematics;
+using Unity.Entities;
+using Improbable.Worker;
+using Improbable.Gdk.Core;
+using Improbable.Gdk.Core.Components;
+using Improbable.TestSchema;
+
+namespace Generated.Improbable.TestSchema
+{
+    public partial class ExhaustiveOptional
+    {
+        public class Translation : ComponentTranslation, IDispatcherCallbacks<global::Improbable.TestSchema.ExhaustiveOptional>
+        {
+            public override ComponentType TargetComponentType => targetComponentType;
+            private static readonly ComponentType targetComponentType = typeof(SpatialOSExhaustiveOptional);
+
+            public override ComponentType[] ReplicationComponentTypes => replicationComponentTypes;
+            private static readonly ComponentType[] replicationComponentTypes = { typeof(SpatialOSExhaustiveOptional), typeof(Authoritative<SpatialOSExhaustiveOptional>), typeof(SpatialEntityId)};
+
+            public override ComponentType[] CleanUpComponentTypes => cleanUpComponentTypes;
+            private static readonly ComponentType[] cleanUpComponentTypes = 
+            { 
+                typeof(ComponentsUpdated<SpatialOSExhaustiveOptional>), typeof(AuthoritiesChanged<SpatialOSExhaustiveOptional>),
+            };
+
+
+            private static readonly ComponentPool<ComponentsUpdated<SpatialOSExhaustiveOptional>> UpdatesPool =
+                new ComponentPool<ComponentsUpdated<SpatialOSExhaustiveOptional>>(
+                    () => new ComponentsUpdated<SpatialOSExhaustiveOptional>(),
+                    (component) => component.Buffer.Clear());
+
+            private static readonly ComponentPool<AuthoritiesChanged<SpatialOSExhaustiveOptional>> AuthsPool =
+                new ComponentPool<AuthoritiesChanged<SpatialOSExhaustiveOptional>>(
+                    () => new AuthoritiesChanged<SpatialOSExhaustiveOptional>(),
+                    (component) => component.Buffer.Clear());
+
+            public Translation(MutableView view) : base(view)
+            {
+            }
+
+            public override void RegisterWithDispatcher(Dispatcher dispatcher)
+            {
+                dispatcher.OnAddComponent<global::Improbable.TestSchema.ExhaustiveOptional>(OnAddComponent);
+                dispatcher.OnComponentUpdate<global::Improbable.TestSchema.ExhaustiveOptional>(OnComponentUpdate);
+                dispatcher.OnRemoveComponent<global::Improbable.TestSchema.ExhaustiveOptional>(OnRemoveComponent);
+                dispatcher.OnAuthorityChange<global::Improbable.TestSchema.ExhaustiveOptional>(OnAuthorityChange);
+
+            }
+
+            public override void AddCommandRequestSender(Unity.Entities.Entity entity, long entityId)
+            {
+            }
+
+            public void OnAddComponent(AddComponentOp<global::Improbable.TestSchema.ExhaustiveOptional> op)
+            {
+                Unity.Entities.Entity entity;
+                if (!view.TryGetEntity(op.EntityId.Id, out entity))
+                {
+                    Debug.LogErrorFormat(TranslationErrors.OpReceivedButNoEntity, op.GetType().Name, op.EntityId.Id);
+                    return;
+                }
+
+                var data = op.Data.Get().Value;
+
+                var spatialOSExhaustiveOptional = new SpatialOSExhaustiveOptional();
+                spatialOSExhaustiveOptional.Field2 = data.field2.HasValue ? new global::System.Nullable<float>(data.field2.Value) : new global::System.Nullable<float>();
+                spatialOSExhaustiveOptional.Field4 = data.field4.HasValue ? new global::System.Nullable<int>(data.field4.Value) : new global::System.Nullable<int>();
+                spatialOSExhaustiveOptional.Field5 = data.field5.HasValue ? new global::System.Nullable<long>(data.field5.Value) : new global::System.Nullable<long>();
+                spatialOSExhaustiveOptional.Field6 = data.field6.HasValue ? new global::System.Nullable<double>(data.field6.Value) : new global::System.Nullable<double>();
+                spatialOSExhaustiveOptional.Field8 = data.field8.HasValue ? new global::System.Nullable<uint>(data.field8.Value) : new global::System.Nullable<uint>();
+                spatialOSExhaustiveOptional.Field9 = data.field9.HasValue ? new global::System.Nullable<ulong>(data.field9.Value) : new global::System.Nullable<ulong>();
+                spatialOSExhaustiveOptional.Field10 = data.field10.HasValue ? new global::System.Nullable<int>(data.field10.Value) : new global::System.Nullable<int>();
+                spatialOSExhaustiveOptional.Field11 = data.field11.HasValue ? new global::System.Nullable<long>(data.field11.Value) : new global::System.Nullable<long>();
+                spatialOSExhaustiveOptional.Field12 = data.field12.HasValue ? new global::System.Nullable<uint>(data.field12.Value) : new global::System.Nullable<uint>();
+                spatialOSExhaustiveOptional.Field13 = data.field13.HasValue ? new global::System.Nullable<ulong>(data.field13.Value) : new global::System.Nullable<ulong>();
+                spatialOSExhaustiveOptional.Field14 = data.field14.HasValue ? new global::System.Nullable<int>(data.field14.Value) : new global::System.Nullable<int>();
+                spatialOSExhaustiveOptional.Field15 = data.field15.HasValue ? new global::System.Nullable<long>(data.field15.Value) : new global::System.Nullable<long>();
+                spatialOSExhaustiveOptional.Field16 = data.field16.HasValue ? new global::System.Nullable<long>(data.field16.Value.Id) : new global::System.Nullable<long>();
+                spatialOSExhaustiveOptional.Field17 = data.field17.HasValue ? new global::System.Nullable<global::Generated.Improbable.TestSchema.SomeType>(global::Generated.Improbable.TestSchema.SomeType.ToNative(data.field17.Value)) : new global::System.Nullable<global::Generated.Improbable.TestSchema.SomeType>();
+                spatialOSExhaustiveOptional.DirtyBit = false;
+
+                view.SetComponentObject(entity, spatialOSExhaustiveOptional);
+                view.AddComponent(entity, new NotAuthoritative<SpatialOSExhaustiveOptional>());
+            }
+
+            public void OnComponentUpdate(ComponentUpdateOp<global::Improbable.TestSchema.ExhaustiveOptional> op)
+            {
+                Unity.Entities.Entity entity;
+                if (!view.TryGetEntity(op.EntityId.Id, out entity))
+                {
+                    Debug.LogErrorFormat(TranslationErrors.OpReceivedButNoEntity, op.GetType().Name, op.EntityId.Id);
+                    return;
+                }
+
+                var componentData = view.GetComponentObject<SpatialOSExhaustiveOptional>(entity);
+                var update = op.Update.Get();
+
+                if (view.HasComponent<NotAuthoritative<SpatialOSExhaustiveOptional>>(entity))
+                {
+                    if (update.field2.HasValue)
+                    {
+                        componentData.Field2 = update.field2.Value.HasValue ? new global::System.Nullable<float>(update.field2.Value.Value) : new global::System.Nullable<float>();
+                    }
+                    if (update.field4.HasValue)
+                    {
+                        componentData.Field4 = update.field4.Value.HasValue ? new global::System.Nullable<int>(update.field4.Value.Value) : new global::System.Nullable<int>();
+                    }
+                    if (update.field5.HasValue)
+                    {
+                        componentData.Field5 = update.field5.Value.HasValue ? new global::System.Nullable<long>(update.field5.Value.Value) : new global::System.Nullable<long>();
+                    }
+                    if (update.field6.HasValue)
+                    {
+                        componentData.Field6 = update.field6.Value.HasValue ? new global::System.Nullable<double>(update.field6.Value.Value) : new global::System.Nullable<double>();
+                    }
+                    if (update.field8.HasValue)
+                    {
+                        componentData.Field8 = update.field8.Value.HasValue ? new global::System.Nullable<uint>(update.field8.Value.Value) : new global::System.Nullable<uint>();
+                    }
+                    if (update.field9.HasValue)
+                    {
+                        componentData.Field9 = update.field9.Value.HasValue ? new global::System.Nullable<ulong>(update.field9.Value.Value) : new global::System.Nullable<ulong>();
+                    }
+                    if (update.field10.HasValue)
+                    {
+                        componentData.Field10 = update.field10.Value.HasValue ? new global::System.Nullable<int>(update.field10.Value.Value) : new global::System.Nullable<int>();
+                    }
+                    if (update.field11.HasValue)
+                    {
+                        componentData.Field11 = update.field11.Value.HasValue ? new global::System.Nullable<long>(update.field11.Value.Value) : new global::System.Nullable<long>();
+                    }
+                    if (update.field12.HasValue)
+                    {
+                        componentData.Field12 = update.field12.Value.HasValue ? new global::System.Nullable<uint>(update.field12.Value.Value) : new global::System.Nullable<uint>();
+                    }
+                    if (update.field13.HasValue)
+                    {
+                        componentData.Field13 = update.field13.Value.HasValue ? new global::System.Nullable<ulong>(update.field13.Value.Value) : new global::System.Nullable<ulong>();
+                    }
+                    if (update.field14.HasValue)
+                    {
+                        componentData.Field14 = update.field14.Value.HasValue ? new global::System.Nullable<int>(update.field14.Value.Value) : new global::System.Nullable<int>();
+                    }
+                    if (update.field15.HasValue)
+                    {
+                        componentData.Field15 = update.field15.Value.HasValue ? new global::System.Nullable<long>(update.field15.Value.Value) : new global::System.Nullable<long>();
+                    }
+                    if (update.field16.HasValue)
+                    {
+                        componentData.Field16 = update.field16.Value.HasValue ? new global::System.Nullable<long>(update.field16.Value.Value.Id) : new global::System.Nullable<long>();
+                    }
+                    if (update.field17.HasValue)
+                    {
+                        componentData.Field17 = update.field17.Value.HasValue ? new global::System.Nullable<global::Generated.Improbable.TestSchema.SomeType>(global::Generated.Improbable.TestSchema.SomeType.ToNative(update.field17.Value.Value)) : new global::System.Nullable<global::Generated.Improbable.TestSchema.SomeType>();
+                    }
+                }
+
+                componentData.DirtyBit = false;
+                view.UpdateComponentObject(entity, componentData, UpdatesPool);
+            }
+
+            public void OnRemoveComponent(RemoveComponentOp op)
+            {
+                Unity.Entities.Entity entity;
+                if (!view.TryGetEntity(op.EntityId.Id, out entity))
+                {
+                    Debug.LogErrorFormat(TranslationErrors.OpReceivedButNoEntity, op.GetType().Name, op.EntityId.Id);
+                    return;
+                }
+
+                view.RemoveComponent<SpatialOSExhaustiveOptional>(entity);
+            }
+
+            public void OnAuthorityChange(AuthorityChangeOp op)
+            {
+                var entityId = op.EntityId.Id;
+                view.HandleAuthorityChange(entityId, op.Authority, AuthsPool);
+            }
+
+            public override void ExecuteReplication(Connection connection)
+            {
+                var componentDataArray = ReplicationComponentGroup.GetComponentArray<SpatialOSExhaustiveOptional>();
+                var spatialEntityIdData = ReplicationComponentGroup.GetComponentDataArray<SpatialEntityId>();
+
+                for (var i = 0; i < componentDataArray.Length; i++)
+                {
+                    var componentData = componentDataArray[i];
+                    var entityId = spatialEntityIdData[i].EntityId;
+                    var hasPendingEvents = false;
+
+                    if (componentData.DirtyBit || hasPendingEvents)
+                    {
+                        var update = new global::Improbable.TestSchema.ExhaustiveOptional.Update();
+                        update.SetField2(componentData.Field2.HasValue ? new global::Improbable.Collections.Option<float>(componentData.Field2.Value) : new global::Improbable.Collections.Option<float>());
+                        update.SetField4(componentData.Field4.HasValue ? new global::Improbable.Collections.Option<int>(componentData.Field4.Value) : new global::Improbable.Collections.Option<int>());
+                        update.SetField5(componentData.Field5.HasValue ? new global::Improbable.Collections.Option<long>(componentData.Field5.Value) : new global::Improbable.Collections.Option<long>());
+                        update.SetField6(componentData.Field6.HasValue ? new global::Improbable.Collections.Option<double>(componentData.Field6.Value) : new global::Improbable.Collections.Option<double>());
+                        update.SetField8(componentData.Field8.HasValue ? new global::Improbable.Collections.Option<uint>(componentData.Field8.Value) : new global::Improbable.Collections.Option<uint>());
+                        update.SetField9(componentData.Field9.HasValue ? new global::Improbable.Collections.Option<ulong>(componentData.Field9.Value) : new global::Improbable.Collections.Option<ulong>());
+                        update.SetField10(componentData.Field10.HasValue ? new global::Improbable.Collections.Option<int>(componentData.Field10.Value) : new global::Improbable.Collections.Option<int>());
+                        update.SetField11(componentData.Field11.HasValue ? new global::Improbable.Collections.Option<long>(componentData.Field11.Value) : new global::Improbable.Collections.Option<long>());
+                        update.SetField12(componentData.Field12.HasValue ? new global::Improbable.Collections.Option<uint>(componentData.Field12.Value) : new global::Improbable.Collections.Option<uint>());
+                        update.SetField13(componentData.Field13.HasValue ? new global::Improbable.Collections.Option<ulong>(componentData.Field13.Value) : new global::Improbable.Collections.Option<ulong>());
+                        update.SetField14(componentData.Field14.HasValue ? new global::Improbable.Collections.Option<int>(componentData.Field14.Value) : new global::Improbable.Collections.Option<int>());
+                        update.SetField15(componentData.Field15.HasValue ? new global::Improbable.Collections.Option<long>(componentData.Field15.Value) : new global::Improbable.Collections.Option<long>());
+                        update.SetField16(componentData.Field16.HasValue ? new global::Improbable.Collections.Option<global::Improbable.EntityId>(new global::Improbable.EntityId(componentData.Field16.Value)) : new global::Improbable.Collections.Option<global::Improbable.EntityId>());
+                        update.SetField17(componentData.Field17.HasValue ? new global::Improbable.Collections.Option<global::Improbable.TestSchema.SomeType>(global::Generated.Improbable.TestSchema.SomeType.ToSpatial(componentData.Field17.Value)) : new global::Improbable.Collections.Option<global::Improbable.TestSchema.SomeType>());
+                        SendComponentUpdate(connection, entityId, update);
+
+                        componentData.DirtyBit = false;
+                        view.SetComponentObject(entityId, componentData);
+
+                    }
+                }
+            }
+
+            public static void SendComponentUpdate(Connection connection, long entityId, global::Improbable.TestSchema.ExhaustiveOptional.Update update)
+            {
+                connection.SendComponentUpdate(new global::Improbable.EntityId(entityId), update);
+            }
+
+            public override void CleanUpComponents(ref EntityCommandBuffer entityCommandBuffer)
+            {
+                RemoveComponents(ref entityCommandBuffer, UpdatesPool, groupIndex: 0);
+                RemoveComponents(ref entityCommandBuffer, AuthsPool, groupIndex: 1);
+            }
+
+            public override void SendCommands(Connection connection)
+            {
+            }
+
+            public static ExhaustiveOptional.Translation GetTranslation(uint internalHandleToTranslation)
+            {
+                return (ExhaustiveOptional.Translation) ComponentTranslation.HandleToTranslation[internalHandleToTranslation];
+            }
+        }
+    }
+
+
+}

--- a/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/ExhaustiveRepeated.cs
+++ b/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/ExhaustiveRepeated.cs
@@ -1,0 +1,195 @@
+// ===========
+// DO NOT EDIT - this file is automatically regenerated.
+// ===========
+
+using UnityEngine;
+using Unity.Mathematics;
+using Improbable.Gdk.Core;
+
+namespace Generated.Improbable.TestSchema
+{ 
+    public class SpatialOSExhaustiveRepeated : Component, ISpatialComponentData
+    {
+        public bool1 DirtyBit { get; set; }
+
+        private global::System.Collections.Generic.List<float> field2;
+
+        public global::System.Collections.Generic.List<float> Field2
+        {
+            get { return field2; }
+            set
+            {
+                DirtyBit = true;
+                field2 = value;
+            }
+        }
+
+        private global::System.Collections.Generic.List<int> field4;
+
+        public global::System.Collections.Generic.List<int> Field4
+        {
+            get { return field4; }
+            set
+            {
+                DirtyBit = true;
+                field4 = value;
+            }
+        }
+
+        private global::System.Collections.Generic.List<long> field5;
+
+        public global::System.Collections.Generic.List<long> Field5
+        {
+            get { return field5; }
+            set
+            {
+                DirtyBit = true;
+                field5 = value;
+            }
+        }
+
+        private global::System.Collections.Generic.List<double> field6;
+
+        public global::System.Collections.Generic.List<double> Field6
+        {
+            get { return field6; }
+            set
+            {
+                DirtyBit = true;
+                field6 = value;
+            }
+        }
+
+        private global::System.Collections.Generic.List<string> field7;
+
+        public global::System.Collections.Generic.List<string> Field7
+        {
+            get { return field7; }
+            set
+            {
+                DirtyBit = true;
+                field7 = value;
+            }
+        }
+
+        private global::System.Collections.Generic.List<uint> field8;
+
+        public global::System.Collections.Generic.List<uint> Field8
+        {
+            get { return field8; }
+            set
+            {
+                DirtyBit = true;
+                field8 = value;
+            }
+        }
+
+        private global::System.Collections.Generic.List<ulong> field9;
+
+        public global::System.Collections.Generic.List<ulong> Field9
+        {
+            get { return field9; }
+            set
+            {
+                DirtyBit = true;
+                field9 = value;
+            }
+        }
+
+        private global::System.Collections.Generic.List<int> field10;
+
+        public global::System.Collections.Generic.List<int> Field10
+        {
+            get { return field10; }
+            set
+            {
+                DirtyBit = true;
+                field10 = value;
+            }
+        }
+
+        private global::System.Collections.Generic.List<long> field11;
+
+        public global::System.Collections.Generic.List<long> Field11
+        {
+            get { return field11; }
+            set
+            {
+                DirtyBit = true;
+                field11 = value;
+            }
+        }
+
+        private global::System.Collections.Generic.List<uint> field12;
+
+        public global::System.Collections.Generic.List<uint> Field12
+        {
+            get { return field12; }
+            set
+            {
+                DirtyBit = true;
+                field12 = value;
+            }
+        }
+
+        private global::System.Collections.Generic.List<ulong> field13;
+
+        public global::System.Collections.Generic.List<ulong> Field13
+        {
+            get { return field13; }
+            set
+            {
+                DirtyBit = true;
+                field13 = value;
+            }
+        }
+
+        private global::System.Collections.Generic.List<int> field14;
+
+        public global::System.Collections.Generic.List<int> Field14
+        {
+            get { return field14; }
+            set
+            {
+                DirtyBit = true;
+                field14 = value;
+            }
+        }
+
+        private global::System.Collections.Generic.List<long> field15;
+
+        public global::System.Collections.Generic.List<long> Field15
+        {
+            get { return field15; }
+            set
+            {
+                DirtyBit = true;
+                field15 = value;
+            }
+        }
+
+        private global::System.Collections.Generic.List<long> field16;
+
+        public global::System.Collections.Generic.List<long> Field16
+        {
+            get { return field16; }
+            set
+            {
+                DirtyBit = true;
+                field16 = value;
+            }
+        }
+
+        private global::System.Collections.Generic.List<global::Generated.Improbable.TestSchema.SomeType> field17;
+
+        public global::System.Collections.Generic.List<global::Generated.Improbable.TestSchema.SomeType> Field17
+        {
+            get { return field17; }
+            set
+            {
+                DirtyBit = true;
+                field17 = value;
+            }
+        }
+    }
+}

--- a/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/ExhaustiveRepeatedTranslation.cs
+++ b/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/ExhaustiveRepeatedTranslation.cs
@@ -1,0 +1,253 @@
+// ===========
+// DO NOT EDIT - this file is automatically regenerated.
+// ===========
+
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using Unity.Mathematics;
+using Unity.Entities;
+using Improbable.Worker;
+using Improbable.Gdk.Core;
+using Improbable.Gdk.Core.Components;
+using Improbable.TestSchema;
+
+namespace Generated.Improbable.TestSchema
+{
+    public partial class ExhaustiveRepeated
+    {
+        public class Translation : ComponentTranslation, IDispatcherCallbacks<global::Improbable.TestSchema.ExhaustiveRepeated>
+        {
+            public override ComponentType TargetComponentType => targetComponentType;
+            private static readonly ComponentType targetComponentType = typeof(SpatialOSExhaustiveRepeated);
+
+            public override ComponentType[] ReplicationComponentTypes => replicationComponentTypes;
+            private static readonly ComponentType[] replicationComponentTypes = { typeof(SpatialOSExhaustiveRepeated), typeof(Authoritative<SpatialOSExhaustiveRepeated>), typeof(SpatialEntityId)};
+
+            public override ComponentType[] CleanUpComponentTypes => cleanUpComponentTypes;
+            private static readonly ComponentType[] cleanUpComponentTypes = 
+            { 
+                typeof(ComponentsUpdated<SpatialOSExhaustiveRepeated>), typeof(AuthoritiesChanged<SpatialOSExhaustiveRepeated>),
+            };
+
+
+            private static readonly ComponentPool<ComponentsUpdated<SpatialOSExhaustiveRepeated>> UpdatesPool =
+                new ComponentPool<ComponentsUpdated<SpatialOSExhaustiveRepeated>>(
+                    () => new ComponentsUpdated<SpatialOSExhaustiveRepeated>(),
+                    (component) => component.Buffer.Clear());
+
+            private static readonly ComponentPool<AuthoritiesChanged<SpatialOSExhaustiveRepeated>> AuthsPool =
+                new ComponentPool<AuthoritiesChanged<SpatialOSExhaustiveRepeated>>(
+                    () => new AuthoritiesChanged<SpatialOSExhaustiveRepeated>(),
+                    (component) => component.Buffer.Clear());
+
+            public Translation(MutableView view) : base(view)
+            {
+            }
+
+            public override void RegisterWithDispatcher(Dispatcher dispatcher)
+            {
+                dispatcher.OnAddComponent<global::Improbable.TestSchema.ExhaustiveRepeated>(OnAddComponent);
+                dispatcher.OnComponentUpdate<global::Improbable.TestSchema.ExhaustiveRepeated>(OnComponentUpdate);
+                dispatcher.OnRemoveComponent<global::Improbable.TestSchema.ExhaustiveRepeated>(OnRemoveComponent);
+                dispatcher.OnAuthorityChange<global::Improbable.TestSchema.ExhaustiveRepeated>(OnAuthorityChange);
+
+            }
+
+            public override void AddCommandRequestSender(Unity.Entities.Entity entity, long entityId)
+            {
+            }
+
+            public void OnAddComponent(AddComponentOp<global::Improbable.TestSchema.ExhaustiveRepeated> op)
+            {
+                Unity.Entities.Entity entity;
+                if (!view.TryGetEntity(op.EntityId.Id, out entity))
+                {
+                    Debug.LogErrorFormat(TranslationErrors.OpReceivedButNoEntity, op.GetType().Name, op.EntityId.Id);
+                    return;
+                }
+
+                var data = op.Data.Get().Value;
+
+                var spatialOSExhaustiveRepeated = new SpatialOSExhaustiveRepeated();
+                spatialOSExhaustiveRepeated.Field2 = data.field2;
+                spatialOSExhaustiveRepeated.Field4 = data.field4;
+                spatialOSExhaustiveRepeated.Field5 = data.field5;
+                spatialOSExhaustiveRepeated.Field6 = data.field6;
+                spatialOSExhaustiveRepeated.Field7 = data.field7;
+                spatialOSExhaustiveRepeated.Field8 = data.field8;
+                spatialOSExhaustiveRepeated.Field9 = data.field9;
+                spatialOSExhaustiveRepeated.Field10 = data.field10;
+                spatialOSExhaustiveRepeated.Field11 = data.field11;
+                spatialOSExhaustiveRepeated.Field12 = data.field12;
+                spatialOSExhaustiveRepeated.Field13 = data.field13;
+                spatialOSExhaustiveRepeated.Field14 = data.field14;
+                spatialOSExhaustiveRepeated.Field15 = data.field15;
+                spatialOSExhaustiveRepeated.Field16 = data.field16.Select(internalObject => internalObject.Id).ToList();
+                spatialOSExhaustiveRepeated.Field17 = data.field17.Select(internalObject => global::Generated.Improbable.TestSchema.SomeType.ToNative(internalObject)).ToList();
+                spatialOSExhaustiveRepeated.DirtyBit = false;
+
+                view.SetComponentObject(entity, spatialOSExhaustiveRepeated);
+                view.AddComponent(entity, new NotAuthoritative<SpatialOSExhaustiveRepeated>());
+            }
+
+            public void OnComponentUpdate(ComponentUpdateOp<global::Improbable.TestSchema.ExhaustiveRepeated> op)
+            {
+                Unity.Entities.Entity entity;
+                if (!view.TryGetEntity(op.EntityId.Id, out entity))
+                {
+                    Debug.LogErrorFormat(TranslationErrors.OpReceivedButNoEntity, op.GetType().Name, op.EntityId.Id);
+                    return;
+                }
+
+                var componentData = view.GetComponentObject<SpatialOSExhaustiveRepeated>(entity);
+                var update = op.Update.Get();
+
+                if (view.HasComponent<NotAuthoritative<SpatialOSExhaustiveRepeated>>(entity))
+                {
+                    if (update.field2.HasValue)
+                    {
+                        componentData.Field2 = update.field2.Value;
+                    }
+                    if (update.field4.HasValue)
+                    {
+                        componentData.Field4 = update.field4.Value;
+                    }
+                    if (update.field5.HasValue)
+                    {
+                        componentData.Field5 = update.field5.Value;
+                    }
+                    if (update.field6.HasValue)
+                    {
+                        componentData.Field6 = update.field6.Value;
+                    }
+                    if (update.field7.HasValue)
+                    {
+                        componentData.Field7 = update.field7.Value;
+                    }
+                    if (update.field8.HasValue)
+                    {
+                        componentData.Field8 = update.field8.Value;
+                    }
+                    if (update.field9.HasValue)
+                    {
+                        componentData.Field9 = update.field9.Value;
+                    }
+                    if (update.field10.HasValue)
+                    {
+                        componentData.Field10 = update.field10.Value;
+                    }
+                    if (update.field11.HasValue)
+                    {
+                        componentData.Field11 = update.field11.Value;
+                    }
+                    if (update.field12.HasValue)
+                    {
+                        componentData.Field12 = update.field12.Value;
+                    }
+                    if (update.field13.HasValue)
+                    {
+                        componentData.Field13 = update.field13.Value;
+                    }
+                    if (update.field14.HasValue)
+                    {
+                        componentData.Field14 = update.field14.Value;
+                    }
+                    if (update.field15.HasValue)
+                    {
+                        componentData.Field15 = update.field15.Value;
+                    }
+                    if (update.field16.HasValue)
+                    {
+                        componentData.Field16 = update.field16.Value.Select(internalObject => internalObject.Id).ToList();
+                    }
+                    if (update.field17.HasValue)
+                    {
+                        componentData.Field17 = update.field17.Value.Select(internalObject => global::Generated.Improbable.TestSchema.SomeType.ToNative(internalObject)).ToList();
+                    }
+                }
+
+                componentData.DirtyBit = false;
+                view.UpdateComponentObject(entity, componentData, UpdatesPool);
+            }
+
+            public void OnRemoveComponent(RemoveComponentOp op)
+            {
+                Unity.Entities.Entity entity;
+                if (!view.TryGetEntity(op.EntityId.Id, out entity))
+                {
+                    Debug.LogErrorFormat(TranslationErrors.OpReceivedButNoEntity, op.GetType().Name, op.EntityId.Id);
+                    return;
+                }
+
+                view.RemoveComponent<SpatialOSExhaustiveRepeated>(entity);
+            }
+
+            public void OnAuthorityChange(AuthorityChangeOp op)
+            {
+                var entityId = op.EntityId.Id;
+                view.HandleAuthorityChange(entityId, op.Authority, AuthsPool);
+            }
+
+            public override void ExecuteReplication(Connection connection)
+            {
+                var componentDataArray = ReplicationComponentGroup.GetComponentArray<SpatialOSExhaustiveRepeated>();
+                var spatialEntityIdData = ReplicationComponentGroup.GetComponentDataArray<SpatialEntityId>();
+
+                for (var i = 0; i < componentDataArray.Length; i++)
+                {
+                    var componentData = componentDataArray[i];
+                    var entityId = spatialEntityIdData[i].EntityId;
+                    var hasPendingEvents = false;
+
+                    if (componentData.DirtyBit || hasPendingEvents)
+                    {
+                        var update = new global::Improbable.TestSchema.ExhaustiveRepeated.Update();
+                        update.SetField2(new global::Improbable.Collections.List<float>(componentData.Field2));
+                        update.SetField4(new global::Improbable.Collections.List<int>(componentData.Field4));
+                        update.SetField5(new global::Improbable.Collections.List<long>(componentData.Field5));
+                        update.SetField6(new global::Improbable.Collections.List<double>(componentData.Field6));
+                        update.SetField7(new global::Improbable.Collections.List<string>(componentData.Field7));
+                        update.SetField8(new global::Improbable.Collections.List<uint>(componentData.Field8));
+                        update.SetField9(new global::Improbable.Collections.List<ulong>(componentData.Field9));
+                        update.SetField10(new global::Improbable.Collections.List<int>(componentData.Field10));
+                        update.SetField11(new global::Improbable.Collections.List<long>(componentData.Field11));
+                        update.SetField12(new global::Improbable.Collections.List<uint>(componentData.Field12));
+                        update.SetField13(new global::Improbable.Collections.List<ulong>(componentData.Field13));
+                        update.SetField14(new global::Improbable.Collections.List<int>(componentData.Field14));
+                        update.SetField15(new global::Improbable.Collections.List<long>(componentData.Field15));
+                        update.SetField16(new global::Improbable.Collections.List<global::Improbable.EntityId>(componentData.Field16.Select(nativeInternalObject => new global::Improbable.EntityId(nativeInternalObject))));
+                        update.SetField17(new global::Improbable.Collections.List<global::Improbable.TestSchema.SomeType>(componentData.Field17.Select(nativeInternalObject => global::Generated.Improbable.TestSchema.SomeType.ToSpatial(nativeInternalObject))));
+                        SendComponentUpdate(connection, entityId, update);
+
+                        componentData.DirtyBit = false;
+                        view.SetComponentObject(entityId, componentData);
+
+                    }
+                }
+            }
+
+            public static void SendComponentUpdate(Connection connection, long entityId, global::Improbable.TestSchema.ExhaustiveRepeated.Update update)
+            {
+                connection.SendComponentUpdate(new global::Improbable.EntityId(entityId), update);
+            }
+
+            public override void CleanUpComponents(ref EntityCommandBuffer entityCommandBuffer)
+            {
+                RemoveComponents(ref entityCommandBuffer, UpdatesPool, groupIndex: 0);
+                RemoveComponents(ref entityCommandBuffer, AuthsPool, groupIndex: 1);
+            }
+
+            public override void SendCommands(Connection connection)
+            {
+            }
+
+            public static ExhaustiveRepeated.Translation GetTranslation(uint internalHandleToTranslation)
+            {
+                return (ExhaustiveRepeated.Translation) ComponentTranslation.HandleToTranslation[internalHandleToTranslation];
+            }
+        }
+    }
+
+
+}

--- a/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/ExhaustiveSingular.cs
+++ b/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/ExhaustiveSingular.cs
@@ -1,0 +1,207 @@
+// ===========
+// DO NOT EDIT - this file is automatically regenerated.
+// ===========
+
+using UnityEngine;
+using Unity.Mathematics;
+using Improbable.Gdk.Core;
+
+namespace Generated.Improbable.TestSchema
+{ 
+    public class SpatialOSExhaustiveSingular : Component, ISpatialComponentData
+    {
+        public bool1 DirtyBit { get; set; }
+
+        private bool1 field1;
+
+        public bool1 Field1
+        {
+            get { return field1; }
+            set
+            {
+                DirtyBit = true;
+                field1 = value;
+            }
+        }
+
+        private float field2;
+
+        public float Field2
+        {
+            get { return field2; }
+            set
+            {
+                DirtyBit = true;
+                field2 = value;
+            }
+        }
+
+        private int field4;
+
+        public int Field4
+        {
+            get { return field4; }
+            set
+            {
+                DirtyBit = true;
+                field4 = value;
+            }
+        }
+
+        private long field5;
+
+        public long Field5
+        {
+            get { return field5; }
+            set
+            {
+                DirtyBit = true;
+                field5 = value;
+            }
+        }
+
+        private double field6;
+
+        public double Field6
+        {
+            get { return field6; }
+            set
+            {
+                DirtyBit = true;
+                field6 = value;
+            }
+        }
+
+        private string field7;
+
+        public string Field7
+        {
+            get { return field7; }
+            set
+            {
+                DirtyBit = true;
+                field7 = value;
+            }
+        }
+
+        private uint field8;
+
+        public uint Field8
+        {
+            get { return field8; }
+            set
+            {
+                DirtyBit = true;
+                field8 = value;
+            }
+        }
+
+        private ulong field9;
+
+        public ulong Field9
+        {
+            get { return field9; }
+            set
+            {
+                DirtyBit = true;
+                field9 = value;
+            }
+        }
+
+        private int field10;
+
+        public int Field10
+        {
+            get { return field10; }
+            set
+            {
+                DirtyBit = true;
+                field10 = value;
+            }
+        }
+
+        private long field11;
+
+        public long Field11
+        {
+            get { return field11; }
+            set
+            {
+                DirtyBit = true;
+                field11 = value;
+            }
+        }
+
+        private uint field12;
+
+        public uint Field12
+        {
+            get { return field12; }
+            set
+            {
+                DirtyBit = true;
+                field12 = value;
+            }
+        }
+
+        private ulong field13;
+
+        public ulong Field13
+        {
+            get { return field13; }
+            set
+            {
+                DirtyBit = true;
+                field13 = value;
+            }
+        }
+
+        private int field14;
+
+        public int Field14
+        {
+            get { return field14; }
+            set
+            {
+                DirtyBit = true;
+                field14 = value;
+            }
+        }
+
+        private long field15;
+
+        public long Field15
+        {
+            get { return field15; }
+            set
+            {
+                DirtyBit = true;
+                field15 = value;
+            }
+        }
+
+        private long field16;
+
+        public long Field16
+        {
+            get { return field16; }
+            set
+            {
+                DirtyBit = true;
+                field16 = value;
+            }
+        }
+
+        private global::Generated.Improbable.TestSchema.SomeType field17;
+
+        public global::Generated.Improbable.TestSchema.SomeType Field17
+        {
+            get { return field17; }
+            set
+            {
+                DirtyBit = true;
+                field17 = value;
+            }
+        }
+    }
+}

--- a/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/ExhaustiveSingularTranslation.cs
+++ b/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/ExhaustiveSingularTranslation.cs
@@ -1,0 +1,259 @@
+// ===========
+// DO NOT EDIT - this file is automatically regenerated.
+// ===========
+
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using Unity.Mathematics;
+using Unity.Entities;
+using Improbable.Worker;
+using Improbable.Gdk.Core;
+using Improbable.Gdk.Core.Components;
+using Improbable.TestSchema;
+
+namespace Generated.Improbable.TestSchema
+{
+    public partial class ExhaustiveSingular
+    {
+        public class Translation : ComponentTranslation, IDispatcherCallbacks<global::Improbable.TestSchema.ExhaustiveSingular>
+        {
+            public override ComponentType TargetComponentType => targetComponentType;
+            private static readonly ComponentType targetComponentType = typeof(SpatialOSExhaustiveSingular);
+
+            public override ComponentType[] ReplicationComponentTypes => replicationComponentTypes;
+            private static readonly ComponentType[] replicationComponentTypes = { typeof(SpatialOSExhaustiveSingular), typeof(Authoritative<SpatialOSExhaustiveSingular>), typeof(SpatialEntityId)};
+
+            public override ComponentType[] CleanUpComponentTypes => cleanUpComponentTypes;
+            private static readonly ComponentType[] cleanUpComponentTypes = 
+            { 
+                typeof(ComponentsUpdated<SpatialOSExhaustiveSingular>), typeof(AuthoritiesChanged<SpatialOSExhaustiveSingular>),
+            };
+
+
+            private static readonly ComponentPool<ComponentsUpdated<SpatialOSExhaustiveSingular>> UpdatesPool =
+                new ComponentPool<ComponentsUpdated<SpatialOSExhaustiveSingular>>(
+                    () => new ComponentsUpdated<SpatialOSExhaustiveSingular>(),
+                    (component) => component.Buffer.Clear());
+
+            private static readonly ComponentPool<AuthoritiesChanged<SpatialOSExhaustiveSingular>> AuthsPool =
+                new ComponentPool<AuthoritiesChanged<SpatialOSExhaustiveSingular>>(
+                    () => new AuthoritiesChanged<SpatialOSExhaustiveSingular>(),
+                    (component) => component.Buffer.Clear());
+
+            public Translation(MutableView view) : base(view)
+            {
+            }
+
+            public override void RegisterWithDispatcher(Dispatcher dispatcher)
+            {
+                dispatcher.OnAddComponent<global::Improbable.TestSchema.ExhaustiveSingular>(OnAddComponent);
+                dispatcher.OnComponentUpdate<global::Improbable.TestSchema.ExhaustiveSingular>(OnComponentUpdate);
+                dispatcher.OnRemoveComponent<global::Improbable.TestSchema.ExhaustiveSingular>(OnRemoveComponent);
+                dispatcher.OnAuthorityChange<global::Improbable.TestSchema.ExhaustiveSingular>(OnAuthorityChange);
+
+            }
+
+            public override void AddCommandRequestSender(Unity.Entities.Entity entity, long entityId)
+            {
+            }
+
+            public void OnAddComponent(AddComponentOp<global::Improbable.TestSchema.ExhaustiveSingular> op)
+            {
+                Unity.Entities.Entity entity;
+                if (!view.TryGetEntity(op.EntityId.Id, out entity))
+                {
+                    Debug.LogErrorFormat(TranslationErrors.OpReceivedButNoEntity, op.GetType().Name, op.EntityId.Id);
+                    return;
+                }
+
+                var data = op.Data.Get().Value;
+
+                var spatialOSExhaustiveSingular = new SpatialOSExhaustiveSingular();
+                spatialOSExhaustiveSingular.Field1 = data.field1;
+                spatialOSExhaustiveSingular.Field2 = data.field2;
+                spatialOSExhaustiveSingular.Field4 = data.field4;
+                spatialOSExhaustiveSingular.Field5 = data.field5;
+                spatialOSExhaustiveSingular.Field6 = data.field6;
+                spatialOSExhaustiveSingular.Field7 = data.field7;
+                spatialOSExhaustiveSingular.Field8 = data.field8;
+                spatialOSExhaustiveSingular.Field9 = data.field9;
+                spatialOSExhaustiveSingular.Field10 = data.field10;
+                spatialOSExhaustiveSingular.Field11 = data.field11;
+                spatialOSExhaustiveSingular.Field12 = data.field12;
+                spatialOSExhaustiveSingular.Field13 = data.field13;
+                spatialOSExhaustiveSingular.Field14 = data.field14;
+                spatialOSExhaustiveSingular.Field15 = data.field15;
+                spatialOSExhaustiveSingular.Field16 = data.field16.Id;
+                spatialOSExhaustiveSingular.Field17 = global::Generated.Improbable.TestSchema.SomeType.ToNative(data.field17);
+                spatialOSExhaustiveSingular.DirtyBit = false;
+
+                view.SetComponentObject(entity, spatialOSExhaustiveSingular);
+                view.AddComponent(entity, new NotAuthoritative<SpatialOSExhaustiveSingular>());
+            }
+
+            public void OnComponentUpdate(ComponentUpdateOp<global::Improbable.TestSchema.ExhaustiveSingular> op)
+            {
+                Unity.Entities.Entity entity;
+                if (!view.TryGetEntity(op.EntityId.Id, out entity))
+                {
+                    Debug.LogErrorFormat(TranslationErrors.OpReceivedButNoEntity, op.GetType().Name, op.EntityId.Id);
+                    return;
+                }
+
+                var componentData = view.GetComponentObject<SpatialOSExhaustiveSingular>(entity);
+                var update = op.Update.Get();
+
+                if (view.HasComponent<NotAuthoritative<SpatialOSExhaustiveSingular>>(entity))
+                {
+                    if (update.field1.HasValue)
+                    {
+                        componentData.Field1 = update.field1.Value;
+                    }
+                    if (update.field2.HasValue)
+                    {
+                        componentData.Field2 = update.field2.Value;
+                    }
+                    if (update.field4.HasValue)
+                    {
+                        componentData.Field4 = update.field4.Value;
+                    }
+                    if (update.field5.HasValue)
+                    {
+                        componentData.Field5 = update.field5.Value;
+                    }
+                    if (update.field6.HasValue)
+                    {
+                        componentData.Field6 = update.field6.Value;
+                    }
+                    if (update.field7.HasValue)
+                    {
+                        componentData.Field7 = update.field7.Value;
+                    }
+                    if (update.field8.HasValue)
+                    {
+                        componentData.Field8 = update.field8.Value;
+                    }
+                    if (update.field9.HasValue)
+                    {
+                        componentData.Field9 = update.field9.Value;
+                    }
+                    if (update.field10.HasValue)
+                    {
+                        componentData.Field10 = update.field10.Value;
+                    }
+                    if (update.field11.HasValue)
+                    {
+                        componentData.Field11 = update.field11.Value;
+                    }
+                    if (update.field12.HasValue)
+                    {
+                        componentData.Field12 = update.field12.Value;
+                    }
+                    if (update.field13.HasValue)
+                    {
+                        componentData.Field13 = update.field13.Value;
+                    }
+                    if (update.field14.HasValue)
+                    {
+                        componentData.Field14 = update.field14.Value;
+                    }
+                    if (update.field15.HasValue)
+                    {
+                        componentData.Field15 = update.field15.Value;
+                    }
+                    if (update.field16.HasValue)
+                    {
+                        componentData.Field16 = update.field16.Value.Id;
+                    }
+                    if (update.field17.HasValue)
+                    {
+                        componentData.Field17 = global::Generated.Improbable.TestSchema.SomeType.ToNative(update.field17.Value);
+                    }
+                }
+
+                componentData.DirtyBit = false;
+                view.UpdateComponentObject(entity, componentData, UpdatesPool);
+            }
+
+            public void OnRemoveComponent(RemoveComponentOp op)
+            {
+                Unity.Entities.Entity entity;
+                if (!view.TryGetEntity(op.EntityId.Id, out entity))
+                {
+                    Debug.LogErrorFormat(TranslationErrors.OpReceivedButNoEntity, op.GetType().Name, op.EntityId.Id);
+                    return;
+                }
+
+                view.RemoveComponent<SpatialOSExhaustiveSingular>(entity);
+            }
+
+            public void OnAuthorityChange(AuthorityChangeOp op)
+            {
+                var entityId = op.EntityId.Id;
+                view.HandleAuthorityChange(entityId, op.Authority, AuthsPool);
+            }
+
+            public override void ExecuteReplication(Connection connection)
+            {
+                var componentDataArray = ReplicationComponentGroup.GetComponentArray<SpatialOSExhaustiveSingular>();
+                var spatialEntityIdData = ReplicationComponentGroup.GetComponentDataArray<SpatialEntityId>();
+
+                for (var i = 0; i < componentDataArray.Length; i++)
+                {
+                    var componentData = componentDataArray[i];
+                    var entityId = spatialEntityIdData[i].EntityId;
+                    var hasPendingEvents = false;
+
+                    if (componentData.DirtyBit || hasPendingEvents)
+                    {
+                        var update = new global::Improbable.TestSchema.ExhaustiveSingular.Update();
+                        update.SetField1(componentData.Field1);
+                        update.SetField2(componentData.Field2);
+                        update.SetField4(componentData.Field4);
+                        update.SetField5(componentData.Field5);
+                        update.SetField6(componentData.Field6);
+                        update.SetField7(componentData.Field7);
+                        update.SetField8(componentData.Field8);
+                        update.SetField9(componentData.Field9);
+                        update.SetField10(componentData.Field10);
+                        update.SetField11(componentData.Field11);
+                        update.SetField12(componentData.Field12);
+                        update.SetField13(componentData.Field13);
+                        update.SetField14(componentData.Field14);
+                        update.SetField15(componentData.Field15);
+                        update.SetField16(new global::Improbable.EntityId(componentData.Field16));
+                        update.SetField17(global::Generated.Improbable.TestSchema.SomeType.ToSpatial(componentData.Field17));
+                        SendComponentUpdate(connection, entityId, update);
+
+                        componentData.DirtyBit = false;
+                        view.SetComponentObject(entityId, componentData);
+
+                    }
+                }
+            }
+
+            public static void SendComponentUpdate(Connection connection, long entityId, global::Improbable.TestSchema.ExhaustiveSingular.Update update)
+            {
+                connection.SendComponentUpdate(new global::Improbable.EntityId(entityId), update);
+            }
+
+            public override void CleanUpComponents(ref EntityCommandBuffer entityCommandBuffer)
+            {
+                RemoveComponents(ref entityCommandBuffer, UpdatesPool, groupIndex: 0);
+                RemoveComponents(ref entityCommandBuffer, AuthsPool, groupIndex: 1);
+            }
+
+            public override void SendCommands(Connection connection)
+            {
+            }
+
+            public static ExhaustiveSingular.Translation GetTranslation(uint internalHandleToTranslation)
+            {
+                return (ExhaustiveSingular.Translation) ComponentTranslation.HandleToTranslation[internalHandleToTranslation];
+            }
+        }
+    }
+
+
+}

--- a/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/NestedComponent.cs
+++ b/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/NestedComponent.cs
@@ -1,0 +1,27 @@
+// ===========
+// DO NOT EDIT - this file is automatically regenerated.
+// ===========
+
+using Unity.Mathematics;
+using Unity.Entities;
+using Improbable.Gdk.Core;
+
+namespace Generated.Improbable.TestSchema
+{ 
+    public struct SpatialOSNestedComponent : IComponentData, ISpatialComponentData
+    {
+        public bool1 DirtyBit { get; set; }
+
+        private global::Generated.Improbable.TestSchema.TypeName nestedType;
+
+        public global::Generated.Improbable.TestSchema.TypeName NestedType
+        {
+            get { return nestedType; }
+            set
+            {
+                DirtyBit = true;
+                nestedType = value;
+            }
+        }
+    }
+}

--- a/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/NestedComponentTranslation.cs
+++ b/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/NestedComponentTranslation.cs
@@ -1,0 +1,169 @@
+// ===========
+// DO NOT EDIT - this file is automatically regenerated.
+// ===========
+
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using Unity.Mathematics;
+using Unity.Entities;
+using Improbable.Worker;
+using Improbable.Gdk.Core;
+using Improbable.Gdk.Core.Components;
+using Improbable.TestSchema;
+
+namespace Generated.Improbable.TestSchema
+{
+    public partial class NestedComponent
+    {
+        public class Translation : ComponentTranslation, IDispatcherCallbacks<global::Improbable.TestSchema.NestedComponent>
+        {
+            public override ComponentType TargetComponentType => targetComponentType;
+            private static readonly ComponentType targetComponentType = typeof(SpatialOSNestedComponent);
+
+            public override ComponentType[] ReplicationComponentTypes => replicationComponentTypes;
+            private static readonly ComponentType[] replicationComponentTypes = { typeof(SpatialOSNestedComponent), typeof(Authoritative<SpatialOSNestedComponent>), typeof(SpatialEntityId)};
+
+            public override ComponentType[] CleanUpComponentTypes => cleanUpComponentTypes;
+            private static readonly ComponentType[] cleanUpComponentTypes = 
+            { 
+                typeof(ComponentsUpdated<SpatialOSNestedComponent>), typeof(AuthoritiesChanged<SpatialOSNestedComponent>),
+            };
+
+
+            private static readonly ComponentPool<ComponentsUpdated<SpatialOSNestedComponent>> UpdatesPool =
+                new ComponentPool<ComponentsUpdated<SpatialOSNestedComponent>>(
+                    () => new ComponentsUpdated<SpatialOSNestedComponent>(),
+                    (component) => component.Buffer.Clear());
+
+            private static readonly ComponentPool<AuthoritiesChanged<SpatialOSNestedComponent>> AuthsPool =
+                new ComponentPool<AuthoritiesChanged<SpatialOSNestedComponent>>(
+                    () => new AuthoritiesChanged<SpatialOSNestedComponent>(),
+                    (component) => component.Buffer.Clear());
+
+            public Translation(MutableView view) : base(view)
+            {
+            }
+
+            public override void RegisterWithDispatcher(Dispatcher dispatcher)
+            {
+                dispatcher.OnAddComponent<global::Improbable.TestSchema.NestedComponent>(OnAddComponent);
+                dispatcher.OnComponentUpdate<global::Improbable.TestSchema.NestedComponent>(OnComponentUpdate);
+                dispatcher.OnRemoveComponent<global::Improbable.TestSchema.NestedComponent>(OnRemoveComponent);
+                dispatcher.OnAuthorityChange<global::Improbable.TestSchema.NestedComponent>(OnAuthorityChange);
+
+            }
+
+            public override void AddCommandRequestSender(Unity.Entities.Entity entity, long entityId)
+            {
+            }
+
+            public void OnAddComponent(AddComponentOp<global::Improbable.TestSchema.NestedComponent> op)
+            {
+                Unity.Entities.Entity entity;
+                if (!view.TryGetEntity(op.EntityId.Id, out entity))
+                {
+                    Debug.LogErrorFormat(TranslationErrors.OpReceivedButNoEntity, op.GetType().Name, op.EntityId.Id);
+                    return;
+                }
+
+                var data = op.Data.Get().Value;
+
+                var spatialOSNestedComponent = new SpatialOSNestedComponent();
+                spatialOSNestedComponent.NestedType = global::Generated.Improbable.TestSchema.TypeName.ToNative(data.nestedType);
+                spatialOSNestedComponent.DirtyBit = false;
+
+                view.AddComponent(entity, spatialOSNestedComponent);
+                view.AddComponent(entity, new NotAuthoritative<SpatialOSNestedComponent>());
+            }
+
+            public void OnComponentUpdate(ComponentUpdateOp<global::Improbable.TestSchema.NestedComponent> op)
+            {
+                Unity.Entities.Entity entity;
+                if (!view.TryGetEntity(op.EntityId.Id, out entity))
+                {
+                    Debug.LogErrorFormat(TranslationErrors.OpReceivedButNoEntity, op.GetType().Name, op.EntityId.Id);
+                    return;
+                }
+
+                var componentData = view.GetComponent<SpatialOSNestedComponent>(entity);
+                var update = op.Update.Get();
+
+                if (view.HasComponent<NotAuthoritative<SpatialOSNestedComponent>>(entity))
+                {
+                    if (update.nestedType.HasValue)
+                    {
+                        componentData.NestedType = global::Generated.Improbable.TestSchema.TypeName.ToNative(update.nestedType.Value);
+                    }
+                }
+
+                componentData.DirtyBit = false;
+                view.UpdateComponent(entity, componentData, UpdatesPool);
+            }
+
+            public void OnRemoveComponent(RemoveComponentOp op)
+            {
+                Unity.Entities.Entity entity;
+                if (!view.TryGetEntity(op.EntityId.Id, out entity))
+                {
+                    Debug.LogErrorFormat(TranslationErrors.OpReceivedButNoEntity, op.GetType().Name, op.EntityId.Id);
+                    return;
+                }
+
+                view.RemoveComponent<SpatialOSNestedComponent>(entity);
+            }
+
+            public void OnAuthorityChange(AuthorityChangeOp op)
+            {
+                var entityId = op.EntityId.Id;
+                view.HandleAuthorityChange(entityId, op.Authority, AuthsPool);
+            }
+
+            public override void ExecuteReplication(Connection connection)
+            {
+                var componentDataArray = ReplicationComponentGroup.GetComponentDataArray<SpatialOSNestedComponent>();
+                var spatialEntityIdData = ReplicationComponentGroup.GetComponentDataArray<SpatialEntityId>();
+
+                for (var i = 0; i < componentDataArray.Length; i++)
+                {
+                    var componentData = componentDataArray[i];
+                    var entityId = spatialEntityIdData[i].EntityId;
+                    var hasPendingEvents = false;
+
+                    if (componentData.DirtyBit || hasPendingEvents)
+                    {
+                        var update = new global::Improbable.TestSchema.NestedComponent.Update();
+                        update.SetNestedType(global::Generated.Improbable.TestSchema.TypeName.ToSpatial(componentData.NestedType));
+                        SendComponentUpdate(connection, entityId, update);
+
+                        componentData.DirtyBit = false;
+                        componentDataArray[i] = componentData;
+
+                    }
+                }
+            }
+
+            public static void SendComponentUpdate(Connection connection, long entityId, global::Improbable.TestSchema.NestedComponent.Update update)
+            {
+                connection.SendComponentUpdate(new global::Improbable.EntityId(entityId), update);
+            }
+
+            public override void CleanUpComponents(ref EntityCommandBuffer entityCommandBuffer)
+            {
+                RemoveComponents(ref entityCommandBuffer, UpdatesPool, groupIndex: 0);
+                RemoveComponents(ref entityCommandBuffer, AuthsPool, groupIndex: 1);
+            }
+
+            public override void SendCommands(Connection connection)
+            {
+            }
+
+            public static NestedComponent.Translation GetTranslation(uint internalHandleToTranslation)
+            {
+                return (NestedComponent.Translation) ComponentTranslation.HandleToTranslation[internalHandleToTranslation];
+            }
+        }
+    }
+
+
+}

--- a/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/SomeType.cs
+++ b/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/SomeType.cs
@@ -1,0 +1,26 @@
+// ===========
+// DO NOT EDIT - this file is automatically regenerated.
+// ===========
+
+using System.Linq;
+using Unity.Mathematics;
+
+namespace Generated.Improbable.TestSchema
+{ 
+    
+    public struct SomeType
+    {
+    
+        public static SomeType ToNative(global::Improbable.TestSchema.SomeType spatialType)
+        {
+            var nativeType = new SomeType();
+            return nativeType;
+        }
+    
+        public static global::Improbable.TestSchema.SomeType ToSpatial(global::Generated.Improbable.TestSchema.SomeType nativeType)
+        {
+            var spatialType = new global::Improbable.TestSchema.SomeType();
+            return spatialType;
+        }
+    }
+}

--- a/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/TypeName.cs
+++ b/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/TypeName.cs
@@ -1,0 +1,99 @@
+// ===========
+// DO NOT EDIT - this file is automatically regenerated.
+// ===========
+
+using System.Linq;
+using Unity.Mathematics;
+
+namespace Generated.Improbable.TestSchema
+{ 
+    
+    public struct TypeName
+    {
+        public global::Generated.Improbable.TestSchema.TypeName.Other OtherType;
+    
+        public static TypeName ToNative(global::Improbable.TestSchema.TypeName spatialType)
+        {
+            var nativeType = new TypeName();
+            nativeType.OtherType = global::Generated.Improbable.TestSchema.TypeName.Other.ToNative(spatialType.otherType);
+            return nativeType;
+        }
+    
+        public static global::Improbable.TestSchema.TypeName ToSpatial(global::Generated.Improbable.TestSchema.TypeName nativeType)
+        {
+            var spatialType = new global::Improbable.TestSchema.TypeName();
+            spatialType.otherType = global::Generated.Improbable.TestSchema.TypeName.Other.ToSpatial(nativeType.OtherType);
+            return spatialType;
+        }
+    
+        
+        public struct Other
+        {
+            public global::Generated.Improbable.TestSchema.TypeName.Other.NestedTypeName SameName;
+        
+            public static Other ToNative(global::Improbable.TestSchema.TypeName.Other spatialType)
+            {
+                var nativeType = new Other();
+                nativeType.SameName = global::Generated.Improbable.TestSchema.TypeName.Other.NestedTypeName.ToNative(spatialType.sameName);
+                return nativeType;
+            }
+        
+            public static global::Improbable.TestSchema.TypeName.Other ToSpatial(global::Generated.Improbable.TestSchema.TypeName.Other nativeType)
+            {
+                var spatialType = new global::Improbable.TestSchema.TypeName.Other();
+                spatialType.sameName = global::Generated.Improbable.TestSchema.TypeName.Other.NestedTypeName.ToSpatial(nativeType.SameName);
+                return spatialType;
+            }
+        
+            
+            public struct NestedTypeName
+            {
+                public global::Generated.Improbable.TestSchema.TypeName.Other.NestedTypeName.Other0 OtherZero;
+                public global::Generated.Improbable.TestSchema.TypeName.Other.NestedTypeName.NestedEnum EnumField;
+            
+                public static NestedTypeName ToNative(global::Improbable.TestSchema.TypeName.Other.NestedTypeName spatialType)
+                {
+                    var nativeType = new NestedTypeName();
+                    nativeType.OtherZero = global::Generated.Improbable.TestSchema.TypeName.Other.NestedTypeName.Other0.ToNative(spatialType.otherZero);
+                    nativeType.EnumField = (global::Generated.Improbable.TestSchema.TypeName.Other.NestedTypeName.NestedEnum) spatialType.enumField;
+                    return nativeType;
+                }
+            
+                public static global::Improbable.TestSchema.TypeName.Other.NestedTypeName ToSpatial(global::Generated.Improbable.TestSchema.TypeName.Other.NestedTypeName nativeType)
+                {
+                    var spatialType = new global::Improbable.TestSchema.TypeName.Other.NestedTypeName();
+                    spatialType.otherZero = global::Generated.Improbable.TestSchema.TypeName.Other.NestedTypeName.Other0.ToSpatial(nativeType.OtherZero);
+                    spatialType.enumField = (global::Improbable.TestSchema.TypeName.Other.NestedTypeName.NestedEnum) nativeType.EnumField;
+                    return spatialType;
+                }
+            
+                
+                public struct Other0
+                {
+                    public int Foo;
+                
+                    public static Other0 ToNative(global::Improbable.TestSchema.TypeName.Other.NestedTypeName.Other0 spatialType)
+                    {
+                        var nativeType = new Other0();
+                        nativeType.Foo = spatialType.foo;
+                        return nativeType;
+                    }
+                
+                    public static global::Improbable.TestSchema.TypeName.Other.NestedTypeName.Other0 ToSpatial(global::Generated.Improbable.TestSchema.TypeName.Other.NestedTypeName.Other0 nativeType)
+                    {
+                        var spatialType = new global::Improbable.TestSchema.TypeName.Other.NestedTypeName.Other0();
+                        spatialType.foo = nativeType.Foo;
+                        return spatialType;
+                    }
+                }
+            
+                
+                public enum NestedEnum : uint
+                {
+                    enum_value = 1,
+                }
+                
+            }
+        }
+    }
+}

--- a/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/blittable/BlittableComponent.cs
+++ b/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/blittable/BlittableComponent.cs
@@ -1,0 +1,75 @@
+// ===========
+// DO NOT EDIT - this file is automatically regenerated.
+// ===========
+
+using Unity.Mathematics;
+using Unity.Entities;
+using Improbable.Gdk.Core;
+
+namespace Generated.Improbable.TestSchema.Blittable
+{ 
+    public struct SpatialOSBlittableComponent : IComponentData, ISpatialComponentData
+    {
+        public bool1 DirtyBit { get; set; }
+
+        private bool1 boolField;
+
+        public bool1 BoolField
+        {
+            get { return boolField; }
+            set
+            {
+                DirtyBit = true;
+                boolField = value;
+            }
+        }
+
+        private int intField;
+
+        public int IntField
+        {
+            get { return intField; }
+            set
+            {
+                DirtyBit = true;
+                intField = value;
+            }
+        }
+
+        private long longField;
+
+        public long LongField
+        {
+            get { return longField; }
+            set
+            {
+                DirtyBit = true;
+                longField = value;
+            }
+        }
+
+        private float floatField;
+
+        public float FloatField
+        {
+            get { return floatField; }
+            set
+            {
+                DirtyBit = true;
+                floatField = value;
+            }
+        }
+
+        private double doubleField;
+
+        public double DoubleField
+        {
+            get { return doubleField; }
+            set
+            {
+                DirtyBit = true;
+                doubleField = value;
+            }
+        }
+    }
+}

--- a/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/blittable/BlittableComponentCommandPayloads.cs
+++ b/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/blittable/BlittableComponentCommandPayloads.cs
@@ -1,0 +1,195 @@
+// ===========
+// DO NOT EDIT - this file is automatically regenerated.
+// ===========
+
+using Improbable.Gdk.Core;
+using System.Collections.Generic;
+
+namespace Generated.Improbable.TestSchema.Blittable
+{
+    public partial class BlittableComponent
+    {
+        public class FirstCommand
+        {
+            public struct Request : IIncomingCommandRequest
+            {
+                public uint RequestId { get; }
+
+                internal Translation Translation { get; }
+
+                public string CallerWorkerId {get; }
+
+                public List<string> CallerAttributeSet { get; }
+
+                public global::Generated.Improbable.TestSchema.Blittable.FirstCommandRequest RawRequest { get; }
+
+                internal Request(uint requestId, 
+                    Translation translation,
+                    string callerWorkerId,
+                    List<string> callerAttributeSet,
+                    global::Generated.Improbable.TestSchema.Blittable.FirstCommandRequest request)
+                {
+                    this.RequestId = requestId;
+                    this.Translation = translation;
+                    this.CallerWorkerId = callerWorkerId;
+                    this.CallerAttributeSet = callerAttributeSet;
+                    this.RawRequest = request;
+                }
+
+                public void SendFirstCommandResponse(global::Generated.Improbable.TestSchema.Blittable.FirstCommandResponse response)
+                {
+                    Translation.FirstCommandResponses.Add(
+                        new OutgoingResponse(RequestId, response));
+                }
+            }
+
+            internal struct OutgoingRequest : IOutgoingCommandRequest
+            {
+                public long TargetEntityId { get; }
+
+                public long SenderEntityId { get; }
+
+                public global::Generated.Improbable.TestSchema.Blittable.FirstCommandRequest RawRequest { get; }
+
+                internal OutgoingRequest(long targetEntityId, long senderEntityId,
+                    global::Generated.Improbable.TestSchema.Blittable.FirstCommandRequest request)
+                {
+                    this.TargetEntityId = targetEntityId;
+                    this.SenderEntityId = senderEntityId;
+                    this.RawRequest = request;
+                }
+            }
+
+            public struct Response : IIncomingCommandResponse
+            {
+                public long EntityId { get; }
+
+                public string Message { get; }
+
+                public CommandStatusCode StatusCode { get; }
+
+                public global::Generated.Improbable.TestSchema.Blittable.FirstCommandResponse? RawResponse { get; }
+
+                public global::Generated.Improbable.TestSchema.Blittable.FirstCommandRequest RawRequest { get; }
+
+                internal Response(long entityId, 
+                    string message,
+                    CommandStatusCode statusCode, 
+                    global::Generated.Improbable.TestSchema.Blittable.FirstCommandResponse? response,
+                    global::Generated.Improbable.TestSchema.Blittable.FirstCommandRequest request)
+                {
+                    this.EntityId = entityId;
+                    this.Message = message;
+                    this.StatusCode = statusCode;
+                    this.RawResponse = response;
+                    this.RawRequest = request;
+                }
+            }
+
+            internal struct OutgoingResponse : IOutgoingCommandResponse
+            {
+                public uint RequestId { get; }
+
+                public global::Generated.Improbable.TestSchema.Blittable.FirstCommandResponse RawResponse { get; }
+
+                internal OutgoingResponse(uint requestId, 
+                    global::Generated.Improbable.TestSchema.Blittable.FirstCommandResponse response)
+                {
+                    this.RequestId = requestId;
+                    this.RawResponse = response;
+                }
+            }
+        }
+        public class SecondCommand
+        {
+            public struct Request : IIncomingCommandRequest
+            {
+                public uint RequestId { get; }
+
+                internal Translation Translation { get; }
+
+                public string CallerWorkerId {get; }
+
+                public List<string> CallerAttributeSet { get; }
+
+                public global::Generated.Improbable.TestSchema.Blittable.SecondCommandRequest RawRequest { get; }
+
+                internal Request(uint requestId, 
+                    Translation translation,
+                    string callerWorkerId,
+                    List<string> callerAttributeSet,
+                    global::Generated.Improbable.TestSchema.Blittable.SecondCommandRequest request)
+                {
+                    this.RequestId = requestId;
+                    this.Translation = translation;
+                    this.CallerWorkerId = callerWorkerId;
+                    this.CallerAttributeSet = callerAttributeSet;
+                    this.RawRequest = request;
+                }
+
+                public void SendSecondCommandResponse(global::Generated.Improbable.TestSchema.Blittable.SecondCommandResponse response)
+                {
+                    Translation.SecondCommandResponses.Add(
+                        new OutgoingResponse(RequestId, response));
+                }
+            }
+
+            internal struct OutgoingRequest : IOutgoingCommandRequest
+            {
+                public long TargetEntityId { get; }
+
+                public long SenderEntityId { get; }
+
+                public global::Generated.Improbable.TestSchema.Blittable.SecondCommandRequest RawRequest { get; }
+
+                internal OutgoingRequest(long targetEntityId, long senderEntityId,
+                    global::Generated.Improbable.TestSchema.Blittable.SecondCommandRequest request)
+                {
+                    this.TargetEntityId = targetEntityId;
+                    this.SenderEntityId = senderEntityId;
+                    this.RawRequest = request;
+                }
+            }
+
+            public struct Response : IIncomingCommandResponse
+            {
+                public long EntityId { get; }
+
+                public string Message { get; }
+
+                public CommandStatusCode StatusCode { get; }
+
+                public global::Generated.Improbable.TestSchema.Blittable.SecondCommandResponse? RawResponse { get; }
+
+                public global::Generated.Improbable.TestSchema.Blittable.SecondCommandRequest RawRequest { get; }
+
+                internal Response(long entityId, 
+                    string message,
+                    CommandStatusCode statusCode, 
+                    global::Generated.Improbable.TestSchema.Blittable.SecondCommandResponse? response,
+                    global::Generated.Improbable.TestSchema.Blittable.SecondCommandRequest request)
+                {
+                    this.EntityId = entityId;
+                    this.Message = message;
+                    this.StatusCode = statusCode;
+                    this.RawResponse = response;
+                    this.RawRequest = request;
+                }
+            }
+
+            internal struct OutgoingResponse : IOutgoingCommandResponse
+            {
+                public uint RequestId { get; }
+
+                public global::Generated.Improbable.TestSchema.Blittable.SecondCommandResponse RawResponse { get; }
+
+                internal OutgoingResponse(uint requestId, 
+                    global::Generated.Improbable.TestSchema.Blittable.SecondCommandResponse response)
+                {
+                    this.RequestId = requestId;
+                    this.RawResponse = response;
+                }
+            }
+        }
+    }
+}

--- a/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/blittable/BlittableComponentEvents.cs
+++ b/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/blittable/BlittableComponentEvents.cs
@@ -1,0 +1,20 @@
+// ===========
+// DO NOT EDIT - this file is automatically regenerated.
+// ===========
+
+using Improbable.Gdk.Core;
+using System.Collections.Generic;
+
+namespace Generated.Improbable.TestSchema.Blittable
+{
+    public struct FirstEventEvent : ISpatialEvent
+    {
+        public global::Generated.Improbable.TestSchema.Blittable.FirstEventPayload Payload;
+    }
+
+    public struct SecondEventEvent : ISpatialEvent
+    {
+        public global::Generated.Improbable.TestSchema.Blittable.SecondEventPayload Payload;
+    }
+
+}

--- a/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/blittable/BlittableComponentTranslation.cs
+++ b/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/blittable/BlittableComponentTranslation.cs
@@ -1,0 +1,517 @@
+// ===========
+// DO NOT EDIT - this file is automatically regenerated.
+// ===========
+
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using Unity.Mathematics;
+using Unity.Entities;
+using Improbable.Worker;
+using Improbable.Gdk.Core;
+using Improbable.Gdk.Core.Components;
+using Improbable.TestSchema.Blittable;
+
+namespace Generated.Improbable.TestSchema.Blittable
+{
+    public partial class BlittableComponent
+    {
+        public class Translation : ComponentTranslation, IDispatcherCallbacks<global::Improbable.TestSchema.Blittable.BlittableComponent>
+        {
+            public override ComponentType TargetComponentType => targetComponentType;
+            private static readonly ComponentType targetComponentType = typeof(SpatialOSBlittableComponent);
+
+            public override ComponentType[] ReplicationComponentTypes => replicationComponentTypes;
+            private static readonly ComponentType[] replicationComponentTypes = { typeof(SpatialOSBlittableComponent), typeof(Authoritative<SpatialOSBlittableComponent>), typeof(SpatialEntityId)};
+
+            public override ComponentType[] CleanUpComponentTypes => cleanUpComponentTypes;
+            private static readonly ComponentType[] cleanUpComponentTypes = 
+            { 
+                typeof(ComponentsUpdated<SpatialOSBlittableComponent>), typeof(AuthoritiesChanged<SpatialOSBlittableComponent>),
+                typeof(CommandRequests<FirstCommand.Request>), typeof(CommandResponses<FirstCommand.Response>),
+                typeof(CommandRequests<SecondCommand.Request>), typeof(CommandResponses<SecondCommand.Response>),
+                typeof(EventsReceived<FirstEventEvent>),
+                typeof(EventsReceived<SecondEventEvent>),
+            };
+
+            private readonly Dictionary<uint, RequestContext> RequestIdToRequestContext = new Dictionary<uint, RequestContext>();
+
+            internal List<FirstCommand.OutgoingRequest> FirstCommandRequests = new List<FirstCommand.OutgoingRequest>();
+            internal List<FirstCommand.OutgoingResponse> FirstCommandResponses = new List<FirstCommand.OutgoingResponse>();
+            private static readonly ComponentPool<CommandRequests<FirstCommand.Request>> FirstCommandRequestPool =
+                new ComponentPool<CommandRequests<FirstCommand.Request>>(
+                    () => new CommandRequests<FirstCommand.Request>(),
+                    (component) => component.Buffer.Clear());
+            private static readonly ComponentPool<CommandResponses<FirstCommand.Response>> FirstCommandResponsePool =
+                new ComponentPool<CommandResponses<FirstCommand.Response>>(
+                    () => new CommandResponses<FirstCommand.Response>(),
+                    (component) => component.Buffer.Clear());
+            internal List<SecondCommand.OutgoingRequest> SecondCommandRequests = new List<SecondCommand.OutgoingRequest>();
+            internal List<SecondCommand.OutgoingResponse> SecondCommandResponses = new List<SecondCommand.OutgoingResponse>();
+            private static readonly ComponentPool<CommandRequests<SecondCommand.Request>> SecondCommandRequestPool =
+                new ComponentPool<CommandRequests<SecondCommand.Request>>(
+                    () => new CommandRequests<SecondCommand.Request>(),
+                    (component) => component.Buffer.Clear());
+            private static readonly ComponentPool<CommandResponses<SecondCommand.Response>> SecondCommandResponsePool =
+                new ComponentPool<CommandResponses<SecondCommand.Response>>(
+                    () => new CommandResponses<SecondCommand.Response>(),
+                    (component) => component.Buffer.Clear());
+
+            internal readonly Dictionary<long, List<global::Generated.Improbable.TestSchema.Blittable.FirstEventPayload>> EntityIdToFirstEventEvents = new Dictionary<long, List<global::Generated.Improbable.TestSchema.Blittable.FirstEventPayload>>();
+
+            private static readonly ComponentPool<EventsReceived<FirstEventEvent>> FirstEventEventPool =
+                new ComponentPool<EventsReceived<FirstEventEvent>>(
+                    () => new EventsReceived<FirstEventEvent>(),
+                    (component) => component.Buffer.Clear());
+            internal readonly Dictionary<long, List<global::Generated.Improbable.TestSchema.Blittable.SecondEventPayload>> EntityIdToSecondEventEvents = new Dictionary<long, List<global::Generated.Improbable.TestSchema.Blittable.SecondEventPayload>>();
+
+            private static readonly ComponentPool<EventsReceived<SecondEventEvent>> SecondEventEventPool =
+                new ComponentPool<EventsReceived<SecondEventEvent>>(
+                    () => new EventsReceived<SecondEventEvent>(),
+                    (component) => component.Buffer.Clear());
+
+            private static readonly ComponentPool<ComponentsUpdated<SpatialOSBlittableComponent>> UpdatesPool =
+                new ComponentPool<ComponentsUpdated<SpatialOSBlittableComponent>>(
+                    () => new ComponentsUpdated<SpatialOSBlittableComponent>(),
+                    (component) => component.Buffer.Clear());
+
+            private static readonly ComponentPool<AuthoritiesChanged<SpatialOSBlittableComponent>> AuthsPool =
+                new ComponentPool<AuthoritiesChanged<SpatialOSBlittableComponent>>(
+                    () => new AuthoritiesChanged<SpatialOSBlittableComponent>(),
+                    (component) => component.Buffer.Clear());
+
+            public Translation(MutableView view) : base(view)
+            {
+            }
+
+            public override void RegisterWithDispatcher(Dispatcher dispatcher)
+            {
+                dispatcher.OnAddComponent<global::Improbable.TestSchema.Blittable.BlittableComponent>(OnAddComponent);
+                dispatcher.OnComponentUpdate<global::Improbable.TestSchema.Blittable.BlittableComponent>(OnComponentUpdate);
+                dispatcher.OnRemoveComponent<global::Improbable.TestSchema.Blittable.BlittableComponent>(OnRemoveComponent);
+                dispatcher.OnAuthorityChange<global::Improbable.TestSchema.Blittable.BlittableComponent>(OnAuthorityChange);
+
+                dispatcher.OnCommandRequest<global::Improbable.TestSchema.Blittable.BlittableComponent.Commands.FirstCommand>(OnCommandRequestFirstCommand);
+                dispatcher.OnCommandResponse<global::Improbable.TestSchema.Blittable.BlittableComponent.Commands.FirstCommand>(OnCommandResponseFirstCommand);
+                dispatcher.OnCommandRequest<global::Improbable.TestSchema.Blittable.BlittableComponent.Commands.SecondCommand>(OnCommandRequestSecondCommand);
+                dispatcher.OnCommandResponse<global::Improbable.TestSchema.Blittable.BlittableComponent.Commands.SecondCommand>(OnCommandResponseSecondCommand);
+            }
+
+            public override void AddCommandRequestSender(Unity.Entities.Entity entity, long entityId)
+            {
+                view.AddComponent(entity, new CommandRequestSender<SpatialOSBlittableComponent>(entityId, translationHandle));
+            }
+
+            public void OnAddComponent(AddComponentOp<global::Improbable.TestSchema.Blittable.BlittableComponent> op)
+            {
+                Unity.Entities.Entity entity;
+                if (!view.TryGetEntity(op.EntityId.Id, out entity))
+                {
+                    Debug.LogErrorFormat(TranslationErrors.OpReceivedButNoEntity, op.GetType().Name, op.EntityId.Id);
+                    return;
+                }
+
+                var data = op.Data.Get().Value;
+
+                var spatialOSBlittableComponent = new SpatialOSBlittableComponent();
+                spatialOSBlittableComponent.BoolField = data.boolField;
+                spatialOSBlittableComponent.IntField = data.intField;
+                spatialOSBlittableComponent.LongField = data.longField;
+                spatialOSBlittableComponent.FloatField = data.floatField;
+                spatialOSBlittableComponent.DoubleField = data.doubleField;
+                spatialOSBlittableComponent.DirtyBit = false;
+
+                view.AddComponent(entity, spatialOSBlittableComponent);
+                view.AddComponent(entity, new NotAuthoritative<SpatialOSBlittableComponent>());
+            }
+
+            public void OnComponentUpdate(ComponentUpdateOp<global::Improbable.TestSchema.Blittable.BlittableComponent> op)
+            {
+                Unity.Entities.Entity entity;
+                if (!view.TryGetEntity(op.EntityId.Id, out entity))
+                {
+                    Debug.LogErrorFormat(TranslationErrors.OpReceivedButNoEntity, op.GetType().Name, op.EntityId.Id);
+                    return;
+                }
+
+                var componentData = view.GetComponent<SpatialOSBlittableComponent>(entity);
+                var update = op.Update.Get();
+
+                if (view.HasComponent<NotAuthoritative<SpatialOSBlittableComponent>>(entity))
+                {
+                    if (update.boolField.HasValue)
+                    {
+                        componentData.BoolField = update.boolField.Value;
+                    }
+                    if (update.intField.HasValue)
+                    {
+                        componentData.IntField = update.intField.Value;
+                    }
+                    if (update.longField.HasValue)
+                    {
+                        componentData.LongField = update.longField.Value;
+                    }
+                    if (update.floatField.HasValue)
+                    {
+                        componentData.FloatField = update.floatField.Value;
+                    }
+                    if (update.doubleField.HasValue)
+                    {
+                        componentData.DoubleField = update.doubleField.Value;
+                    }
+                }
+
+                var firstEventEvents = update.firstEvent;
+                foreach (var spatialEvent in firstEventEvents)
+                {
+                    var nativeEvent = new FirstEventEvent
+                    {
+                        Payload = global::Generated.Improbable.TestSchema.Blittable.FirstEventPayload.ToNative(spatialEvent)
+                    };
+
+                    view.AddEventReceived(entity, nativeEvent, FirstEventEventPool);
+                }
+                var secondEventEvents = update.secondEvent;
+                foreach (var spatialEvent in secondEventEvents)
+                {
+                    var nativeEvent = new SecondEventEvent
+                    {
+                        Payload = global::Generated.Improbable.TestSchema.Blittable.SecondEventPayload.ToNative(spatialEvent)
+                    };
+
+                    view.AddEventReceived(entity, nativeEvent, SecondEventEventPool);
+                }
+                componentData.DirtyBit = false;
+                view.UpdateComponent(entity, componentData, UpdatesPool);
+            }
+
+            public void OnRemoveComponent(RemoveComponentOp op)
+            {
+                Unity.Entities.Entity entity;
+                if (!view.TryGetEntity(op.EntityId.Id, out entity))
+                {
+                    Debug.LogErrorFormat(TranslationErrors.OpReceivedButNoEntity, op.GetType().Name, op.EntityId.Id);
+                    return;
+                }
+
+                view.RemoveComponent<SpatialOSBlittableComponent>(entity);
+            }
+
+            public void OnAuthorityChange(AuthorityChangeOp op)
+            {
+                var entityId = op.EntityId.Id;
+                if (op.Authority == Authority.Authoritative)
+                {
+                    EntityIdToFirstEventEvents[entityId] = new List<global::Generated.Improbable.TestSchema.Blittable.FirstEventPayload>();
+                    EntityIdToSecondEventEvents[entityId] = new List<global::Generated.Improbable.TestSchema.Blittable.SecondEventPayload>();
+                    view.AddComponent(entityId, new EventSender<SpatialOSBlittableComponent>(entityId, translationHandle));
+                }
+                else if (op.Authority == Authority.NotAuthoritative)
+                {
+                    EntityIdToFirstEventEvents.Remove(entityId);
+                    EntityIdToSecondEventEvents.Remove(entityId);
+                    view.RemoveComponent<EventSender<SpatialOSBlittableComponent>>(entityId);
+                }
+                view.HandleAuthorityChange(entityId, op.Authority, AuthsPool);
+            }
+
+            public override void ExecuteReplication(Connection connection)
+            {
+                var componentDataArray = ReplicationComponentGroup.GetComponentDataArray<SpatialOSBlittableComponent>();
+                var spatialEntityIdData = ReplicationComponentGroup.GetComponentDataArray<SpatialEntityId>();
+
+                for (var i = 0; i < componentDataArray.Length; i++)
+                {
+                    var componentData = componentDataArray[i];
+                    var entityId = spatialEntityIdData[i].EntityId;
+                    var hasPendingEvents = false;
+                    var firstEventEvents = EntityIdToFirstEventEvents[entityId];
+                    hasPendingEvents |= firstEventEvents.Count() > 0;
+                    var secondEventEvents = EntityIdToSecondEventEvents[entityId];
+                    hasPendingEvents |= secondEventEvents.Count() > 0;
+
+                    if (componentData.DirtyBit || hasPendingEvents)
+                    {
+                        var update = new global::Improbable.TestSchema.Blittable.BlittableComponent.Update();
+                        update.SetBoolField(componentData.BoolField);
+                        update.SetIntField(componentData.IntField);
+                        update.SetLongField(componentData.LongField);
+                        update.SetFloatField(componentData.FloatField);
+                        update.SetDoubleField(componentData.DoubleField);
+                        foreach (var nativeEvent in firstEventEvents)
+                        {
+                            var spatialEvent = global::Generated.Improbable.TestSchema.Blittable.FirstEventPayload.ToSpatial(nativeEvent);
+                            update.firstEvent.Add(spatialEvent);
+                        }
+                        foreach (var nativeEvent in secondEventEvents)
+                        {
+                            var spatialEvent = global::Generated.Improbable.TestSchema.Blittable.SecondEventPayload.ToSpatial(nativeEvent);
+                            update.secondEvent.Add(spatialEvent);
+                        }
+                        SendComponentUpdate(connection, entityId, update);
+
+                        componentData.DirtyBit = false;
+                        componentDataArray[i] = componentData;
+
+                        firstEventEvents.Clear();
+                        secondEventEvents.Clear();
+                    }
+                }
+            }
+
+            public static void SendComponentUpdate(Connection connection, long entityId, global::Improbable.TestSchema.Blittable.BlittableComponent.Update update)
+            {
+                connection.SendComponentUpdate(new global::Improbable.EntityId(entityId), update);
+            }
+
+            public override void CleanUpComponents(ref EntityCommandBuffer entityCommandBuffer)
+            {
+                RemoveComponents(ref entityCommandBuffer, UpdatesPool, groupIndex: 0);
+                RemoveComponents(ref entityCommandBuffer, AuthsPool, groupIndex: 1);
+                RemoveComponents(ref entityCommandBuffer, FirstCommandRequestPool, groupIndex: 2);
+                RemoveComponents(ref entityCommandBuffer, FirstCommandResponsePool, groupIndex: 3);
+                RemoveComponents(ref entityCommandBuffer, SecondCommandRequestPool, groupIndex: 4);
+                RemoveComponents(ref entityCommandBuffer, SecondCommandResponsePool, groupIndex: 5);
+                RemoveComponents(ref entityCommandBuffer, FirstEventEventPool, groupIndex: 6);
+                RemoveComponents(ref entityCommandBuffer, SecondEventEventPool, groupIndex: 7);
+            }
+
+            public void OnCommandRequestFirstCommand(CommandRequestOp<global::Improbable.TestSchema.Blittable.BlittableComponent.Commands.FirstCommand> op)
+            {
+                Unity.Entities.Entity entity;
+                if (!view.TryGetEntity(op.EntityId.Id, out entity))
+                {
+                    Debug.LogErrorFormat(TranslationErrors.CannotFindEntityForCommandRequest, op.EntityId.Id,
+                        "FirstCommand");
+                    return;
+                }
+
+                var requestPayload = op.Request.Get().Value;
+                var unityRequestPayload = global::Generated.Improbable.TestSchema.Blittable.FirstCommandRequest.ToNative(requestPayload);
+                var request = new FirstCommand.Request(op.RequestId.Id, this, op.CallerWorkerId, op.CallerAttributeSet, unityRequestPayload);
+
+                view.AddCommandRequest(entity, request, FirstCommandRequestPool);
+            }
+
+            public void OnCommandResponseFirstCommand(CommandResponseOp<global::Improbable.TestSchema.Blittable.BlittableComponent.Commands.FirstCommand> op)
+            {
+                var requestId = op.RequestId.Id;
+                RequestContext requestContext;
+                if (!RequestIdToRequestContext.TryGetValue(requestId, out requestContext))
+                {
+                    Debug.LogErrorFormat(TranslationErrors.CannotFindEntityForCommandResponse, op.EntityId.Id,
+                        "FirstCommand");
+                    return;
+                }
+
+                RequestIdToRequestContext.Remove(requestId);
+
+                Unity.Entities.Entity entity;
+                if (requestContext.EntityId == MutableView.WorkerEntityId)
+                {
+                    entity = view.WorkerEntity;
+                }
+                else if (!view.TryGetEntity(requestContext.EntityId, out entity))
+                {
+                    return;
+                }
+
+                var unityResponsePayload = op.Response.HasValue 
+                    ? global::Generated.Improbable.TestSchema.Blittable.FirstCommandResponse.ToNative(op.Response.Value.Get().Value) 
+                    : (global::Generated.Improbable.TestSchema.Blittable.FirstCommandResponse?) null;
+                var outgoingRequest = (FirstCommand.OutgoingRequest) requestContext.Request;
+                var response = new FirstCommand.Response(op.EntityId.Id, op.Message, (CommandStatusCode) op.StatusCode, unityResponsePayload, outgoingRequest.RawRequest);
+
+                view.AddCommandResponse(entity, response, FirstCommandResponsePool);
+            }
+
+            private void SendFirstCommandRequest(Connection connection, FirstCommand.OutgoingRequest outgoingRequest)
+            {
+                var requestPayload = global::Generated.Improbable.TestSchema.Blittable.FirstCommandRequest.ToSpatial(outgoingRequest.RawRequest);
+                var request = new global::Improbable.TestSchema.Blittable.BlittableComponent.Commands.FirstCommand.Request(requestPayload);
+
+                var requestId = connection.SendCommandRequest(new global::Improbable.EntityId(outgoingRequest.TargetEntityId), request, null);
+
+                RequestIdToRequestContext.Add(requestId.Id, new RequestContext(outgoingRequest.SenderEntityId, outgoingRequest));
+            }
+
+            private void SendFirstCommandResponse(Connection connection, FirstCommand.OutgoingResponse outgoingResponse)
+            {
+                var responsePayload = global::Generated.Improbable.TestSchema.Blittable.FirstCommandResponse.ToSpatial(outgoingResponse.RawResponse);
+                var response = new global::Improbable.TestSchema.Blittable.BlittableComponent.Commands.FirstCommand.Response(responsePayload);
+
+                var requestId = new RequestId<IncomingCommandRequest<global::Improbable.TestSchema.Blittable.BlittableComponent.Commands.FirstCommand>>(
+                    outgoingResponse.RequestId);
+
+                connection.SendCommandResponse(requestId, response);
+            }
+
+            public void OnCommandRequestSecondCommand(CommandRequestOp<global::Improbable.TestSchema.Blittable.BlittableComponent.Commands.SecondCommand> op)
+            {
+                Unity.Entities.Entity entity;
+                if (!view.TryGetEntity(op.EntityId.Id, out entity))
+                {
+                    Debug.LogErrorFormat(TranslationErrors.CannotFindEntityForCommandRequest, op.EntityId.Id,
+                        "SecondCommand");
+                    return;
+                }
+
+                var requestPayload = op.Request.Get().Value;
+                var unityRequestPayload = global::Generated.Improbable.TestSchema.Blittable.SecondCommandRequest.ToNative(requestPayload);
+                var request = new SecondCommand.Request(op.RequestId.Id, this, op.CallerWorkerId, op.CallerAttributeSet, unityRequestPayload);
+
+                view.AddCommandRequest(entity, request, SecondCommandRequestPool);
+            }
+
+            public void OnCommandResponseSecondCommand(CommandResponseOp<global::Improbable.TestSchema.Blittable.BlittableComponent.Commands.SecondCommand> op)
+            {
+                var requestId = op.RequestId.Id;
+                RequestContext requestContext;
+                if (!RequestIdToRequestContext.TryGetValue(requestId, out requestContext))
+                {
+                    Debug.LogErrorFormat(TranslationErrors.CannotFindEntityForCommandResponse, op.EntityId.Id,
+                        "SecondCommand");
+                    return;
+                }
+
+                RequestIdToRequestContext.Remove(requestId);
+
+                Unity.Entities.Entity entity;
+                if (requestContext.EntityId == MutableView.WorkerEntityId)
+                {
+                    entity = view.WorkerEntity;
+                }
+                else if (!view.TryGetEntity(requestContext.EntityId, out entity))
+                {
+                    return;
+                }
+
+                var unityResponsePayload = op.Response.HasValue 
+                    ? global::Generated.Improbable.TestSchema.Blittable.SecondCommandResponse.ToNative(op.Response.Value.Get().Value) 
+                    : (global::Generated.Improbable.TestSchema.Blittable.SecondCommandResponse?) null;
+                var outgoingRequest = (SecondCommand.OutgoingRequest) requestContext.Request;
+                var response = new SecondCommand.Response(op.EntityId.Id, op.Message, (CommandStatusCode) op.StatusCode, unityResponsePayload, outgoingRequest.RawRequest);
+
+                view.AddCommandResponse(entity, response, SecondCommandResponsePool);
+            }
+
+            private void SendSecondCommandRequest(Connection connection, SecondCommand.OutgoingRequest outgoingRequest)
+            {
+                var requestPayload = global::Generated.Improbable.TestSchema.Blittable.SecondCommandRequest.ToSpatial(outgoingRequest.RawRequest);
+                var request = new global::Improbable.TestSchema.Blittable.BlittableComponent.Commands.SecondCommand.Request(requestPayload);
+
+                var requestId = connection.SendCommandRequest(new global::Improbable.EntityId(outgoingRequest.TargetEntityId), request, null);
+
+                RequestIdToRequestContext.Add(requestId.Id, new RequestContext(outgoingRequest.SenderEntityId, outgoingRequest));
+            }
+
+            private void SendSecondCommandResponse(Connection connection, SecondCommand.OutgoingResponse outgoingResponse)
+            {
+                var responsePayload = global::Generated.Improbable.TestSchema.Blittable.SecondCommandResponse.ToSpatial(outgoingResponse.RawResponse);
+                var response = new global::Improbable.TestSchema.Blittable.BlittableComponent.Commands.SecondCommand.Response(responsePayload);
+
+                var requestId = new RequestId<IncomingCommandRequest<global::Improbable.TestSchema.Blittable.BlittableComponent.Commands.SecondCommand>>(
+                    outgoingResponse.RequestId);
+
+                connection.SendCommandResponse(requestId, response);
+            }
+
+            public override void SendCommands(Connection connection)
+            {
+                foreach (var request in FirstCommandRequests)
+                {
+                    SendFirstCommandRequest(connection, request);
+                }
+                FirstCommandRequests.Clear();
+
+                foreach (var response in FirstCommandResponses)
+                {
+                    SendFirstCommandResponse(connection, response);
+                }
+                FirstCommandResponses.Clear();
+
+                foreach (var request in SecondCommandRequests)
+                {
+                    SendSecondCommandRequest(connection, request);
+                }
+                SecondCommandRequests.Clear();
+
+                foreach (var response in SecondCommandResponses)
+                {
+                    SendSecondCommandResponse(connection, response);
+                }
+                SecondCommandResponses.Clear();
+
+            }
+
+            public static BlittableComponent.Translation GetTranslation(uint internalHandleToTranslation)
+            {
+                return (BlittableComponent.Translation) ComponentTranslation.HandleToTranslation[internalHandleToTranslation];
+            }
+        }
+    }
+
+    public static class SpatialOSBlittableComponentCommandRequestHandlers
+    {
+        public static void SendFirstCommandRequest(this CommandRequestSender<SpatialOSBlittableComponent> commandRequestSender,
+            long targetEntityId, global::Generated.Improbable.TestSchema.Blittable.FirstCommandRequest request)
+        {
+            var translation = BlittableComponent.Translation.GetTranslation(commandRequestSender.InternalHandleToTranslation);
+
+            translation.FirstCommandRequests.Add(new BlittableComponent.FirstCommand.OutgoingRequest(targetEntityId,
+                commandRequestSender.EntityId, request));
+        }
+
+        public static void SendSecondCommandRequest(this CommandRequestSender<SpatialOSBlittableComponent> commandRequestSender,
+            long targetEntityId, global::Generated.Improbable.TestSchema.Blittable.SecondCommandRequest request)
+        {
+            var translation = BlittableComponent.Translation.GetTranslation(commandRequestSender.InternalHandleToTranslation);
+
+            translation.SecondCommandRequests.Add(new BlittableComponent.SecondCommand.OutgoingRequest(targetEntityId,
+                commandRequestSender.EntityId, request));
+        }
+
+    }
+
+    public static class SpatialOSBlittableComponentEventHandlers
+    {
+        public static void SendFirstEventEvent(this EventSender<SpatialOSBlittableComponent> eventSender,
+            global::Generated.Improbable.TestSchema.Blittable.FirstEventPayload eventData)
+        {
+            var translation = BlittableComponent.Translation.GetTranslation(eventSender.InternalHandleToTranslation);
+            translation.EntityIdToFirstEventEvents[eventSender.EntityId].Add(eventData);
+        }
+
+        public static List<global::Generated.Improbable.TestSchema.Blittable.FirstEventPayload> GetFirstEventEvents(this EventSender<SpatialOSBlittableComponent> eventSender)
+        {
+            var translation = BlittableComponent.Translation.GetTranslation(eventSender.InternalHandleToTranslation);
+            return translation.EntityIdToFirstEventEvents[eventSender.EntityId];
+        }
+
+        public static void ClearFirstEventEvents(this EventSender<SpatialOSBlittableComponent> eventSender)
+        {
+            var translation = BlittableComponent.Translation.GetTranslation(eventSender.InternalHandleToTranslation);
+            translation.EntityIdToFirstEventEvents[eventSender.EntityId].Clear();
+        }
+
+        public static void SendSecondEventEvent(this EventSender<SpatialOSBlittableComponent> eventSender,
+            global::Generated.Improbable.TestSchema.Blittable.SecondEventPayload eventData)
+        {
+            var translation = BlittableComponent.Translation.GetTranslation(eventSender.InternalHandleToTranslation);
+            translation.EntityIdToSecondEventEvents[eventSender.EntityId].Add(eventData);
+        }
+
+        public static List<global::Generated.Improbable.TestSchema.Blittable.SecondEventPayload> GetSecondEventEvents(this EventSender<SpatialOSBlittableComponent> eventSender)
+        {
+            var translation = BlittableComponent.Translation.GetTranslation(eventSender.InternalHandleToTranslation);
+            return translation.EntityIdToSecondEventEvents[eventSender.EntityId];
+        }
+
+        public static void ClearSecondEventEvents(this EventSender<SpatialOSBlittableComponent> eventSender)
+        {
+            var translation = BlittableComponent.Translation.GetTranslation(eventSender.InternalHandleToTranslation);
+            translation.EntityIdToSecondEventEvents[eventSender.EntityId].Clear();
+        }
+
+    }
+}

--- a/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/blittable/FirstCommandRequest.cs
+++ b/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/blittable/FirstCommandRequest.cs
@@ -1,0 +1,29 @@
+// ===========
+// DO NOT EDIT - this file is automatically regenerated.
+// ===========
+
+using System.Linq;
+using Unity.Mathematics;
+
+namespace Generated.Improbable.TestSchema.Blittable
+{ 
+    
+    public struct FirstCommandRequest
+    {
+        public int Field;
+    
+        public static FirstCommandRequest ToNative(global::Improbable.TestSchema.Blittable.FirstCommandRequest spatialType)
+        {
+            var nativeType = new FirstCommandRequest();
+            nativeType.Field = spatialType.field;
+            return nativeType;
+        }
+    
+        public static global::Improbable.TestSchema.Blittable.FirstCommandRequest ToSpatial(global::Generated.Improbable.TestSchema.Blittable.FirstCommandRequest nativeType)
+        {
+            var spatialType = new global::Improbable.TestSchema.Blittable.FirstCommandRequest();
+            spatialType.field = nativeType.Field;
+            return spatialType;
+        }
+    }
+}

--- a/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/blittable/FirstCommandResponse.cs
+++ b/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/blittable/FirstCommandResponse.cs
@@ -1,0 +1,29 @@
+// ===========
+// DO NOT EDIT - this file is automatically regenerated.
+// ===========
+
+using System.Linq;
+using Unity.Mathematics;
+
+namespace Generated.Improbable.TestSchema.Blittable
+{ 
+    
+    public struct FirstCommandResponse
+    {
+        public bool1 Response;
+    
+        public static FirstCommandResponse ToNative(global::Improbable.TestSchema.Blittable.FirstCommandResponse spatialType)
+        {
+            var nativeType = new FirstCommandResponse();
+            nativeType.Response = spatialType.response;
+            return nativeType;
+        }
+    
+        public static global::Improbable.TestSchema.Blittable.FirstCommandResponse ToSpatial(global::Generated.Improbable.TestSchema.Blittable.FirstCommandResponse nativeType)
+        {
+            var spatialType = new global::Improbable.TestSchema.Blittable.FirstCommandResponse();
+            spatialType.response = nativeType.Response;
+            return spatialType;
+        }
+    }
+}

--- a/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/blittable/FirstEventPayload.cs
+++ b/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/blittable/FirstEventPayload.cs
@@ -1,0 +1,32 @@
+// ===========
+// DO NOT EDIT - this file is automatically regenerated.
+// ===========
+
+using System.Linq;
+using Unity.Mathematics;
+
+namespace Generated.Improbable.TestSchema.Blittable
+{ 
+    
+    public struct FirstEventPayload
+    {
+        public bool1 Field1;
+        public int Field2;
+    
+        public static FirstEventPayload ToNative(global::Improbable.TestSchema.Blittable.FirstEventPayload spatialType)
+        {
+            var nativeType = new FirstEventPayload();
+            nativeType.Field1 = spatialType.field1;
+            nativeType.Field2 = spatialType.field2;
+            return nativeType;
+        }
+    
+        public static global::Improbable.TestSchema.Blittable.FirstEventPayload ToSpatial(global::Generated.Improbable.TestSchema.Blittable.FirstEventPayload nativeType)
+        {
+            var spatialType = new global::Improbable.TestSchema.Blittable.FirstEventPayload();
+            spatialType.field1 = nativeType.Field1;
+            spatialType.field2 = nativeType.Field2;
+            return spatialType;
+        }
+    }
+}

--- a/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/blittable/SecondCommandRequest.cs
+++ b/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/blittable/SecondCommandRequest.cs
@@ -1,0 +1,29 @@
+// ===========
+// DO NOT EDIT - this file is automatically regenerated.
+// ===========
+
+using System.Linq;
+using Unity.Mathematics;
+
+namespace Generated.Improbable.TestSchema.Blittable
+{ 
+    
+    public struct SecondCommandRequest
+    {
+        public long Field;
+    
+        public static SecondCommandRequest ToNative(global::Improbable.TestSchema.Blittable.SecondCommandRequest spatialType)
+        {
+            var nativeType = new SecondCommandRequest();
+            nativeType.Field = spatialType.field;
+            return nativeType;
+        }
+    
+        public static global::Improbable.TestSchema.Blittable.SecondCommandRequest ToSpatial(global::Generated.Improbable.TestSchema.Blittable.SecondCommandRequest nativeType)
+        {
+            var spatialType = new global::Improbable.TestSchema.Blittable.SecondCommandRequest();
+            spatialType.field = nativeType.Field;
+            return spatialType;
+        }
+    }
+}

--- a/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/blittable/SecondCommandResponse.cs
+++ b/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/blittable/SecondCommandResponse.cs
@@ -1,0 +1,29 @@
+// ===========
+// DO NOT EDIT - this file is automatically regenerated.
+// ===========
+
+using System.Linq;
+using Unity.Mathematics;
+
+namespace Generated.Improbable.TestSchema.Blittable
+{ 
+    
+    public struct SecondCommandResponse
+    {
+        public double Response;
+    
+        public static SecondCommandResponse ToNative(global::Improbable.TestSchema.Blittable.SecondCommandResponse spatialType)
+        {
+            var nativeType = new SecondCommandResponse();
+            nativeType.Response = spatialType.response;
+            return nativeType;
+        }
+    
+        public static global::Improbable.TestSchema.Blittable.SecondCommandResponse ToSpatial(global::Generated.Improbable.TestSchema.Blittable.SecondCommandResponse nativeType)
+        {
+            var spatialType = new global::Improbable.TestSchema.Blittable.SecondCommandResponse();
+            spatialType.response = nativeType.Response;
+            return spatialType;
+        }
+    }
+}

--- a/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/blittable/SecondEventPayload.cs
+++ b/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/blittable/SecondEventPayload.cs
@@ -1,0 +1,32 @@
+// ===========
+// DO NOT EDIT - this file is automatically regenerated.
+// ===========
+
+using System.Linq;
+using Unity.Mathematics;
+
+namespace Generated.Improbable.TestSchema.Blittable
+{ 
+    
+    public struct SecondEventPayload
+    {
+        public float Field1;
+        public double Field2;
+    
+        public static SecondEventPayload ToNative(global::Improbable.TestSchema.Blittable.SecondEventPayload spatialType)
+        {
+            var nativeType = new SecondEventPayload();
+            nativeType.Field1 = spatialType.field1;
+            nativeType.Field2 = spatialType.field2;
+            return nativeType;
+        }
+    
+        public static global::Improbable.TestSchema.Blittable.SecondEventPayload ToSpatial(global::Generated.Improbable.TestSchema.Blittable.SecondEventPayload nativeType)
+        {
+            var spatialType = new global::Improbable.TestSchema.Blittable.SecondEventPayload();
+            spatialType.field1 = nativeType.Field1;
+            spatialType.field2 = nativeType.Field2;
+            return spatialType;
+        }
+    }
+}

--- a/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/nonblittable/FirstCommandRequest.cs
+++ b/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/nonblittable/FirstCommandRequest.cs
@@ -1,0 +1,29 @@
+// ===========
+// DO NOT EDIT - this file is automatically regenerated.
+// ===========
+
+using System.Linq;
+using Unity.Mathematics;
+
+namespace Generated.Improbable.TestSchema.Nonblittable
+{ 
+    
+    public struct FirstCommandRequest
+    {
+        public int Field;
+    
+        public static FirstCommandRequest ToNative(global::Improbable.TestSchema.Nonblittable.FirstCommandRequest spatialType)
+        {
+            var nativeType = new FirstCommandRequest();
+            nativeType.Field = spatialType.field;
+            return nativeType;
+        }
+    
+        public static global::Improbable.TestSchema.Nonblittable.FirstCommandRequest ToSpatial(global::Generated.Improbable.TestSchema.Nonblittable.FirstCommandRequest nativeType)
+        {
+            var spatialType = new global::Improbable.TestSchema.Nonblittable.FirstCommandRequest();
+            spatialType.field = nativeType.Field;
+            return spatialType;
+        }
+    }
+}

--- a/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/nonblittable/FirstCommandResponse.cs
+++ b/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/nonblittable/FirstCommandResponse.cs
@@ -1,0 +1,29 @@
+// ===========
+// DO NOT EDIT - this file is automatically regenerated.
+// ===========
+
+using System.Linq;
+using Unity.Mathematics;
+
+namespace Generated.Improbable.TestSchema.Nonblittable
+{ 
+    
+    public struct FirstCommandResponse
+    {
+        public string Response;
+    
+        public static FirstCommandResponse ToNative(global::Improbable.TestSchema.Nonblittable.FirstCommandResponse spatialType)
+        {
+            var nativeType = new FirstCommandResponse();
+            nativeType.Response = spatialType.response;
+            return nativeType;
+        }
+    
+        public static global::Improbable.TestSchema.Nonblittable.FirstCommandResponse ToSpatial(global::Generated.Improbable.TestSchema.Nonblittable.FirstCommandResponse nativeType)
+        {
+            var spatialType = new global::Improbable.TestSchema.Nonblittable.FirstCommandResponse();
+            spatialType.response = nativeType.Response;
+            return spatialType;
+        }
+    }
+}

--- a/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/nonblittable/FirstEventPayload.cs
+++ b/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/nonblittable/FirstEventPayload.cs
@@ -1,0 +1,32 @@
+// ===========
+// DO NOT EDIT - this file is automatically regenerated.
+// ===========
+
+using System.Linq;
+using Unity.Mathematics;
+
+namespace Generated.Improbable.TestSchema.Nonblittable
+{ 
+    
+    public struct FirstEventPayload
+    {
+        public bool1 Field1;
+        public string Field2;
+    
+        public static FirstEventPayload ToNative(global::Improbable.TestSchema.Nonblittable.FirstEventPayload spatialType)
+        {
+            var nativeType = new FirstEventPayload();
+            nativeType.Field1 = spatialType.field1;
+            nativeType.Field2 = spatialType.field2;
+            return nativeType;
+        }
+    
+        public static global::Improbable.TestSchema.Nonblittable.FirstEventPayload ToSpatial(global::Generated.Improbable.TestSchema.Nonblittable.FirstEventPayload nativeType)
+        {
+            var spatialType = new global::Improbable.TestSchema.Nonblittable.FirstEventPayload();
+            spatialType.field1 = nativeType.Field1;
+            spatialType.field2 = nativeType.Field2;
+            return spatialType;
+        }
+    }
+}

--- a/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/nonblittable/NonBlittableComponent.cs
+++ b/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/nonblittable/NonBlittableComponent.cs
@@ -1,0 +1,123 @@
+// ===========
+// DO NOT EDIT - this file is automatically regenerated.
+// ===========
+
+using UnityEngine;
+using Unity.Mathematics;
+using Improbable.Gdk.Core;
+
+namespace Generated.Improbable.TestSchema.Nonblittable
+{ 
+    public class SpatialOSNonBlittableComponent : Component, ISpatialComponentData
+    {
+        public bool1 DirtyBit { get; set; }
+
+        private bool1 boolField;
+
+        public bool1 BoolField
+        {
+            get { return boolField; }
+            set
+            {
+                DirtyBit = true;
+                boolField = value;
+            }
+        }
+
+        private int intField;
+
+        public int IntField
+        {
+            get { return intField; }
+            set
+            {
+                DirtyBit = true;
+                intField = value;
+            }
+        }
+
+        private long longField;
+
+        public long LongField
+        {
+            get { return longField; }
+            set
+            {
+                DirtyBit = true;
+                longField = value;
+            }
+        }
+
+        private float floatField;
+
+        public float FloatField
+        {
+            get { return floatField; }
+            set
+            {
+                DirtyBit = true;
+                floatField = value;
+            }
+        }
+
+        private double doubleField;
+
+        public double DoubleField
+        {
+            get { return doubleField; }
+            set
+            {
+                DirtyBit = true;
+                doubleField = value;
+            }
+        }
+
+        private string stringField;
+
+        public string StringField
+        {
+            get { return stringField; }
+            set
+            {
+                DirtyBit = true;
+                stringField = value;
+            }
+        }
+
+        private global::System.Nullable<int> optionalField;
+
+        public global::System.Nullable<int> OptionalField
+        {
+            get { return optionalField; }
+            set
+            {
+                DirtyBit = true;
+                optionalField = value;
+            }
+        }
+
+        private global::System.Collections.Generic.List<int> listField;
+
+        public global::System.Collections.Generic.List<int> ListField
+        {
+            get { return listField; }
+            set
+            {
+                DirtyBit = true;
+                listField = value;
+            }
+        }
+
+        private global::System.Collections.Generic.Dictionary<int, string> mapField;
+
+        public global::System.Collections.Generic.Dictionary<int, string> MapField
+        {
+            get { return mapField; }
+            set
+            {
+                DirtyBit = true;
+                mapField = value;
+            }
+        }
+    }
+}

--- a/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/nonblittable/NonBlittableComponentCommandPayloads.cs
+++ b/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/nonblittable/NonBlittableComponentCommandPayloads.cs
@@ -1,0 +1,195 @@
+// ===========
+// DO NOT EDIT - this file is automatically regenerated.
+// ===========
+
+using Improbable.Gdk.Core;
+using System.Collections.Generic;
+
+namespace Generated.Improbable.TestSchema.Nonblittable
+{
+    public partial class NonBlittableComponent
+    {
+        public class FirstCommand
+        {
+            public struct Request : IIncomingCommandRequest
+            {
+                public uint RequestId { get; }
+
+                internal Translation Translation { get; }
+
+                public string CallerWorkerId {get; }
+
+                public List<string> CallerAttributeSet { get; }
+
+                public global::Generated.Improbable.TestSchema.Nonblittable.FirstCommandRequest RawRequest { get; }
+
+                internal Request(uint requestId, 
+                    Translation translation,
+                    string callerWorkerId,
+                    List<string> callerAttributeSet,
+                    global::Generated.Improbable.TestSchema.Nonblittable.FirstCommandRequest request)
+                {
+                    this.RequestId = requestId;
+                    this.Translation = translation;
+                    this.CallerWorkerId = callerWorkerId;
+                    this.CallerAttributeSet = callerAttributeSet;
+                    this.RawRequest = request;
+                }
+
+                public void SendFirstCommandResponse(global::Generated.Improbable.TestSchema.Nonblittable.FirstCommandResponse response)
+                {
+                    Translation.FirstCommandResponses.Add(
+                        new OutgoingResponse(RequestId, response));
+                }
+            }
+
+            internal struct OutgoingRequest : IOutgoingCommandRequest
+            {
+                public long TargetEntityId { get; }
+
+                public long SenderEntityId { get; }
+
+                public global::Generated.Improbable.TestSchema.Nonblittable.FirstCommandRequest RawRequest { get; }
+
+                internal OutgoingRequest(long targetEntityId, long senderEntityId,
+                    global::Generated.Improbable.TestSchema.Nonblittable.FirstCommandRequest request)
+                {
+                    this.TargetEntityId = targetEntityId;
+                    this.SenderEntityId = senderEntityId;
+                    this.RawRequest = request;
+                }
+            }
+
+            public struct Response : IIncomingCommandResponse
+            {
+                public long EntityId { get; }
+
+                public string Message { get; }
+
+                public CommandStatusCode StatusCode { get; }
+
+                public global::Generated.Improbable.TestSchema.Nonblittable.FirstCommandResponse? RawResponse { get; }
+
+                public global::Generated.Improbable.TestSchema.Nonblittable.FirstCommandRequest RawRequest { get; }
+
+                internal Response(long entityId, 
+                    string message,
+                    CommandStatusCode statusCode, 
+                    global::Generated.Improbable.TestSchema.Nonblittable.FirstCommandResponse? response,
+                    global::Generated.Improbable.TestSchema.Nonblittable.FirstCommandRequest request)
+                {
+                    this.EntityId = entityId;
+                    this.Message = message;
+                    this.StatusCode = statusCode;
+                    this.RawResponse = response;
+                    this.RawRequest = request;
+                }
+            }
+
+            internal struct OutgoingResponse : IOutgoingCommandResponse
+            {
+                public uint RequestId { get; }
+
+                public global::Generated.Improbable.TestSchema.Nonblittable.FirstCommandResponse RawResponse { get; }
+
+                internal OutgoingResponse(uint requestId, 
+                    global::Generated.Improbable.TestSchema.Nonblittable.FirstCommandResponse response)
+                {
+                    this.RequestId = requestId;
+                    this.RawResponse = response;
+                }
+            }
+        }
+        public class SecondCommand
+        {
+            public struct Request : IIncomingCommandRequest
+            {
+                public uint RequestId { get; }
+
+                internal Translation Translation { get; }
+
+                public string CallerWorkerId {get; }
+
+                public List<string> CallerAttributeSet { get; }
+
+                public global::Generated.Improbable.TestSchema.Nonblittable.SecondCommandRequest RawRequest { get; }
+
+                internal Request(uint requestId, 
+                    Translation translation,
+                    string callerWorkerId,
+                    List<string> callerAttributeSet,
+                    global::Generated.Improbable.TestSchema.Nonblittable.SecondCommandRequest request)
+                {
+                    this.RequestId = requestId;
+                    this.Translation = translation;
+                    this.CallerWorkerId = callerWorkerId;
+                    this.CallerAttributeSet = callerAttributeSet;
+                    this.RawRequest = request;
+                }
+
+                public void SendSecondCommandResponse(global::Generated.Improbable.TestSchema.Nonblittable.SecondCommandResponse response)
+                {
+                    Translation.SecondCommandResponses.Add(
+                        new OutgoingResponse(RequestId, response));
+                }
+            }
+
+            internal struct OutgoingRequest : IOutgoingCommandRequest
+            {
+                public long TargetEntityId { get; }
+
+                public long SenderEntityId { get; }
+
+                public global::Generated.Improbable.TestSchema.Nonblittable.SecondCommandRequest RawRequest { get; }
+
+                internal OutgoingRequest(long targetEntityId, long senderEntityId,
+                    global::Generated.Improbable.TestSchema.Nonblittable.SecondCommandRequest request)
+                {
+                    this.TargetEntityId = targetEntityId;
+                    this.SenderEntityId = senderEntityId;
+                    this.RawRequest = request;
+                }
+            }
+
+            public struct Response : IIncomingCommandResponse
+            {
+                public long EntityId { get; }
+
+                public string Message { get; }
+
+                public CommandStatusCode StatusCode { get; }
+
+                public global::Generated.Improbable.TestSchema.Nonblittable.SecondCommandResponse? RawResponse { get; }
+
+                public global::Generated.Improbable.TestSchema.Nonblittable.SecondCommandRequest RawRequest { get; }
+
+                internal Response(long entityId, 
+                    string message,
+                    CommandStatusCode statusCode, 
+                    global::Generated.Improbable.TestSchema.Nonblittable.SecondCommandResponse? response,
+                    global::Generated.Improbable.TestSchema.Nonblittable.SecondCommandRequest request)
+                {
+                    this.EntityId = entityId;
+                    this.Message = message;
+                    this.StatusCode = statusCode;
+                    this.RawResponse = response;
+                    this.RawRequest = request;
+                }
+            }
+
+            internal struct OutgoingResponse : IOutgoingCommandResponse
+            {
+                public uint RequestId { get; }
+
+                public global::Generated.Improbable.TestSchema.Nonblittable.SecondCommandResponse RawResponse { get; }
+
+                internal OutgoingResponse(uint requestId, 
+                    global::Generated.Improbable.TestSchema.Nonblittable.SecondCommandResponse response)
+                {
+                    this.RequestId = requestId;
+                    this.RawResponse = response;
+                }
+            }
+        }
+    }
+}

--- a/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/nonblittable/NonBlittableComponentEvents.cs
+++ b/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/nonblittable/NonBlittableComponentEvents.cs
@@ -1,0 +1,20 @@
+// ===========
+// DO NOT EDIT - this file is automatically regenerated.
+// ===========
+
+using Improbable.Gdk.Core;
+using System.Collections.Generic;
+
+namespace Generated.Improbable.TestSchema.Nonblittable
+{
+    public struct FirstEventEvent : ISpatialEvent
+    {
+        public global::Generated.Improbable.TestSchema.Nonblittable.FirstEventPayload Payload;
+    }
+
+    public struct SecondEventEvent : ISpatialEvent
+    {
+        public global::Generated.Improbable.TestSchema.Nonblittable.SecondEventPayload Payload;
+    }
+
+}

--- a/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/nonblittable/NonBlittableComponentTranslation.cs
+++ b/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/nonblittable/NonBlittableComponentTranslation.cs
@@ -1,0 +1,541 @@
+// ===========
+// DO NOT EDIT - this file is automatically regenerated.
+// ===========
+
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using Unity.Mathematics;
+using Unity.Entities;
+using Improbable.Worker;
+using Improbable.Gdk.Core;
+using Improbable.Gdk.Core.Components;
+using Improbable.TestSchema.Nonblittable;
+
+namespace Generated.Improbable.TestSchema.Nonblittable
+{
+    public partial class NonBlittableComponent
+    {
+        public class Translation : ComponentTranslation, IDispatcherCallbacks<global::Improbable.TestSchema.Nonblittable.NonBlittableComponent>
+        {
+            public override ComponentType TargetComponentType => targetComponentType;
+            private static readonly ComponentType targetComponentType = typeof(SpatialOSNonBlittableComponent);
+
+            public override ComponentType[] ReplicationComponentTypes => replicationComponentTypes;
+            private static readonly ComponentType[] replicationComponentTypes = { typeof(SpatialOSNonBlittableComponent), typeof(Authoritative<SpatialOSNonBlittableComponent>), typeof(SpatialEntityId)};
+
+            public override ComponentType[] CleanUpComponentTypes => cleanUpComponentTypes;
+            private static readonly ComponentType[] cleanUpComponentTypes = 
+            { 
+                typeof(ComponentsUpdated<SpatialOSNonBlittableComponent>), typeof(AuthoritiesChanged<SpatialOSNonBlittableComponent>),
+                typeof(CommandRequests<FirstCommand.Request>), typeof(CommandResponses<FirstCommand.Response>),
+                typeof(CommandRequests<SecondCommand.Request>), typeof(CommandResponses<SecondCommand.Response>),
+                typeof(EventsReceived<FirstEventEvent>),
+                typeof(EventsReceived<SecondEventEvent>),
+            };
+
+            private readonly Dictionary<uint, RequestContext> RequestIdToRequestContext = new Dictionary<uint, RequestContext>();
+
+            internal List<FirstCommand.OutgoingRequest> FirstCommandRequests = new List<FirstCommand.OutgoingRequest>();
+            internal List<FirstCommand.OutgoingResponse> FirstCommandResponses = new List<FirstCommand.OutgoingResponse>();
+            private static readonly ComponentPool<CommandRequests<FirstCommand.Request>> FirstCommandRequestPool =
+                new ComponentPool<CommandRequests<FirstCommand.Request>>(
+                    () => new CommandRequests<FirstCommand.Request>(),
+                    (component) => component.Buffer.Clear());
+            private static readonly ComponentPool<CommandResponses<FirstCommand.Response>> FirstCommandResponsePool =
+                new ComponentPool<CommandResponses<FirstCommand.Response>>(
+                    () => new CommandResponses<FirstCommand.Response>(),
+                    (component) => component.Buffer.Clear());
+            internal List<SecondCommand.OutgoingRequest> SecondCommandRequests = new List<SecondCommand.OutgoingRequest>();
+            internal List<SecondCommand.OutgoingResponse> SecondCommandResponses = new List<SecondCommand.OutgoingResponse>();
+            private static readonly ComponentPool<CommandRequests<SecondCommand.Request>> SecondCommandRequestPool =
+                new ComponentPool<CommandRequests<SecondCommand.Request>>(
+                    () => new CommandRequests<SecondCommand.Request>(),
+                    (component) => component.Buffer.Clear());
+            private static readonly ComponentPool<CommandResponses<SecondCommand.Response>> SecondCommandResponsePool =
+                new ComponentPool<CommandResponses<SecondCommand.Response>>(
+                    () => new CommandResponses<SecondCommand.Response>(),
+                    (component) => component.Buffer.Clear());
+
+            internal readonly Dictionary<long, List<global::Generated.Improbable.TestSchema.Nonblittable.FirstEventPayload>> EntityIdToFirstEventEvents = new Dictionary<long, List<global::Generated.Improbable.TestSchema.Nonblittable.FirstEventPayload>>();
+
+            private static readonly ComponentPool<EventsReceived<FirstEventEvent>> FirstEventEventPool =
+                new ComponentPool<EventsReceived<FirstEventEvent>>(
+                    () => new EventsReceived<FirstEventEvent>(),
+                    (component) => component.Buffer.Clear());
+            internal readonly Dictionary<long, List<global::Generated.Improbable.TestSchema.Nonblittable.SecondEventPayload>> EntityIdToSecondEventEvents = new Dictionary<long, List<global::Generated.Improbable.TestSchema.Nonblittable.SecondEventPayload>>();
+
+            private static readonly ComponentPool<EventsReceived<SecondEventEvent>> SecondEventEventPool =
+                new ComponentPool<EventsReceived<SecondEventEvent>>(
+                    () => new EventsReceived<SecondEventEvent>(),
+                    (component) => component.Buffer.Clear());
+
+            private static readonly ComponentPool<ComponentsUpdated<SpatialOSNonBlittableComponent>> UpdatesPool =
+                new ComponentPool<ComponentsUpdated<SpatialOSNonBlittableComponent>>(
+                    () => new ComponentsUpdated<SpatialOSNonBlittableComponent>(),
+                    (component) => component.Buffer.Clear());
+
+            private static readonly ComponentPool<AuthoritiesChanged<SpatialOSNonBlittableComponent>> AuthsPool =
+                new ComponentPool<AuthoritiesChanged<SpatialOSNonBlittableComponent>>(
+                    () => new AuthoritiesChanged<SpatialOSNonBlittableComponent>(),
+                    (component) => component.Buffer.Clear());
+
+            public Translation(MutableView view) : base(view)
+            {
+            }
+
+            public override void RegisterWithDispatcher(Dispatcher dispatcher)
+            {
+                dispatcher.OnAddComponent<global::Improbable.TestSchema.Nonblittable.NonBlittableComponent>(OnAddComponent);
+                dispatcher.OnComponentUpdate<global::Improbable.TestSchema.Nonblittable.NonBlittableComponent>(OnComponentUpdate);
+                dispatcher.OnRemoveComponent<global::Improbable.TestSchema.Nonblittable.NonBlittableComponent>(OnRemoveComponent);
+                dispatcher.OnAuthorityChange<global::Improbable.TestSchema.Nonblittable.NonBlittableComponent>(OnAuthorityChange);
+
+                dispatcher.OnCommandRequest<global::Improbable.TestSchema.Nonblittable.NonBlittableComponent.Commands.FirstCommand>(OnCommandRequestFirstCommand);
+                dispatcher.OnCommandResponse<global::Improbable.TestSchema.Nonblittable.NonBlittableComponent.Commands.FirstCommand>(OnCommandResponseFirstCommand);
+                dispatcher.OnCommandRequest<global::Improbable.TestSchema.Nonblittable.NonBlittableComponent.Commands.SecondCommand>(OnCommandRequestSecondCommand);
+                dispatcher.OnCommandResponse<global::Improbable.TestSchema.Nonblittable.NonBlittableComponent.Commands.SecondCommand>(OnCommandResponseSecondCommand);
+            }
+
+            public override void AddCommandRequestSender(Unity.Entities.Entity entity, long entityId)
+            {
+                view.AddComponent(entity, new CommandRequestSender<SpatialOSNonBlittableComponent>(entityId, translationHandle));
+            }
+
+            public void OnAddComponent(AddComponentOp<global::Improbable.TestSchema.Nonblittable.NonBlittableComponent> op)
+            {
+                Unity.Entities.Entity entity;
+                if (!view.TryGetEntity(op.EntityId.Id, out entity))
+                {
+                    Debug.LogErrorFormat(TranslationErrors.OpReceivedButNoEntity, op.GetType().Name, op.EntityId.Id);
+                    return;
+                }
+
+                var data = op.Data.Get().Value;
+
+                var spatialOSNonBlittableComponent = new SpatialOSNonBlittableComponent();
+                spatialOSNonBlittableComponent.BoolField = data.boolField;
+                spatialOSNonBlittableComponent.IntField = data.intField;
+                spatialOSNonBlittableComponent.LongField = data.longField;
+                spatialOSNonBlittableComponent.FloatField = data.floatField;
+                spatialOSNonBlittableComponent.DoubleField = data.doubleField;
+                spatialOSNonBlittableComponent.StringField = data.stringField;
+                spatialOSNonBlittableComponent.OptionalField = data.optionalField.HasValue ? new global::System.Nullable<int>(data.optionalField.Value) : new global::System.Nullable<int>();
+                spatialOSNonBlittableComponent.ListField = data.listField;
+                spatialOSNonBlittableComponent.MapField = data.mapField.ToDictionary(entry => entry.Key, entry => entry.Value);
+                spatialOSNonBlittableComponent.DirtyBit = false;
+
+                view.SetComponentObject(entity, spatialOSNonBlittableComponent);
+                view.AddComponent(entity, new NotAuthoritative<SpatialOSNonBlittableComponent>());
+            }
+
+            public void OnComponentUpdate(ComponentUpdateOp<global::Improbable.TestSchema.Nonblittable.NonBlittableComponent> op)
+            {
+                Unity.Entities.Entity entity;
+                if (!view.TryGetEntity(op.EntityId.Id, out entity))
+                {
+                    Debug.LogErrorFormat(TranslationErrors.OpReceivedButNoEntity, op.GetType().Name, op.EntityId.Id);
+                    return;
+                }
+
+                var componentData = view.GetComponentObject<SpatialOSNonBlittableComponent>(entity);
+                var update = op.Update.Get();
+
+                if (view.HasComponent<NotAuthoritative<SpatialOSNonBlittableComponent>>(entity))
+                {
+                    if (update.boolField.HasValue)
+                    {
+                        componentData.BoolField = update.boolField.Value;
+                    }
+                    if (update.intField.HasValue)
+                    {
+                        componentData.IntField = update.intField.Value;
+                    }
+                    if (update.longField.HasValue)
+                    {
+                        componentData.LongField = update.longField.Value;
+                    }
+                    if (update.floatField.HasValue)
+                    {
+                        componentData.FloatField = update.floatField.Value;
+                    }
+                    if (update.doubleField.HasValue)
+                    {
+                        componentData.DoubleField = update.doubleField.Value;
+                    }
+                    if (update.stringField.HasValue)
+                    {
+                        componentData.StringField = update.stringField.Value;
+                    }
+                    if (update.optionalField.HasValue)
+                    {
+                        componentData.OptionalField = update.optionalField.Value.HasValue ? new global::System.Nullable<int>(update.optionalField.Value.Value) : new global::System.Nullable<int>();
+                    }
+                    if (update.listField.HasValue)
+                    {
+                        componentData.ListField = update.listField.Value;
+                    }
+                    if (update.mapField.HasValue)
+                    {
+                        componentData.MapField = update.mapField.Value.ToDictionary(entry => entry.Key, entry => entry.Value);
+                    }
+                }
+
+                var firstEventEvents = update.firstEvent;
+                foreach (var spatialEvent in firstEventEvents)
+                {
+                    var nativeEvent = new FirstEventEvent
+                    {
+                        Payload = global::Generated.Improbable.TestSchema.Nonblittable.FirstEventPayload.ToNative(spatialEvent)
+                    };
+
+                    view.AddEventReceived(entity, nativeEvent, FirstEventEventPool);
+                }
+                var secondEventEvents = update.secondEvent;
+                foreach (var spatialEvent in secondEventEvents)
+                {
+                    var nativeEvent = new SecondEventEvent
+                    {
+                        Payload = global::Generated.Improbable.TestSchema.Nonblittable.SecondEventPayload.ToNative(spatialEvent)
+                    };
+
+                    view.AddEventReceived(entity, nativeEvent, SecondEventEventPool);
+                }
+                componentData.DirtyBit = false;
+                view.UpdateComponentObject(entity, componentData, UpdatesPool);
+            }
+
+            public void OnRemoveComponent(RemoveComponentOp op)
+            {
+                Unity.Entities.Entity entity;
+                if (!view.TryGetEntity(op.EntityId.Id, out entity))
+                {
+                    Debug.LogErrorFormat(TranslationErrors.OpReceivedButNoEntity, op.GetType().Name, op.EntityId.Id);
+                    return;
+                }
+
+                view.RemoveComponent<SpatialOSNonBlittableComponent>(entity);
+            }
+
+            public void OnAuthorityChange(AuthorityChangeOp op)
+            {
+                var entityId = op.EntityId.Id;
+                if (op.Authority == Authority.Authoritative)
+                {
+                    EntityIdToFirstEventEvents[entityId] = new List<global::Generated.Improbable.TestSchema.Nonblittable.FirstEventPayload>();
+                    EntityIdToSecondEventEvents[entityId] = new List<global::Generated.Improbable.TestSchema.Nonblittable.SecondEventPayload>();
+                    view.AddComponent(entityId, new EventSender<SpatialOSNonBlittableComponent>(entityId, translationHandle));
+                }
+                else if (op.Authority == Authority.NotAuthoritative)
+                {
+                    EntityIdToFirstEventEvents.Remove(entityId);
+                    EntityIdToSecondEventEvents.Remove(entityId);
+                    view.RemoveComponent<EventSender<SpatialOSNonBlittableComponent>>(entityId);
+                }
+                view.HandleAuthorityChange(entityId, op.Authority, AuthsPool);
+            }
+
+            public override void ExecuteReplication(Connection connection)
+            {
+                var componentDataArray = ReplicationComponentGroup.GetComponentArray<SpatialOSNonBlittableComponent>();
+                var spatialEntityIdData = ReplicationComponentGroup.GetComponentDataArray<SpatialEntityId>();
+
+                for (var i = 0; i < componentDataArray.Length; i++)
+                {
+                    var componentData = componentDataArray[i];
+                    var entityId = spatialEntityIdData[i].EntityId;
+                    var hasPendingEvents = false;
+                    var firstEventEvents = EntityIdToFirstEventEvents[entityId];
+                    hasPendingEvents |= firstEventEvents.Count() > 0;
+                    var secondEventEvents = EntityIdToSecondEventEvents[entityId];
+                    hasPendingEvents |= secondEventEvents.Count() > 0;
+
+                    if (componentData.DirtyBit || hasPendingEvents)
+                    {
+                        var update = new global::Improbable.TestSchema.Nonblittable.NonBlittableComponent.Update();
+                        update.SetBoolField(componentData.BoolField);
+                        update.SetIntField(componentData.IntField);
+                        update.SetLongField(componentData.LongField);
+                        update.SetFloatField(componentData.FloatField);
+                        update.SetDoubleField(componentData.DoubleField);
+                        update.SetStringField(componentData.StringField);
+                        update.SetOptionalField(componentData.OptionalField.HasValue ? new global::Improbable.Collections.Option<int>(componentData.OptionalField.Value) : new global::Improbable.Collections.Option<int>());
+                        update.SetListField(new global::Improbable.Collections.List<int>(componentData.ListField));
+                        update.SetMapField(new global::Improbable.Collections.Map<int,string>(componentData.MapField.ToDictionary(entry => entry.Key, entry => entry.Value)));
+                        foreach (var nativeEvent in firstEventEvents)
+                        {
+                            var spatialEvent = global::Generated.Improbable.TestSchema.Nonblittable.FirstEventPayload.ToSpatial(nativeEvent);
+                            update.firstEvent.Add(spatialEvent);
+                        }
+                        foreach (var nativeEvent in secondEventEvents)
+                        {
+                            var spatialEvent = global::Generated.Improbable.TestSchema.Nonblittable.SecondEventPayload.ToSpatial(nativeEvent);
+                            update.secondEvent.Add(spatialEvent);
+                        }
+                        SendComponentUpdate(connection, entityId, update);
+
+                        componentData.DirtyBit = false;
+                        view.SetComponentObject(entityId, componentData);
+
+                        firstEventEvents.Clear();
+                        secondEventEvents.Clear();
+                    }
+                }
+            }
+
+            public static void SendComponentUpdate(Connection connection, long entityId, global::Improbable.TestSchema.Nonblittable.NonBlittableComponent.Update update)
+            {
+                connection.SendComponentUpdate(new global::Improbable.EntityId(entityId), update);
+            }
+
+            public override void CleanUpComponents(ref EntityCommandBuffer entityCommandBuffer)
+            {
+                RemoveComponents(ref entityCommandBuffer, UpdatesPool, groupIndex: 0);
+                RemoveComponents(ref entityCommandBuffer, AuthsPool, groupIndex: 1);
+                RemoveComponents(ref entityCommandBuffer, FirstCommandRequestPool, groupIndex: 2);
+                RemoveComponents(ref entityCommandBuffer, FirstCommandResponsePool, groupIndex: 3);
+                RemoveComponents(ref entityCommandBuffer, SecondCommandRequestPool, groupIndex: 4);
+                RemoveComponents(ref entityCommandBuffer, SecondCommandResponsePool, groupIndex: 5);
+                RemoveComponents(ref entityCommandBuffer, FirstEventEventPool, groupIndex: 6);
+                RemoveComponents(ref entityCommandBuffer, SecondEventEventPool, groupIndex: 7);
+            }
+
+            public void OnCommandRequestFirstCommand(CommandRequestOp<global::Improbable.TestSchema.Nonblittable.NonBlittableComponent.Commands.FirstCommand> op)
+            {
+                Unity.Entities.Entity entity;
+                if (!view.TryGetEntity(op.EntityId.Id, out entity))
+                {
+                    Debug.LogErrorFormat(TranslationErrors.CannotFindEntityForCommandRequest, op.EntityId.Id,
+                        "FirstCommand");
+                    return;
+                }
+
+                var requestPayload = op.Request.Get().Value;
+                var unityRequestPayload = global::Generated.Improbable.TestSchema.Nonblittable.FirstCommandRequest.ToNative(requestPayload);
+                var request = new FirstCommand.Request(op.RequestId.Id, this, op.CallerWorkerId, op.CallerAttributeSet, unityRequestPayload);
+
+                view.AddCommandRequest(entity, request, FirstCommandRequestPool);
+            }
+
+            public void OnCommandResponseFirstCommand(CommandResponseOp<global::Improbable.TestSchema.Nonblittable.NonBlittableComponent.Commands.FirstCommand> op)
+            {
+                var requestId = op.RequestId.Id;
+                RequestContext requestContext;
+                if (!RequestIdToRequestContext.TryGetValue(requestId, out requestContext))
+                {
+                    Debug.LogErrorFormat(TranslationErrors.CannotFindEntityForCommandResponse, op.EntityId.Id,
+                        "FirstCommand");
+                    return;
+                }
+
+                RequestIdToRequestContext.Remove(requestId);
+
+                Unity.Entities.Entity entity;
+                if (requestContext.EntityId == MutableView.WorkerEntityId)
+                {
+                    entity = view.WorkerEntity;
+                }
+                else if (!view.TryGetEntity(requestContext.EntityId, out entity))
+                {
+                    return;
+                }
+
+                var unityResponsePayload = op.Response.HasValue 
+                    ? global::Generated.Improbable.TestSchema.Nonblittable.FirstCommandResponse.ToNative(op.Response.Value.Get().Value) 
+                    : (global::Generated.Improbable.TestSchema.Nonblittable.FirstCommandResponse?) null;
+                var outgoingRequest = (FirstCommand.OutgoingRequest) requestContext.Request;
+                var response = new FirstCommand.Response(op.EntityId.Id, op.Message, (CommandStatusCode) op.StatusCode, unityResponsePayload, outgoingRequest.RawRequest);
+
+                view.AddCommandResponse(entity, response, FirstCommandResponsePool);
+            }
+
+            private void SendFirstCommandRequest(Connection connection, FirstCommand.OutgoingRequest outgoingRequest)
+            {
+                var requestPayload = global::Generated.Improbable.TestSchema.Nonblittable.FirstCommandRequest.ToSpatial(outgoingRequest.RawRequest);
+                var request = new global::Improbable.TestSchema.Nonblittable.NonBlittableComponent.Commands.FirstCommand.Request(requestPayload);
+
+                var requestId = connection.SendCommandRequest(new global::Improbable.EntityId(outgoingRequest.TargetEntityId), request, null);
+
+                RequestIdToRequestContext.Add(requestId.Id, new RequestContext(outgoingRequest.SenderEntityId, outgoingRequest));
+            }
+
+            private void SendFirstCommandResponse(Connection connection, FirstCommand.OutgoingResponse outgoingResponse)
+            {
+                var responsePayload = global::Generated.Improbable.TestSchema.Nonblittable.FirstCommandResponse.ToSpatial(outgoingResponse.RawResponse);
+                var response = new global::Improbable.TestSchema.Nonblittable.NonBlittableComponent.Commands.FirstCommand.Response(responsePayload);
+
+                var requestId = new RequestId<IncomingCommandRequest<global::Improbable.TestSchema.Nonblittable.NonBlittableComponent.Commands.FirstCommand>>(
+                    outgoingResponse.RequestId);
+
+                connection.SendCommandResponse(requestId, response);
+            }
+
+            public void OnCommandRequestSecondCommand(CommandRequestOp<global::Improbable.TestSchema.Nonblittable.NonBlittableComponent.Commands.SecondCommand> op)
+            {
+                Unity.Entities.Entity entity;
+                if (!view.TryGetEntity(op.EntityId.Id, out entity))
+                {
+                    Debug.LogErrorFormat(TranslationErrors.CannotFindEntityForCommandRequest, op.EntityId.Id,
+                        "SecondCommand");
+                    return;
+                }
+
+                var requestPayload = op.Request.Get().Value;
+                var unityRequestPayload = global::Generated.Improbable.TestSchema.Nonblittable.SecondCommandRequest.ToNative(requestPayload);
+                var request = new SecondCommand.Request(op.RequestId.Id, this, op.CallerWorkerId, op.CallerAttributeSet, unityRequestPayload);
+
+                view.AddCommandRequest(entity, request, SecondCommandRequestPool);
+            }
+
+            public void OnCommandResponseSecondCommand(CommandResponseOp<global::Improbable.TestSchema.Nonblittable.NonBlittableComponent.Commands.SecondCommand> op)
+            {
+                var requestId = op.RequestId.Id;
+                RequestContext requestContext;
+                if (!RequestIdToRequestContext.TryGetValue(requestId, out requestContext))
+                {
+                    Debug.LogErrorFormat(TranslationErrors.CannotFindEntityForCommandResponse, op.EntityId.Id,
+                        "SecondCommand");
+                    return;
+                }
+
+                RequestIdToRequestContext.Remove(requestId);
+
+                Unity.Entities.Entity entity;
+                if (requestContext.EntityId == MutableView.WorkerEntityId)
+                {
+                    entity = view.WorkerEntity;
+                }
+                else if (!view.TryGetEntity(requestContext.EntityId, out entity))
+                {
+                    return;
+                }
+
+                var unityResponsePayload = op.Response.HasValue 
+                    ? global::Generated.Improbable.TestSchema.Nonblittable.SecondCommandResponse.ToNative(op.Response.Value.Get().Value) 
+                    : (global::Generated.Improbable.TestSchema.Nonblittable.SecondCommandResponse?) null;
+                var outgoingRequest = (SecondCommand.OutgoingRequest) requestContext.Request;
+                var response = new SecondCommand.Response(op.EntityId.Id, op.Message, (CommandStatusCode) op.StatusCode, unityResponsePayload, outgoingRequest.RawRequest);
+
+                view.AddCommandResponse(entity, response, SecondCommandResponsePool);
+            }
+
+            private void SendSecondCommandRequest(Connection connection, SecondCommand.OutgoingRequest outgoingRequest)
+            {
+                var requestPayload = global::Generated.Improbable.TestSchema.Nonblittable.SecondCommandRequest.ToSpatial(outgoingRequest.RawRequest);
+                var request = new global::Improbable.TestSchema.Nonblittable.NonBlittableComponent.Commands.SecondCommand.Request(requestPayload);
+
+                var requestId = connection.SendCommandRequest(new global::Improbable.EntityId(outgoingRequest.TargetEntityId), request, null);
+
+                RequestIdToRequestContext.Add(requestId.Id, new RequestContext(outgoingRequest.SenderEntityId, outgoingRequest));
+            }
+
+            private void SendSecondCommandResponse(Connection connection, SecondCommand.OutgoingResponse outgoingResponse)
+            {
+                var responsePayload = global::Generated.Improbable.TestSchema.Nonblittable.SecondCommandResponse.ToSpatial(outgoingResponse.RawResponse);
+                var response = new global::Improbable.TestSchema.Nonblittable.NonBlittableComponent.Commands.SecondCommand.Response(responsePayload);
+
+                var requestId = new RequestId<IncomingCommandRequest<global::Improbable.TestSchema.Nonblittable.NonBlittableComponent.Commands.SecondCommand>>(
+                    outgoingResponse.RequestId);
+
+                connection.SendCommandResponse(requestId, response);
+            }
+
+            public override void SendCommands(Connection connection)
+            {
+                foreach (var request in FirstCommandRequests)
+                {
+                    SendFirstCommandRequest(connection, request);
+                }
+                FirstCommandRequests.Clear();
+
+                foreach (var response in FirstCommandResponses)
+                {
+                    SendFirstCommandResponse(connection, response);
+                }
+                FirstCommandResponses.Clear();
+
+                foreach (var request in SecondCommandRequests)
+                {
+                    SendSecondCommandRequest(connection, request);
+                }
+                SecondCommandRequests.Clear();
+
+                foreach (var response in SecondCommandResponses)
+                {
+                    SendSecondCommandResponse(connection, response);
+                }
+                SecondCommandResponses.Clear();
+
+            }
+
+            public static NonBlittableComponent.Translation GetTranslation(uint internalHandleToTranslation)
+            {
+                return (NonBlittableComponent.Translation) ComponentTranslation.HandleToTranslation[internalHandleToTranslation];
+            }
+        }
+    }
+
+    public static class SpatialOSNonBlittableComponentCommandRequestHandlers
+    {
+        public static void SendFirstCommandRequest(this CommandRequestSender<SpatialOSNonBlittableComponent> commandRequestSender,
+            long targetEntityId, global::Generated.Improbable.TestSchema.Nonblittable.FirstCommandRequest request)
+        {
+            var translation = NonBlittableComponent.Translation.GetTranslation(commandRequestSender.InternalHandleToTranslation);
+
+            translation.FirstCommandRequests.Add(new NonBlittableComponent.FirstCommand.OutgoingRequest(targetEntityId,
+                commandRequestSender.EntityId, request));
+        }
+
+        public static void SendSecondCommandRequest(this CommandRequestSender<SpatialOSNonBlittableComponent> commandRequestSender,
+            long targetEntityId, global::Generated.Improbable.TestSchema.Nonblittable.SecondCommandRequest request)
+        {
+            var translation = NonBlittableComponent.Translation.GetTranslation(commandRequestSender.InternalHandleToTranslation);
+
+            translation.SecondCommandRequests.Add(new NonBlittableComponent.SecondCommand.OutgoingRequest(targetEntityId,
+                commandRequestSender.EntityId, request));
+        }
+
+    }
+
+    public static class SpatialOSNonBlittableComponentEventHandlers
+    {
+        public static void SendFirstEventEvent(this EventSender<SpatialOSNonBlittableComponent> eventSender,
+            global::Generated.Improbable.TestSchema.Nonblittable.FirstEventPayload eventData)
+        {
+            var translation = NonBlittableComponent.Translation.GetTranslation(eventSender.InternalHandleToTranslation);
+            translation.EntityIdToFirstEventEvents[eventSender.EntityId].Add(eventData);
+        }
+
+        public static List<global::Generated.Improbable.TestSchema.Nonblittable.FirstEventPayload> GetFirstEventEvents(this EventSender<SpatialOSNonBlittableComponent> eventSender)
+        {
+            var translation = NonBlittableComponent.Translation.GetTranslation(eventSender.InternalHandleToTranslation);
+            return translation.EntityIdToFirstEventEvents[eventSender.EntityId];
+        }
+
+        public static void ClearFirstEventEvents(this EventSender<SpatialOSNonBlittableComponent> eventSender)
+        {
+            var translation = NonBlittableComponent.Translation.GetTranslation(eventSender.InternalHandleToTranslation);
+            translation.EntityIdToFirstEventEvents[eventSender.EntityId].Clear();
+        }
+
+        public static void SendSecondEventEvent(this EventSender<SpatialOSNonBlittableComponent> eventSender,
+            global::Generated.Improbable.TestSchema.Nonblittable.SecondEventPayload eventData)
+        {
+            var translation = NonBlittableComponent.Translation.GetTranslation(eventSender.InternalHandleToTranslation);
+            translation.EntityIdToSecondEventEvents[eventSender.EntityId].Add(eventData);
+        }
+
+        public static List<global::Generated.Improbable.TestSchema.Nonblittable.SecondEventPayload> GetSecondEventEvents(this EventSender<SpatialOSNonBlittableComponent> eventSender)
+        {
+            var translation = NonBlittableComponent.Translation.GetTranslation(eventSender.InternalHandleToTranslation);
+            return translation.EntityIdToSecondEventEvents[eventSender.EntityId];
+        }
+
+        public static void ClearSecondEventEvents(this EventSender<SpatialOSNonBlittableComponent> eventSender)
+        {
+            var translation = NonBlittableComponent.Translation.GetTranslation(eventSender.InternalHandleToTranslation);
+            translation.EntityIdToSecondEventEvents[eventSender.EntityId].Clear();
+        }
+
+    }
+}

--- a/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/nonblittable/SecondCommandRequest.cs
+++ b/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/nonblittable/SecondCommandRequest.cs
@@ -1,0 +1,29 @@
+// ===========
+// DO NOT EDIT - this file is automatically regenerated.
+// ===========
+
+using System.Linq;
+using Unity.Mathematics;
+
+namespace Generated.Improbable.TestSchema.Nonblittable
+{ 
+    
+    public struct SecondCommandRequest
+    {
+        public long Field;
+    
+        public static SecondCommandRequest ToNative(global::Improbable.TestSchema.Nonblittable.SecondCommandRequest spatialType)
+        {
+            var nativeType = new SecondCommandRequest();
+            nativeType.Field = spatialType.field;
+            return nativeType;
+        }
+    
+        public static global::Improbable.TestSchema.Nonblittable.SecondCommandRequest ToSpatial(global::Generated.Improbable.TestSchema.Nonblittable.SecondCommandRequest nativeType)
+        {
+            var spatialType = new global::Improbable.TestSchema.Nonblittable.SecondCommandRequest();
+            spatialType.field = nativeType.Field;
+            return spatialType;
+        }
+    }
+}

--- a/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/nonblittable/SecondCommandResponse.cs
+++ b/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/nonblittable/SecondCommandResponse.cs
@@ -1,0 +1,29 @@
+// ===========
+// DO NOT EDIT - this file is automatically regenerated.
+// ===========
+
+using System.Linq;
+using Unity.Mathematics;
+
+namespace Generated.Improbable.TestSchema.Nonblittable
+{ 
+    
+    public struct SecondCommandResponse
+    {
+        public string Response;
+    
+        public static SecondCommandResponse ToNative(global::Improbable.TestSchema.Nonblittable.SecondCommandResponse spatialType)
+        {
+            var nativeType = new SecondCommandResponse();
+            nativeType.Response = spatialType.response;
+            return nativeType;
+        }
+    
+        public static global::Improbable.TestSchema.Nonblittable.SecondCommandResponse ToSpatial(global::Generated.Improbable.TestSchema.Nonblittable.SecondCommandResponse nativeType)
+        {
+            var spatialType = new global::Improbable.TestSchema.Nonblittable.SecondCommandResponse();
+            spatialType.response = nativeType.Response;
+            return spatialType;
+        }
+    }
+}

--- a/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/nonblittable/SecondEventPayload.cs
+++ b/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/nonblittable/SecondEventPayload.cs
@@ -1,0 +1,32 @@
+// ===========
+// DO NOT EDIT - this file is automatically regenerated.
+// ===========
+
+using System.Linq;
+using Unity.Mathematics;
+
+namespace Generated.Improbable.TestSchema.Nonblittable
+{ 
+    
+    public struct SecondEventPayload
+    {
+        public float Field1;
+        public global::System.Collections.Generic.List<double> Field2;
+    
+        public static SecondEventPayload ToNative(global::Improbable.TestSchema.Nonblittable.SecondEventPayload spatialType)
+        {
+            var nativeType = new SecondEventPayload();
+            nativeType.Field1 = spatialType.field1;
+            nativeType.Field2 = spatialType.field2;
+            return nativeType;
+        }
+    
+        public static global::Improbable.TestSchema.Nonblittable.SecondEventPayload ToSpatial(global::Generated.Improbable.TestSchema.Nonblittable.SecondEventPayload nativeType)
+        {
+            var spatialType = new global::Improbable.TestSchema.Nonblittable.SecondEventPayload();
+            spatialType.field1 = nativeType.Field1;
+            spatialType.field2 = new global::Improbable.Collections.List<double>(nativeType.Field2);
+            return spatialType;
+        }
+    }
+}

--- a/code_generator/End2End/schema/nested_typenames.schema
+++ b/code_generator/End2End/schema/nested_typenames.schema
@@ -1,26 +1,24 @@
 package improbable.test_schema;
 
-// TODO: UTY-360 Uncomment this file when Nested Type definitions are supported.
-//
-// type NestedTypeName {
-//     type Other {
-//         type NestedTypeSameName {
-//             type Other0 {
-//                 int32 foo = 1;
-//             }
-//             enum NestedEnum {
-//                 enum_value = 1;
-//             }
-//             Other0 other_zero = 1;
-//             NestedEnum enum_field = 2;
-//         }
-//         NestedTypeSameName same_name = 1;
-//     }
-//     Other other = 1;
-// }
+type TypeName {
+    type Other {
+        type NestedTypeName {
+            type Other0 {
+                int32 foo = 1;
+            }
+            enum NestedEnum {
+                enum_value = 1;
+            }
+            Other0 other_zero = 1;
+            NestedEnum enum_field = 2;
+        }
+        NestedTypeName same_name = 1;
+    }
+    Other other_type = 1;
+}
 
-// component NestedComponent {
-//     id = 20152;
-//     NestedTypeName nested_type = 1;
-// }
-//
+component NestedComponent {
+    id = 20152;
+    TypeName nested_type = 1;
+}
+

--- a/code_generator/GdkCodeGenerator.csproj
+++ b/code_generator/GdkCodeGenerator.csproj
@@ -81,8 +81,10 @@
     <Compile Include="src\Generation\Generators\Parts\UnityComponentConversionGeneratorPart.cs" />
     <Compile Include="src\Generation\Generators\Parts\UnityComponentDataGeneratorPart.cs" />
     <Compile Include="src\Generation\Generators\Parts\UnityComponentGeneratorPart.cs" />
+    <Compile Include="src\Generation\Generators\Parts\UnityEnumContentPart.cs" />
     <Compile Include="src\Generation\Generators\Parts\UnityEnumGeneratorPart.cs" />
     <Compile Include="src\Generation\Generators\Parts\UnityEventGeneratorPart.cs" />
+    <Compile Include="src\Generation\Generators\Parts\UnityTypeContentPart.cs" />
     <Compile Include="src\Generation\Generators\Parts\UnityTypeGeneratorPart.cs" />
     <Compile Include="src\Generation\Model\Details\UnityCommandDetails.cs" />
     <Compile Include="src\Generation\Model\Details\UnityComponentDetails.cs" />
@@ -112,8 +114,10 @@
     <T4Files Include="Templates\UnityComponentDataGenerator.tt" />
     <T4Files Include="Templates\UnityComponentGenerator.tt" />
     <T4Files Include="Templates\UnityEnumGenerator.tt" />
+    <T4Files Include="Templates\UnityEnumContent.tt" />
     <T4Files Include="Templates\UnityEventGenerator.tt" />
     <T4Files Include="Templates\UnityTypeGenerator.tt" />
+    <T4Files Include="Templates\UnityTypeContent.tt" />
   </ItemGroup>
   <UsingTask TaskName="Improbable.TextTemplating.TransformAllTask" AssemblyFile="$(SolutionDir)dependencies\Improbable.TextTemplating.dll" />
   <Target Name="BeforeBuild">

--- a/code_generator/Templates/UnityEnumContent.tt
+++ b/code_generator/Templates/UnityEnumContent.tt
@@ -1,0 +1,12 @@
+<#@ template language="C#" #>
+<#@ output extension=".cs" #>
+<#
+    var enumDetails = GetEnumDetails();
+#>
+
+public enum <#=  enumDetails.PascalCaseName #> : uint
+{
+<# foreach (var valueDefinition in enumDefinition.valueDefinitions) { #>
+    <#= valueDefinition.name #> = <#= valueDefinition.value #>,
+<# } #>
+}

--- a/code_generator/Templates/UnityEnumGenerator.tt
+++ b/code_generator/Templates/UnityEnumGenerator.tt
@@ -5,5 +5,5 @@
 
 namespace <#= qualifiedNamespace #>
 { 
-    <#= CommonGeneratorUtils.IndentString(new UnityEnumContent().Generate(enumDefinition)) #>
+    <#= CommonGeneratorUtils.IndentEveryNewline(new UnityEnumContent().Generate(enumDefinition)) #>
 }

--- a/code_generator/Templates/UnityEnumGenerator.tt
+++ b/code_generator/Templates/UnityEnumGenerator.tt
@@ -1,17 +1,9 @@
 <#@ template language="C#" #>
 <#@ output extension=".cs" #>
-<#
-    var generatedHeader = CommonGeneratorUtils.GetGeneratedHeader();
-    var enumDetails = GetEnumDetails();
-#>
-<#= generatedHeader #>
+
+<#= CommonGeneratorUtils.GetGeneratedHeader() #>
 
 namespace <#= qualifiedNamespace #>
 { 
-    public enum <#=  enumDetails.PascalCaseName #> : uint
-    {
-<# foreach (var valueDefinition in enumDefinition.valueDefinitions) { #>
-        <#= valueDefinition.name #> = <#= valueDefinition.value #>,
-<# } #>
-    }
+    <#= CommonGeneratorUtils.IndentString(new UnityEnumContent().Generate(enumDefinition)) #>
 }

--- a/code_generator/Templates/UnityTypeContent.tt
+++ b/code_generator/Templates/UnityTypeContent.tt
@@ -34,7 +34,7 @@ public struct <#= typeDetails.CapitalisedName #>
     {
 #>
 
-    <#= CommonGeneratorUtils.IndentString(typeGenerator.Generate(nestedType, enumSet)) #>
+    <#= CommonGeneratorUtils.IndentEveryNewline(typeGenerator.Generate(nestedType, enumSet)) #>
 <# } #>
 <# 
     var enumGenerator = new UnityEnumContent();
@@ -42,6 +42,6 @@ public struct <#= typeDetails.CapitalisedName #>
     {
 #>
 
-    <#= CommonGeneratorUtils.IndentString(enumGenerator.Generate(nestedEnum)) #>
+    <#= CommonGeneratorUtils.IndentEveryNewline(enumGenerator.Generate(nestedEnum)) #>
 <# } #>
 }

--- a/code_generator/Templates/UnityTypeContent.tt
+++ b/code_generator/Templates/UnityTypeContent.tt
@@ -1,0 +1,47 @@
+<#@ template language="C#" #>
+<#@ output extension=".cs" #>
+<#
+    var typeDetails = GetTypeDetails();
+    var fieldDetailsList = GetFieldDetailsList();
+#>
+
+public struct <#= typeDetails.CapitalisedName #>
+{
+<# foreach (var fieldDetails in fieldDetailsList) { #>
+    public <#= fieldDetails.Type #> <#= fieldDetails.PascalCaseName #>;
+<# } #>
+
+    public static <#= typeDetails.CapitalisedName #> ToNative(<#= typeDetails.FullyQualifiedSpatialTypeName #> spatialType)
+    {
+        var nativeType = new <#= typeDetails.CapitalisedName #>();
+<# foreach (var fieldDetails in fieldDetailsList) { #>
+        nativeType.<#= fieldDetails.PascalCaseName #> = <#= UnityTypeMappings.GetNativeTypeMethod(fieldDetails.RawFieldDefinition, "spatialType." + fieldDetails.CamelCaseName, enumSet) #>;
+<# } #>
+        return nativeType;
+    }
+
+    public static <#= typeDetails.FullyQualifiedSpatialTypeName #> ToSpatial(<#= typeDetails.FullyQualifiedTypeName #> nativeType)
+    {
+        var spatialType = new <#= typeDetails.FullyQualifiedSpatialTypeName #>();
+<# foreach (var fieldDetails in fieldDetailsList) { #>
+        spatialType.<#= fieldDetails.CamelCaseName #> = <#= UnityTypeMappings.GetSpatialTypeMethod(fieldDetails.RawFieldDefinition, "nativeType." + fieldDetails.PascalCaseName, enumSet) #>;
+<# } #>
+        return spatialType;
+    }
+<# 
+    var typeGenerator = new UnityTypeContent();
+    foreach (var nestedType in nestedTypes) 
+    {
+#>
+
+    <#= CommonGeneratorUtils.IndentString(typeGenerator.Generate(nestedType, enumSet)) #>
+<# } #>
+<# 
+    var enumGenerator = new UnityEnumContent();
+    foreach (var nestedEnum in nestedEnums) 
+    {
+#>
+
+    <#= CommonGeneratorUtils.IndentString(enumGenerator.Generate(nestedEnum)) #>
+<# } #>
+}

--- a/code_generator/Templates/UnityTypeGenerator.tt
+++ b/code_generator/Templates/UnityTypeGenerator.tt
@@ -10,5 +10,5 @@ namespace <#= qualifiedNamespace #>
 <# 
     var generator = new UnityTypeContent();
 #>
-    <#= CommonGeneratorUtils.IndentString(generator.Generate(typeDefinition, enumSet)) #>
+    <#= CommonGeneratorUtils.IndentEveryNewline(generator.Generate(typeDefinition, enumSet)) #>
 }

--- a/code_generator/Templates/UnityTypeGenerator.tt
+++ b/code_generator/Templates/UnityTypeGenerator.tt
@@ -1,39 +1,14 @@
 <#@ template language="C#" #>
 <#@ output extension=".cs" #>
-<#
-    var typeDetails = GetTypeDetails();
-    var fieldDetailsList = GetFieldDetailsList();
-    var generatedHeader = CommonGeneratorUtils.GetGeneratedHeader();
-#>
-<#= generatedHeader #>
+<#= CommonGeneratorUtils.GetGeneratedHeader() #>
 
 using System.Linq;
 using Unity.Mathematics;
 
 namespace <#= qualifiedNamespace #>
 { 
-    public struct <#= typeDetails.CapitalisedName #>
-    {
-<# foreach (var fieldDetails in fieldDetailsList) { #>
-        public <#= fieldDetails.Type #> <#= fieldDetails.PascalCaseName #>;
-<# } #>
-
-        public static <#= typeDetails.CapitalisedName #> ToNative(<#= typeDetails.FullyQualifiedSpatialTypeName #> spatialType)
-        {
-            var nativeType = new <#= typeDetails.CapitalisedName #>();
-<# foreach (var fieldDetails in fieldDetailsList) { #>
-            nativeType.<#= fieldDetails.PascalCaseName #> = <#= UnityTypeMappings.GetNativeTypeMethod(fieldDetails.RawFieldDefinition, "spatialType." + fieldDetails.CamelCaseName, enumSet) #>;
-<# } #>
-            return nativeType;
-        }
-
-        public static <#= typeDetails.FullyQualifiedSpatialTypeName #> ToSpatial(<#= typeDetails.FullyQualifiedTypeName #> nativeType)
-        {
-            var spatialType = new <#= typeDetails.FullyQualifiedSpatialTypeName #>();
-<# foreach (var fieldDetails in fieldDetailsList) { #>
-            spatialType.<#= fieldDetails.CamelCaseName #> = <#= UnityTypeMappings.GetSpatialTypeMethod(fieldDetails.RawFieldDefinition, "nativeType." + fieldDetails.PascalCaseName, enumSet) #>;
-<# } #>
-            return spatialType;
-        }
-    }
+<# 
+    var generator = new UnityTypeContent();
+#>
+    <#= CommonGeneratorUtils.IndentString(generator.Generate(typeDefinition, enumSet)) #>
 }

--- a/code_generator/src/CodeGenerator.cs
+++ b/code_generator/src/CodeGenerator.cs
@@ -79,9 +79,27 @@ namespace Improbable.Gdk.CodeGenerator
                 {
                     enumSet.Add(unityEnum.qualifiedName);
                 }
+
+                foreach (var typeDefinition in schema.TypeDefinitions)
+                {
+                    ExtractEnums(typeDefinition, enumSet);
+                }
             }
 
             return enumSet;
+        }
+
+        private void ExtractEnums(UnityTypeDefinition typeDefinition, HashSet<string> enumSet)
+        {
+            foreach (var enumDefinition in typeDefinition.EnumDefinitions)
+            {
+                enumSet.Add(enumDefinition.qualifiedName);
+            }
+
+            foreach (var nestedTypeDefinition in typeDefinition.TypeDefinitions)
+            {
+                ExtractEnums(nestedTypeDefinition, enumSet);
+            }
         }
 
         private void CleanTargetDirectory()

--- a/code_generator/src/Generation/Generators/CommonGeneratorUtils.cs
+++ b/code_generator/src/Generation/Generators/CommonGeneratorUtils.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Improbable.Gdk.CodeGenerator
 {
     public static class CommonGeneratorUtils
@@ -5,6 +7,11 @@ namespace Improbable.Gdk.CodeGenerator
         public static string GetGeneratedHeader()
         {
             return "// ===========\r\n// DO NOT EDIT - this file is automatically regenerated.\r\n// ===========";
+        }
+
+        public static string IndentString(string input)
+        {
+            return input.Replace("\r\n", "\r\n    ");
         }
     }
 }

--- a/code_generator/src/Generation/Generators/CommonGeneratorUtils.cs
+++ b/code_generator/src/Generation/Generators/CommonGeneratorUtils.cs
@@ -7,7 +7,7 @@ namespace Improbable.Gdk.CodeGenerator
             return "// ===========\r\n// DO NOT EDIT - this file is automatically regenerated.\r\n// ===========";
         }
 
-        public static string IndentString(string input)
+        public static string IndentEveryNewline(string input)
         {
             return input.Replace("\r\n", "\r\n    ");
         }

--- a/code_generator/src/Generation/Generators/CommonGeneratorUtils.cs
+++ b/code_generator/src/Generation/Generators/CommonGeneratorUtils.cs
@@ -1,5 +1,3 @@
-using System;
-
 namespace Improbable.Gdk.CodeGenerator
 {
     public static class CommonGeneratorUtils

--- a/code_generator/src/Generation/Generators/Parts/UnityEnumContentPart.cs
+++ b/code_generator/src/Generation/Generators/Parts/UnityEnumContentPart.cs
@@ -1,0 +1,20 @@
+using Improbable.CodeGeneration.Model;
+
+namespace Improbable.Gdk.CodeGenerator
+{
+    public partial class UnityEnumContent
+    {
+        private EnumDefinitionRaw enumDefinition;
+
+        public string Generate(EnumDefinitionRaw enumDefinition)
+        {
+            this.enumDefinition = enumDefinition;
+            return TransformText();
+        }
+
+        public UnityEnumDetails GetEnumDetails()
+        {
+            return new UnityEnumDetails(enumDefinition);
+        }
+    }
+}

--- a/code_generator/src/Generation/Generators/Parts/UnityTypeContentPart.cs
+++ b/code_generator/src/Generation/Generators/Parts/UnityTypeContentPart.cs
@@ -27,7 +27,8 @@ namespace Improbable.Gdk.CodeGenerator
 
         private List<UnityFieldDetails> GetFieldDetailsList()
         {
-            return typeDefinition.FieldDefinitions.Select((fieldDefinition) => new UnityFieldDetails(fieldDefinition.RawFieldDefinition)).ToList();
+            return typeDefinition.FieldDefinitions
+                .Select((fieldDefinition) => new UnityFieldDetails(fieldDefinition.RawFieldDefinition)).ToList();
         }
     }
 }

--- a/code_generator/src/Generation/Generators/Parts/UnityTypeContentPart.cs
+++ b/code_generator/src/Generation/Generators/Parts/UnityTypeContentPart.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+using System.Linq;
+using Improbable.CodeGeneration.Model;
+
+namespace Improbable.Gdk.CodeGenerator
+{
+    public partial class UnityTypeContent
+    {
+        private UnityTypeDefinition typeDefinition;
+        private HashSet<string> enumSet;
+        private List<UnityTypeDefinition> nestedTypes;
+        private List<EnumDefinitionRaw> nestedEnums;
+
+        public string Generate(UnityTypeDefinition typeDefinition, HashSet<string> enumSet)
+        {
+            this.typeDefinition = typeDefinition;
+            this.enumSet = enumSet;
+            this.nestedTypes = typeDefinition.TypeDefinitions;
+            this.nestedEnums = typeDefinition.EnumDefinitions.ToList();
+            return TransformText();
+        }
+
+        private UnityTypeDetails GetTypeDetails()
+        {
+            return new UnityTypeDetails(typeDefinition);
+        }
+
+        private List<UnityFieldDetails> GetFieldDetailsList()
+        {
+            return typeDefinition.FieldDefinitions.Select((fieldDefinition) => new UnityFieldDetails(fieldDefinition.RawFieldDefinition)).ToList();
+        }
+    }
+}

--- a/code_generator/src/Generation/Generators/Parts/UnityTypeGeneratorPart.cs
+++ b/code_generator/src/Generation/Generators/Parts/UnityTypeGeneratorPart.cs
@@ -1,5 +1,4 @@
 using System.Collections.Generic;
-using System.Linq;
 
 namespace Improbable.Gdk.CodeGenerator
 {

--- a/code_generator/src/Generation/Generators/Parts/UnityTypeGeneratorPart.cs
+++ b/code_generator/src/Generation/Generators/Parts/UnityTypeGeneratorPart.cs
@@ -14,19 +14,7 @@ namespace Improbable.Gdk.CodeGenerator
             qualifiedNamespace = UnityTypeMappings.PackagePrefix + package;
             this.typeDefinition = typeDefinition;
             this.enumSet = enumSet;
-
             return TransformText();
-        }
-
-        private UnityTypeDetails GetTypeDetails()
-        {
-            return new UnityTypeDetails(typeDefinition);
-        }
-
-        private List<UnityFieldDetails> GetFieldDetailsList()
-        {
-            return typeDefinition.FieldDefinitions
-                .Select(fieldDefinition => new UnityFieldDetails(fieldDefinition.RawFieldDefinition)).ToList();
         }
     }
 }

--- a/workers/unity/Assets/Gdk/Core/Components/ISpatialComponentData.cs
+++ b/workers/unity/Assets/Gdk/Core/Components/ISpatialComponentData.cs
@@ -1,4 +1,3 @@
-using Unity.Entities;
 using Unity.Mathematics;
 
 namespace Improbable.Gdk.Core

--- a/workers/unity/Assets/Gdk/Core/MutableView/MutableView.cs
+++ b/workers/unity/Assets/Gdk/Core/MutableView/MutableView.cs
@@ -15,7 +15,9 @@ namespace Improbable.Gdk.Core
         public const long WorkerEntityId = -1337;
         public Entity WorkerEntity { get; }
 
-        public readonly Dictionary<int, ComponentTranslation> TranslationUnits = new Dictionary<int, ComponentTranslation>();
+        public readonly Dictionary<int, ComponentTranslation> TranslationUnits =
+            new Dictionary<int, ComponentTranslation>();
+
         private Action<Entity, long> addAllCommandRequestSenders;
 
         private readonly EntityManager entityManager;

--- a/workers/unity/Assets/Gdk/TestUtils/Tests/Editmode/HybridGdkSystemTestBaseTests.cs
+++ b/workers/unity/Assets/Gdk/TestUtils/Tests/Editmode/HybridGdkSystemTestBaseTests.cs
@@ -25,7 +25,7 @@ namespace Improbable.Gdk.TestUtils.EditmodeTests
                 For this test, the GameObjectRigidBody[i] will always be null,
                 but we are only testing that this struct can be injected even if
                 it has ComponentArray<> fields, and not its contents.
-                */ 
+                */
                 public ComponentArray<Rigidbody> GameObjectRigidBody;
 
                 public ComponentDataArray<TestPreparation> PreparationStruct;

--- a/workers/unity/Assets/Playground/Scripts/Player/ProcessLaunchCommandSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/Player/ProcessLaunchCommandSystem.cs
@@ -18,7 +18,8 @@ namespace Playground
             [ReadOnly] public EntityArray Entity;
             public ComponentDataArray<SpatialOSLauncher> Launcher;
 
-            [ReadOnly] public ComponentArray<CommandRequests<Generated.Playground.Launcher.LaunchEntity.Request>> CommandRequests;
+            [ReadOnly]
+            public ComponentArray<CommandRequests<Generated.Playground.Launcher.LaunchEntity.Request>> CommandRequests;
 
             [ReadOnly] public ComponentDataArray<CommandRequestSender<SpatialOSLaunchable>> Sender;
         }
@@ -28,7 +29,8 @@ namespace Playground
             public int Length;
             public ComponentDataArray<SpatialOSLaunchable> Launchable;
 
-            [ReadOnly] public ComponentArray<CommandRequests<Generated.Playground.Launchable.LaunchMe.Request>> CommandRequests;
+            [ReadOnly]
+            public ComponentArray<CommandRequests<Generated.Playground.Launchable.LaunchMe.Request>> CommandRequests;
 
             [ReadOnly] public ComponentArray<Rigidbody> Rigidbody;
         }


### PR DESCRIPTION
## NOTE: The last commit is all the generated test code. This is to allow easy diffing. Ignore this commit if you are not interested.

#### Description
A number of changes had to be made to enable recursively generating types:
1. The `enumSet` of all enums in a schema corpus now includes enums defined in types.
2. Refactored `UnityTypeGenerator` into two parts:
 a. `UnityTypeContent` which contains the template for the actual struct content. It recursively calls generate on itself and `UnityEnumContent`
 b. `UnityTypeGenerator` which contains the imports and namespace declaration and then generates the content using the above tt file.
3. `UnityEnumGenerator` had the same refactor as above.
4. Added an `IndentString` function to enable proper alignment of nested types.
5. Committed generated code to allow for easy diffing when we change the code generator.

Also uncommented the nested schema to show that it works! 
#### Tests
Ran `End2End` tests on the CodeGenerator. It compiled and ran properly!
#### Documentation
N/A - this is a change that gets us closer to full schema compatibility.
#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
@jessicafalk @samiwh 