### PR TITLE
UTY-309: Remove LogError and replace by a dispatcher and error objects.

### DIFF
--- a/code_generator/GdkCodeGenerator/Templates/UnityComponentConversionGenerator.tt
+++ b/code_generator/GdkCodeGenerator/Templates/UnityComponentConversionGenerator.tt
@@ -115,7 +115,9 @@ namespace <#= qualifiedNamespace #>
                 Unity.Entities.Entity entity;
                 if (!view.TryGetEntity(op.EntityId.Id, out entity))
                 {
-                    Debug.LogErrorFormat(TranslationErrors.OpReceivedButNoEntity, op.GetType().Name, op.EntityId.Id);
+                    LogDispatcher.HandleLog(LogType.Error, new LogEvent("Entity not found during OnAddComponent.")
+                        .WithField(IdType.EntityId.ToString(), op.EntityId.Id)
+                        .WithField("OpName", op.GetType().Name));
                     return;
                 }
 <# if(fieldDetailsList.Count > 0) { #>
@@ -145,7 +147,10 @@ namespace <#= qualifiedNamespace #>
                 }
                 else
                 {
-                    Debug.LogErrorFormat(TranslationErrors.ComponentAlreadyAdded, typeof(<#= componentDetails.TypeName #>).Name, op.EntityId.Id);
+                    LogDispatcher.HandleLog(LogType.Error, new LogEvent(
+                            "Received ComponentAdded but have already received one for this entity.")
+                        .WithField(IdType.EntityId.ToString(), op.EntityId.Id)
+                        .WithField("OpName", typeof(<#= componentDetails.TypeName #>).Name));
                 }
             }
 
@@ -154,7 +159,9 @@ namespace <#= qualifiedNamespace #>
                 Unity.Entities.Entity entity;
                 if (!view.TryGetEntity(op.EntityId.Id, out entity))
                 {
-                    Debug.LogErrorFormat(TranslationErrors.OpReceivedButNoEntity, op.GetType().Name, op.EntityId.Id);
+                    LogDispatcher.HandleLog(LogType.Error, new LogEvent("Entity not found during OnComponentUpdate.")
+                        .WithField(IdType.EntityId.ToString(), op.EntityId.Id)
+                        .WithField("OpName", op.GetType().Name));
                     return;
                 }
 
@@ -222,7 +229,9 @@ namespace <#= qualifiedNamespace #>
                 Unity.Entities.Entity entity;
                 if (!view.TryGetEntity(op.EntityId.Id, out entity))
                 {
-                    Debug.LogErrorFormat(TranslationErrors.OpReceivedButNoEntity, op.GetType().Name, op.EntityId.Id);
+                    LogDispatcher.HandleLog(LogType.Error, new LogEvent("Entity not found during OnRemoveComponent.")
+                        .WithField(IdType.EntityId.ToString(), op.EntityId.Id)
+                        .WithField("OpName", op.GetType().Name));
                     return;
                 }
 
@@ -238,7 +247,10 @@ namespace <#= qualifiedNamespace #>
                 }
                 else
                 {
-                    Debug.LogErrorFormat(TranslationErrors.ComponentAlreadyRemoved, typeof(<#= componentDetails.TypeName #>).Name, op.EntityId.Id);
+                    LogDispatcher.HandleLog(LogType.Error, new LogEvent(
+                            "Received ComponentRemoved but have already received one for this entity.")
+                        .WithField(IdType.EntityId.ToString(), op.EntityId.Id)
+                        .WithField("OpName", typeof(<#= componentDetails.TypeName #>).Name));
                 }
             }
 
@@ -341,8 +353,9 @@ namespace <#= qualifiedNamespace #>
                 Unity.Entities.Entity entity;
                 if (!view.TryGetEntity(op.EntityId.Id, out entity))
                 {
-                    Debug.LogErrorFormat(TranslationErrors.CannotFindEntityForCommandRequest, op.EntityId.Id,
-                        "<#= commandDetails.CommandName #>");
+                    LogDispatcher.HandleLog(LogType.Error, new LogEvent("Entity not found during OnCommandRequest.")
+                        .WithField(IdType.EntityId.ToString(), op.EntityId.Id)
+                        .WithField("OpName", "<#= commandDetails.CommandName #>"));
                     return;
                 }
 
@@ -359,8 +372,9 @@ namespace <#= qualifiedNamespace #>
                 RequestContext requestContext;
                 if (!RequestIdToRequestContext.TryGetValue(requestId, out requestContext))
                 {
-                    Debug.LogErrorFormat(TranslationErrors.CannotFindEntityForCommandResponse, op.EntityId.Id,
-                        "<#= commandDetails.CommandName #>");
+                    LogDispatcher.HandleLog(LogType.Error, new LogEvent("Entity not found during OnCommandResponse.")
+                        .WithField(IdType.EntityId.ToString(), op.EntityId.Id)
+                        .WithField("OpName", "<#= commandDetails.CommandName #>"));
                     return;
                 }
 

--- a/workers/unity/Assets/Gdk/Core/Components/ComponentTranslation.cs
+++ b/workers/unity/Assets/Gdk/Core/Components/ComponentTranslation.cs
@@ -23,10 +23,12 @@ namespace Improbable.Gdk.Core.Components
 
         public abstract ComponentType TargetComponentType { get; }
         protected readonly MutableView view;
+        protected readonly ILogDispatcher LogDispatcher;
 
         protected ComponentTranslation(MutableView view)
         {
             this.view = view;
+            LogDispatcher = view.LogDispatcher;
             translationHandle = GetNextHandle();
             HandleToTranslation.Add(translationHandle, this);
         }
@@ -39,30 +41,6 @@ namespace Improbable.Gdk.Core.Components
             {
                 HandleToTranslation.Remove(translationHandle);
             }
-        }
-
-        protected static class TranslationErrors
-        {
-            public const string OpReceivedButNoEntity =
-                "Received {0} with EntityId {1}, but there is no entity associated with that EntityId.";
-
-            public const string CannotFindEntityForCommandRequest =
-                "Cannot find entity {0} locally to receive command request {1}.";
-
-            public const string CannotFindEntityForCommandResponse =
-                "Cannot find entity {0} locally to receive command response for {1}.";
-
-            public const string CannotFindEntityForWorldCommandResponse =
-                "Cannot find entity {0} locally to receive world command response for {1}.";
-
-            public const string RequestDoesNotExist =
-                "Cannot find request with ID {0}, response type {1}.";
-
-            public const string ComponentAlreadyAdded =
-                "Received ComponentAdded op for {0} on entity {1}, but have already received one.";
-
-            public const string ComponentAlreadyRemoved =
-                "Received ComponentRemoved op for {0} on entity {1}, but have already received one.";
         }
 
         public static readonly Dictionary<uint, ComponentTranslation> HandleToTranslation =

--- a/workers/unity/Assets/Gdk/Core/Components/WorldCommandsTranslation.cs
+++ b/workers/unity/Assets/Gdk/Core/Components/WorldCommandsTranslation.cs
@@ -352,7 +352,10 @@ namespace Improbable.Gdk.Core
             long entityId;
             if (!RequestIdToEntityId.TryGetValue(requestId, out entityId))
             {
-                Debug.LogErrorFormat(TranslationErrors.RequestDoesNotExist, requestId, responseName);
+                view.LogDispatcher.HandleLog(LogType.Error, new LogEvent(
+                        "Entity not found when attempting to get EntityId from RequestId.")
+                    .WithField(IdType.RequestId.ToString(), requestId)
+                    .WithField("OpName", responseName));
                 return false;
             }
 
@@ -364,8 +367,10 @@ namespace Improbable.Gdk.Core
             }
             else if (!view.TryGetEntity(entityId, out entity))
             {
-                Debug.LogWarningFormat(TranslationErrors.CannotFindEntityForWorldCommandResponse, entityId,
-                    responseName);
+                view.LogDispatcher.HandleLog(LogType.Error, new LogEvent(
+                        "Entity not found when attempting to get Entity from EntityId.")
+                    .WithField(IdType.EntityId.ToString(), entityId)
+                    .WithField("OpName", responseName));
                 return false;
             }
 

--- a/workers/unity/Assets/Gdk/Core/Config/ConnectionConfig.cs
+++ b/workers/unity/Assets/Gdk/Core/Config/ConnectionConfig.cs
@@ -14,7 +14,9 @@ namespace Improbable.Gdk.Core
         {
             if (string.IsNullOrEmpty(configValue))
             {
-                throw new System.ArgumentException($"No valid {configName} has been provided");
+                throw new ConnectionFailedException(
+                    $"Config validation failed with: No valid {configName} has been provided",
+                    ConnectionErrorReason.InvalidConfig);
             }
         }
     }

--- a/workers/unity/Assets/Gdk/Core/Error.meta
+++ b/workers/unity/Assets/Gdk/Core/Error.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 27c4c776fb0b99547bbb78a0adf3cfff
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Assets/Gdk/Core/Error/ILogDispatcher.cs
+++ b/workers/unity/Assets/Gdk/Core/Error/ILogDispatcher.cs
@@ -1,0 +1,9 @@
+using UnityEngine;
+
+namespace Improbable.Gdk.Core
+{
+    public interface ILogDispatcher
+    {
+        void HandleLog(LogType type, LogEvent logEvent);
+    }
+}

--- a/workers/unity/Assets/Gdk/Core/Error/ILogDispatcher.cs.meta
+++ b/workers/unity/Assets/Gdk/Core/Error/ILogDispatcher.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 044432836be466c40b50288e4d4c5fef
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Assets/Gdk/Core/Error/IdType.cs
+++ b/workers/unity/Assets/Gdk/Core/Error/IdType.cs
@@ -1,0 +1,8 @@
+namespace Improbable.Gdk.Core
+{
+    public enum IdType
+    {
+        EntityId,
+        RequestId
+    }
+}

--- a/workers/unity/Assets/Gdk/Core/Error/IdType.cs.meta
+++ b/workers/unity/Assets/Gdk/Core/Error/IdType.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 94099d7f8c0657a4187f258ec872fa17
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Assets/Gdk/Core/Error/LogEvent.cs
+++ b/workers/unity/Assets/Gdk/Core/Error/LogEvent.cs
@@ -1,0 +1,42 @@
+using System.Collections.Generic;
+using System.Text;
+
+namespace Improbable.Gdk.Core
+{
+    public struct LogEvent
+    {
+        public string Message;
+        public Dictionary<string, object> Data;
+
+        public LogEvent(string message)
+        {
+            Message = message;
+            Data = new Dictionary<string, object>();
+        }
+
+        public LogEvent WithField(string key, object value)
+        {
+            Data.Add(key, value);
+            return this;
+        }
+
+        public override string ToString()
+        {
+            var builder = new StringBuilder();
+
+            builder.AppendLine(Message);
+
+            if (Data.Count > 0)
+            {
+                builder.AppendLine("Log event context:");
+
+                foreach (var entry in Data)
+                {
+                    builder.AppendLine($"'{entry.Key}': '{entry.Value}'");
+                }
+            }
+
+            return builder.ToString();
+        }
+    }
+}

--- a/workers/unity/Assets/Gdk/Core/Error/LogEvent.cs.meta
+++ b/workers/unity/Assets/Gdk/Core/Error/LogEvent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 54c60161233919d45b4ee40652955896
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Assets/Gdk/Core/Error/LoggingDispatcher.cs
+++ b/workers/unity/Assets/Gdk/Core/Error/LoggingDispatcher.cs
@@ -1,0 +1,29 @@
+using UnityEngine;
+
+namespace Improbable.Gdk.Core
+{
+    public class LoggingDispatcher : ILogDispatcher
+    {
+        public void HandleLog(LogType type, LogEvent logEvent)
+        {
+            switch (type)
+            {
+                case LogType.Error:
+                    Debug.LogError(logEvent);
+                    break;
+                case LogType.Warning:
+                    Debug.LogWarning(logEvent);
+                    break;
+                case LogType.Log:
+                    Debug.Log(logEvent);
+                    break;
+                case LogType.Assert:
+                    Debug.LogAssertion(logEvent);
+                    break;
+                case LogType.Exception:
+                    Debug.LogError(logEvent);
+                    break;
+            }
+        }
+    }
+}

--- a/workers/unity/Assets/Gdk/Core/Error/LoggingDispatcher.cs.meta
+++ b/workers/unity/Assets/Gdk/Core/Error/LoggingDispatcher.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2ce762fb97b26c74aa89f22fee80c27e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Assets/Gdk/Core/Exceptions.meta
+++ b/workers/unity/Assets/Gdk/Core/Exceptions.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1da0043b65b01d34eace8d96742b455c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Assets/Gdk/Core/Exceptions/ConnectionFailedException.cs
+++ b/workers/unity/Assets/Gdk/Core/Exceptions/ConnectionFailedException.cs
@@ -1,0 +1,21 @@
+using System;
+
+namespace Improbable.Gdk.Core
+{
+    public enum ConnectionErrorReason
+    {
+        CannotEstablishConnection,
+        DeploymentNotFound,
+        InvalidConfig
+    }
+
+    public class ConnectionFailedException : Exception
+    {
+        public ConnectionErrorReason Reason;
+
+        public ConnectionFailedException(string message, ConnectionErrorReason reason) : base(message)
+        {
+            Reason = reason;
+        }
+    }
+}

--- a/workers/unity/Assets/Gdk/Core/Exceptions/ConnectionFailedException.cs.meta
+++ b/workers/unity/Assets/Gdk/Core/Exceptions/ConnectionFailedException.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4619fde6ba703f14f88fac9b550d498b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Assets/Gdk/Core/Exceptions/InvalidConfigurationException.cs
+++ b/workers/unity/Assets/Gdk/Core/Exceptions/InvalidConfigurationException.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Improbable.Gdk.Core
+{
+    public class InvalidConfigurationException : Exception
+    {
+        public InvalidConfigurationException(string message) : base(message)
+        {
+        }
+    }
+}

--- a/workers/unity/Assets/Gdk/Core/Exceptions/InvalidConfigurationException.cs.meta
+++ b/workers/unity/Assets/Gdk/Core/Exceptions/InvalidConfigurationException.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8d42cfbb71b8f8540b0248c1f074d85b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Assets/Gdk/Core/MutableView/MutableView.cs
+++ b/workers/unity/Assets/Gdk/Core/MutableView/MutableView.cs
@@ -14,6 +14,7 @@ namespace Improbable.Gdk.Core
     {
         public const long WorkerEntityId = -1337;
         public Entity WorkerEntity { get; }
+        public ILogDispatcher LogDispatcher { get; }
 
         public readonly Dictionary<int, ComponentTranslation> TranslationUnits =
             new Dictionary<int, ComponentTranslation>();
@@ -33,11 +34,14 @@ namespace Improbable.Gdk.Core
 
         private readonly Dictionary<long, Entity> entityMapping;
 
-        public MutableView(World world)
+        public const string UnexpectedAuthorityChangeError = "Unexpected state transition during authority change.";
+
+        public MutableView(World world, ILogDispatcher logDispatcher)
         {
             entityManager = world.GetOrCreateManager<EntityManager>();
             entityMapping = new Dictionary<long, Entity>();
             gameObjectManager = new GameObjectManager();
+            LogDispatcher = logDispatcher;
 
             setComponentObjectAction = (Action<Entity, ComponentType, object>) Delegate.CreateDelegate(
                 typeof(Action<Entity, ComponentType, object>), entityManager, setComponentObjectMethodInfo);
@@ -69,7 +73,10 @@ namespace Improbable.Gdk.Core
             Entity entity;
             if (!TryGetEntity(entityId, out entity))
             {
-                Debug.LogErrorFormat(Errors.NoCorrespondingEntityForEntityId, typeof(T).Name, entityId);
+                LogDispatcher.HandleLog(LogType.Error, new LogEvent(
+                        "Entity not found when attempting to add a component to an entity.")
+                    .WithField(IdType.EntityId.ToString(), entityId)
+                    .WithField("OpName", typeof(T).Name));
                 return;
             }
 
@@ -91,7 +98,10 @@ namespace Improbable.Gdk.Core
             Entity entity;
             if (!TryGetEntity(entityId, out entity))
             {
-                Debug.LogErrorFormat(Errors.NoCorrespondingEntityForEntityId, typeof(T).Name, entityId);
+                LogDispatcher.HandleLog(LogType.Error, new LogEvent(
+                        "Entity not found when attemting to remove a component from an entity.")
+                    .WithField(IdType.EntityId.ToString(), entityId)
+                    .WithField("OpName", typeof(T).Name));
             }
 
             RemoveComponent<T>(entity);
@@ -144,7 +154,10 @@ namespace Improbable.Gdk.Core
             Entity entity;
             if (!TryGetEntity(entityId, out entity))
             {
-                Debug.LogErrorFormat(Errors.NoCorrespondingEntityForEntityId, typeof(T).Name, entityId);
+                LogDispatcher.HandleLog(LogType.Error, new LogEvent(
+                        "Entity not found when attempting to set component object.")
+                    .WithField(IdType.EntityId.ToString(), entityId)
+                    .WithField("OpName", typeof(T).Name));
                 return;
             }
 
@@ -206,7 +219,9 @@ namespace Improbable.Gdk.Core
             Entity entity;
             if (!TryGetEntity(entityId, out entity))
             {
-                Debug.LogErrorFormat(Errors.NoCorrespondingEntityForEntityId, typeof(T).Name, entityId);
+                LogDispatcher.HandleLog(LogType.Error, new LogEvent("Entity not found during authority change.")
+                    .WithField(IdType.EntityId.ToString(), entityId)
+                    .WithField("OpName", typeof(T).Name));
                 return;
             }
 
@@ -215,8 +230,10 @@ namespace Improbable.Gdk.Core
                 case Authority.Authoritative:
                     if (!HasComponent<NotAuthoritative<T>>(entity))
                     {
-                        Debug.LogErrorFormat(Errors.IncorrectAuthorityTransition, Authority.Authoritative,
-                            Authority.NotAuthoritative);
+                        LogDispatcher.HandleLog(LogType.Error, new LogEvent(UnexpectedAuthorityChangeError)
+                            .WithField("Type", typeof(Authority))
+                            .WithField("NewState", Authority.Authoritative)
+                            .WithField("OldState", Authority.NotAuthoritative));
                         return;
                     }
 
@@ -226,8 +243,10 @@ namespace Improbable.Gdk.Core
                 case Authority.AuthorityLossImminent:
                     if (!HasComponent<Authoritative<T>>(entity))
                     {
-                        Debug.LogErrorFormat(Errors.IncorrectAuthorityTransition, Authority.AuthorityLossImminent,
-                            Authority.Authoritative);
+                        LogDispatcher.HandleLog(LogType.Error, new LogEvent(UnexpectedAuthorityChangeError)
+                            .WithField("Type", typeof(Authority))
+                            .WithField("NewState", Authority.AuthorityLossImminent)
+                            .WithField("OldState", Authority.Authoritative));
                         return;
                     }
 
@@ -236,8 +255,10 @@ namespace Improbable.Gdk.Core
                 case Authority.NotAuthoritative:
                     if (!HasComponent<Authoritative<T>>(entity))
                     {
-                        Debug.LogErrorFormat(Errors.IncorrectAuthorityTransition, Authority.NotAuthoritative,
-                            Authority.Authoritative);
+                        LogDispatcher.HandleLog(LogType.Error, new LogEvent(UnexpectedAuthorityChangeError)
+                            .WithField("Type", typeof(Authority))
+                            .WithField("NewState", Authority.NotAuthoritative)
+                            .WithField("OldState", Authority.Authoritative));
                         return;
                     }
 
@@ -272,7 +293,9 @@ namespace Improbable.Gdk.Core
         {
             if (entityMapping.ContainsKey(entityId))
             {
-                Debug.LogErrorFormat(Errors.AddEntityButEntityIdAlreadyExists, entityId);
+                LogDispatcher.HandleLog(LogType.Error, new LogEvent(
+                        "Tried to add an entity but there is already an entity associated with that EntityId.")
+                    .WithField(IdType.EntityId.ToString(), entityId));
                 return;
             }
 
@@ -292,7 +315,9 @@ namespace Improbable.Gdk.Core
             Entity entity;
             if (!TryGetEntity(entityId, out entity))
             {
-                Debug.LogErrorFormat(Errors.DeleteNonExistentEntity, entityId);
+                LogDispatcher.HandleLog(LogType.Error, new LogEvent(
+                        "Tried to delete an entity but there is already an entity associated with that EntityId.")
+                    .WithField(IdType.EntityId.ToString(), entityId));
                 return;
             }
 
@@ -327,21 +352,6 @@ namespace Improbable.Gdk.Core
             var messageBuffer = GetOrCreateComponent(entity, pool);
             messageBuffer.Buffer.Add(message);
             SetComponentObject(entity, messageBuffer);
-        }
-
-        private static class Errors
-        {
-            public static string NoCorrespondingEntityForEntityId =
-                "Received {0} for EntityId {1}, but there is no entity associated with that EntityId.";
-
-            public const string IncorrectAuthorityTransition =
-                "Unexpected authority transition to state: {0}. Expected previous state: {1}.";
-
-            public const string AddEntityButEntityIdAlreadyExists =
-                "Tried to add an entity with EntityId {0}, but there is already an entity associated with that EntityId.";
-
-            public const string DeleteNonExistentEntity =
-                "Tried to delete an entity with EntityId {0}, but there is no entity associated with that EntityId";
         }
     }
 }

--- a/workers/unity/Assets/Gdk/Core/Systems/CustomSpatialOSSendSystem.cs
+++ b/workers/unity/Assets/Gdk/Core/Systems/CustomSpatialOSSendSystem.cs
@@ -1,4 +1,5 @@
 using Unity.Entities;
+using UnityEngine;
 
 namespace Improbable.Gdk.Core
 {
@@ -16,7 +17,12 @@ namespace Improbable.Gdk.Core
             worker = WorkerRegistry.GetWorkerForWorld(World);
 
             spatialOSSendSystem = World.GetOrCreateManager<SpatialOSSendSystem>();
-            spatialOSSendSystem.RegisterCustomReplicationSystem(typeof(T));
+            if (!spatialOSSendSystem.TryRegisterCustomReplicationSystem(typeof(T)))
+            {
+                worker.View.LogDispatcher.HandleLog(LogType.Error, new LogEvent(
+                        "Custom Replication System for this component already exists.")
+                    .WithField("ComponentType", typeof(T)));
+            }
         }
     }
 }

--- a/workers/unity/Assets/Gdk/Core/Systems/SpatialOSSendSystem.cs
+++ b/workers/unity/Assets/Gdk/Core/Systems/SpatialOSSendSystem.cs
@@ -1,18 +1,11 @@
 using System.Collections.Generic;
 using Unity.Entities;
-using UnityEngine;
 
 namespace Improbable.Gdk.Core
 {
     [UpdateInGroup(typeof(SpatialOSSendGroup.InternalSpatialOSSendGroup))]
     public class SpatialOSSendSystem : ComponentSystem
     {
-        internal static class Warnings
-        {
-            public const string CustomReplicationSystemAlreadyExists =
-                "Custom Replication System for type {0} already exists!";
-        }
-
         private WorkerBase worker;
         private MutableView view;
 
@@ -44,15 +37,15 @@ namespace Improbable.Gdk.Core
             }
         }
 
-        public void RegisterCustomReplicationSystem(ComponentType type)
+        public bool TryRegisterCustomReplicationSystem(ComponentType type)
         {
             if (!registeredReplicators.Contains(type.TypeIndex))
             {
-                Debug.LogWarningFormat(Warnings.CustomReplicationSystemAlreadyExists, type);
-                return;
+                return false;
             }
 
-            registeredReplicators.Remove(type.TypeIndex);
+            // The default replication system is removed, instead the custom one is responsible for replication.
+            return registeredReplicators.Remove(type.TypeIndex);
         }
 
         protected override void OnUpdate()

--- a/workers/unity/Assets/Gdk/Core/Tests/Editmode/Config/LocatorConfigTests.cs
+++ b/workers/unity/Assets/Gdk/Core/Tests/Editmode/Config/LocatorConfigTests.cs
@@ -35,7 +35,7 @@ namespace Improbable.Gdk.Core.EditmodeTests
             var config = GetDefaultWorkingConfig();
             config.LocatorHost = "";
 
-            var exception = Assert.Throws<System.ArgumentException>(() => config.Validate());
+            var exception = Assert.Throws<ConnectionFailedException>(() => config.Validate());
             Assert.IsTrue(exception.Message.Contains("locatorHost"));
         }
 
@@ -47,7 +47,7 @@ namespace Improbable.Gdk.Core.EditmodeTests
             config.LocatorParameters.LoginToken.Token = "some token who cares";
             config.LocatorParameters.ProjectName = "";
 
-            var exception = Assert.Throws<System.ArgumentException>(() => config.Validate());
+            var exception = Assert.Throws<ConnectionFailedException>(() => config.Validate());
             Assert.IsTrue(exception.Message.Contains("projectName"));
         }
 
