### PR TITLE
UTY-581: Bugfix ci/test.sh fails to run unity tests if UNITY_HOME contains a space.

### DIFF
--- a/ci/includes/pinned-tools.sh
+++ b/ci/includes/pinned-tools.sh
@@ -24,7 +24,7 @@ function getUnityDir() {
 }
 
 UNITY_DIR="$(getUnityDir)"
-export UNITY_EXE=$(printf %q "${UNITY_DIR}/Editor/Unity.exe")
+export UNITY_EXE="${UNITY_DIR}/Editor/Unity.exe"
 
 export LINTER="cleanupcode.exe"
 

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -46,7 +46,7 @@ markEndOfBlock "Code Generator End2End Testing"
 
 markStartOfBlock "Editmode Testing"
 
-${UNITY_EXE} \
+"${UNITY_EXE}" \
     -nographics \
     -batchmode \
     -projectPath "${PROJECT_DIR}/workers/unity" \
@@ -61,7 +61,7 @@ markEndOfBlock "Editmode Testing"
 
 markStartOfBlock "Playmode Testing"
 
-${UNITY_EXE} \
+"${UNITY_EXE}" \
     -nographics \
     -batchmode \
     -projectPath "${PROJECT_DIR}/workers/unity" \


### PR DESCRIPTION
#### Description
ci/test.sh fails to run unity tests if your UNITY_HOME environment variable has a space in it.
- fixed UNITY_EXE export in ci/tools/pinned-tools.sh
- enclosed unity test commands in quotes in ci/test.sh
#### Tests
Ran tests locally, & in TeamCity.