### PR TITLE
Fix cube movement

### DIFF
--- a/workers/unity/Assets/Playground/Scripts/Cubes/CubeMovementSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/Cubes/CubeMovementSystem.cs
@@ -21,17 +21,27 @@ namespace Playground
 
         private static Vector3 speed = new Vector3(2, 0, 0);
 
+        private Vector3 origin;
+
+        protected override void OnCreateManager(int capacity)
+        {
+            base.OnCreateManager(capacity);
+
+            var worker = WorkerRegistry.GetWorkerForWorld(World);
+            origin = worker.Origin;
+        }
+
         protected override void OnUpdate()
         {
             for (var i = 0; i < data.Length; i++)
             {
                 var rigidbodyComponent = data.Rigidbody[i];
-                if (rigidbodyComponent.position.x > 10)
+                if (rigidbodyComponent.position.x - origin.x > 10)
                 {
                     speed = new Vector3(-2, 0, 0);
                 }
 
-                if (rigidbodyComponent.position.x < -10)
+                if (rigidbodyComponent.position.x - origin.x < -10)
                 {
                     speed = new Vector3(2, 0, 0);
                 }


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
The CubeMovementSystem relied on the origin being at 0. When the origin was changed this broke and the cubes kept running off the platform.

#### Tests
Ran the game, all works.

#### Documentation
N/A

#### Primary reviewers
@jessicafalk 