@@ -59,7 +59,7 @@ namespace Improbable.Gdk.Core.EditmodeTests
             config.LocatorParameters.LoginToken.Token = "";
             config.LocatorParameters.ProjectName = "some project who cares";
 
-            var exception = Assert.Throws<System.ArgumentException>(() => config.Validate());
+            var exception = Assert.Throws<ConnectionFailedException>(() => config.Validate());
             Assert.IsTrue(exception.Message.Contains("loginToken"));
         }
 

--- a/workers/unity/Assets/Gdk/Core/Tests/Editmode/Config/ReceptionistConfigTests.cs
+++ b/workers/unity/Assets/Gdk/Core/Tests/Editmode/Config/ReceptionistConfigTests.cs
@@ -36,7 +36,7 @@ namespace Improbable.Gdk.Core.EditmodeTests
             var config = GetDefaultWorkingConfig();
             config.ReceptionistHost = "";
 
-            var exception = Assert.Throws<System.ArgumentException>(() => config.Validate());
+            var exception = Assert.Throws<ConnectionFailedException>(() => config.Validate());
             Assert.IsTrue(exception.Message.Contains("receptionistHost"));
         }
 

--- a/workers/unity/Assets/Gdk/Core/Tests/Editmode/Worker/WorkerRegistryTest.cs
+++ b/workers/unity/Assets/Gdk/Core/Tests/Editmode/Worker/WorkerRegistryTest.cs
@@ -20,7 +20,7 @@ namespace Improbable.Gdk.Core.EditmodeTests
             using (var testWorker = new UnityTestWorker("someId", Vector3.zero))
             {
                 testWorker.RegisterSystems();
-                var exception = Assert.Throws<System.Exception>(() => WorkerRegistry.SetWorkerForWorld(testWorker));
+                var exception = Assert.Throws<System.ArgumentException>(() => WorkerRegistry.SetWorkerForWorld(testWorker));
                 Assert.IsTrue(exception.Message.Contains("worker") && exception.Message.Contains("world"));
             }
         }

--- a/workers/unity/Assets/Gdk/Core/Utility/ViewCommandBuffer.cs
+++ b/workers/unity/Assets/Gdk/Core/Utility/ViewCommandBuffer.cs
@@ -57,8 +57,9 @@ namespace Improbable.Gdk.Core
                             bufferedCommand.ComponentType);
                         break;
                     default:
-                        Debug.LogErrorFormat("ViewCommandBuffer encountered unknown command type: {0}",
-                            bufferedCommand.CommandType);
+                        view.LogDispatcher.HandleLog(LogType.Error, new LogEvent(
+                                "ViewCommandBuffer encountered unknown command type during buffer flush.")
+                            .WithField("CommandType", bufferedCommand.CommandType));
                         break;
                 }
             }

--- a/workers/unity/Assets/Gdk/Core/Worker/WorkerBase.cs
+++ b/workers/unity/Assets/Gdk/Core/Worker/WorkerBase.cs
@@ -19,18 +19,22 @@ namespace Improbable.Gdk.Core
 
         public abstract string GetWorkerType { get; }
 
-        protected WorkerBase(string workerId, Vector3 origin)
+        protected WorkerBase(string workerId, Vector3 origin) : this(workerId, origin, new LoggingDispatcher())
+        {
+        }
+
+        protected WorkerBase(string workerId, Vector3 origin, ILogDispatcher loggingDispatcher)
         {
             if (string.IsNullOrEmpty(workerId))
             {
-                throw new ArgumentException("WorkerId is null or empty.");
+                throw new ArgumentException("WorkerId is null or empty.", nameof(workerId));
             }
 
             WorkerId = workerId;
             World = new World(WorkerId);
             WorkerRegistry.SetWorkerForWorld(this);
 
-            View = new MutableView(World);
+            View = new MutableView(World, loggingDispatcher);
             Origin = origin;
         }
 
@@ -41,7 +45,7 @@ namespace Improbable.Gdk.Core
             World.Dispose();
         }
 
-        public bool Connect(ConnectionConfig config)
+        public void Connect(ConnectionConfig config)
         {
             if (config is ReceptionistConfig)
             {
@@ -51,10 +55,10 @@ namespace Improbable.Gdk.Core
             {
                 Connection = ConnectionUtility.LocatorConnectToSpatial((LocatorConfig) config, GetWorkerType);
             }
-
-            if (Connection == null)
+            else
             {
-                return false;
+                throw new InvalidConfigurationException($"Invalid connection config was provided: '{config}' Only" +
+                    "ReceptionistConfig and LocatorConfig are supported.");
             }
 
             Application.quitting += () =>
@@ -62,8 +66,8 @@ namespace Improbable.Gdk.Core
                 ConnectionUtility.Disconnect(Connection);
                 Connection = null;
             };
+
             View.Connect();
-            return true;
         }
 
         public virtual void RegisterSystems()

--- a/workers/unity/Assets/Gdk/Core/Worker/WorkerRegistry.cs
+++ b/workers/unity/Assets/Gdk/Core/Worker/WorkerRegistry.cs
@@ -19,7 +19,7 @@ namespace Improbable.Gdk.Core
         {
             if (WorldToWorker.ContainsKey(worker.World))
             {
-                throw new Exception(string.Format("A worker is already stored for world {0}", worker.World.Name));
+                throw new ArgumentException($"A worker is already stored for world '{worker.World.Name}'");
             }
 
             WorldToWorker[worker.World] = worker;
@@ -65,8 +65,7 @@ namespace Improbable.Gdk.Core
             Func<string, Vector3, WorkerBase> createWorker;
             if (!WorkerTypeToInitializationFunction.TryGetValue(workerType, out createWorker))
             {
-                Debug.LogErrorFormat("No worker found for worker type {0}", workerType);
-                return null;
+                throw new ArgumentException("No worker found for worker type '{0}'", workerType);
             }
 
             return createWorker(workerId, origin);

--- a/workers/unity/Assets/Playground/Scripts/Bootstrap.cs
+++ b/workers/unity/Assets/Playground/Scripts/Bootstrap.cs
@@ -68,11 +68,6 @@ namespace Playground
                     ? WorkerRegistry.CreateWorker<UnityClient>($"{workerType}-{Guid.NewGuid()}", new Vector3(0, 0, 0))
                     : WorkerRegistry.CreateWorker(workerType, workerId, new Vector3(0, 0, 0));
 
-                if (worker == null)
-                {
-                    return;
-                }
-
                 Workers.Add(worker);
 
                 connectionConfig = ConnectionUtility.CreateConnectionConfigFromCommandLine(commandLineArgs);
@@ -80,8 +75,9 @@ namespace Playground
 
             if (World.AllWorlds.Count <= 0)
             {
-                Debug.LogError(
-                    "No worlds have been created, due to invalid worker types being specified.");
+                throw new InvalidConfigurationException(
+                    "No worlds have been created, due to invalid worker types being specified. Check the config in" +
+                    "Improbable -> Configure editor workers.");
             }
 
             var worlds = World.AllWorlds.ToArray();
@@ -95,7 +91,16 @@ namespace Playground
             foreach (var worker in Workers)
             {
                 LoadLevel(worker);
-                worker.Connect(connectionConfig);
+
+                try
+                {
+                    worker.Connect(connectionConfig);
+                }
+                catch (ConnectionFailedException exception)
+                {
+                    worker.View.LogDispatcher.HandleLog(LogType.Error, new LogEvent(exception.Message)
+                        .WithField("Reason", exception.Reason));
+                }
             }
         }
 

--- a/workers/unity/Assets/Playground/Scripts/Spawning/ArchetypeInitializationSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/Spawning/ArchetypeInitializationSystem.cs
@@ -48,7 +48,10 @@ namespace Playground
 
             if (!(worker is UnityClient) && !(worker is UnityGameLogic))
             {
-                Debug.LogErrorFormat(Errors.UnknownWorkerType, World.Name);
+                view.LogDispatcher.HandleLog(LogType.Error, new LogEvent(
+                        "Worker type isn't supported by the ArchetypeInitializationSystem.")
+                    .WithField("WorldName", World.Name)
+                    .WithField("WorkerType", worker));
             }
 
             workerType = worker.GetWorkerType;
@@ -65,7 +68,10 @@ namespace Playground
                 if (!ArchetypeConfig.WorkerTypeToArchetypeNameToComponentTypes[workerType]
                     .TryGetValue(archetypeName, out componentTypesToAdd))
                 {
-                    Debug.LogErrorFormat(Errors.MappingNotFound, workerType, archetypeName);
+                    view.LogDispatcher.HandleLog(LogType.Error, new LogEvent(
+                            "No corresponding archetype mapping found.")
+                        .WithField("ArchetypeName", archetypeName)
+                        .WithField("WorkerType", workerType));
                     continue;
                 }
 
@@ -101,15 +107,6 @@ namespace Playground
             }
 
             viewCommandBuffer.FlushBuffer(view);
-        }
-
-        internal static class Errors
-        {
-            public const string MappingNotFound =
-                "No corresponding archetype mapping found for workerType {0}, key {1}.";
-
-            public const string UnknownWorkerType =
-                "Unknown workerType for world name {0}.";
         }
     }
 }

--- a/workers/unity/Assets/Playground/Scripts/Spawning/GameObjectInitializationSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/Spawning/GameObjectInitializationSystem.cs
@@ -53,7 +53,10 @@ namespace Playground
 
                 if (!(worker is UnityClient) && !(worker is UnityGameLogic))
                 {
-                    Debug.LogErrorFormat(Errors.UnknownWorkerType, World.Name);
+                    view.LogDispatcher.HandleLog(LogType.Error, new LogEvent(
+                            "Worker type isn't supported by the GameObjectInitializationSystem.")
+                        .WithField("WorldName", World.Name)
+                        .WithField("WorkerType", worker));
                 }
 
                 var prefabName = worker is UnityGameLogic
@@ -76,7 +79,8 @@ namespace Playground
                 prefab = Resources.Load<GameObject>(prefabName);
                 if (prefab == null)
                 {
-                    Debug.LogErrorFormat(Errors.PrefabNotFound, prefabName);
+                    view.LogDispatcher.HandleLog(LogType.Error, new LogEvent("Prefab not found.")
+                        .WithField("PrefabPath", prefabName));
                     return;
                 }
 
@@ -101,15 +105,6 @@ namespace Playground
             }
 
             view.AddGameObjectEntity(entity, gameObject);
-        }
-
-        internal static class Errors
-        {
-            public const string PrefabNotFound =
-                "Prefab for prefabPath {0} not found.";
-
-            public const string UnknownWorkerType =
-                "Unknown workerType for world name {0}.";
         }
     }
 }


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
We are using `Debug.LogError` in a few places in the GDK. This has been replaced by an ErrorDispatcher and in some cases by returning ConnectionError object.

Design doc: https://brevi.link/unity-gdk-log-error-replacement 

#### Tests
Ran the game sucessfully.

#### Documentation
N/A

#### Primary reviewers
@jessicafalk @samiwh 