### PR TITLE
UTY-540: ComponentAdded / ComponentRemoved reactive tags

### DIFF
--- a/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/ExhaustiveBlittableSingularTranslation.cs
+++ b/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/ExhaustiveBlittableSingularTranslation.cs
@@ -98,8 +98,11 @@ namespace Generated.Improbable.TestSchema
                 }
                 else if (!view.HasComponent<ComponentAdded<SpatialOSExhaustiveBlittableSingular>>(entity))
                 {
-                    var addedTag = new ComponentAdded<SpatialOSExhaustiveBlittableSingular>();
-                    view.AddComponent(entity, addedTag);
+                    view.AddComponent(entity, new ComponentAdded<SpatialOSExhaustiveBlittableSingular>());
+                }
+                else
+                {
+                    Debug.LogErrorFormat(TranslationErrors.ComponentAlreadyAdded, typeof(SpatialOSExhaustiveBlittableSingular).Name, op.EntityId.Id);
                 }
             }
 
@@ -284,8 +287,11 @@ namespace Generated.Improbable.TestSchema
                 }
                 else if (!view.HasComponent<ComponentRemoved<SpatialOSExhaustiveBlittableSingular>>(entity))
                 {
-                    var removedTag = new ComponentRemoved<SpatialOSExhaustiveBlittableSingular>();
-                    view.AddComponent(entity, removedTag);
+                    view.AddComponent(entity, new ComponentRemoved<SpatialOSExhaustiveBlittableSingular>());
+                }
+                else
+                {
+                    Debug.LogErrorFormat(TranslationErrors.ComponentAlreadyRemoved, typeof(SpatialOSExhaustiveBlittableSingular).Name, op.EntityId.Id);
                 }
             }
 

--- a/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/ExhaustiveBlittableSingularTranslation.cs
+++ b/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/ExhaustiveBlittableSingularTranslation.cs
@@ -28,6 +28,8 @@ namespace Generated.Improbable.TestSchema
             private static readonly ComponentType[] cleanUpComponentTypes = 
             { 
                 typeof(AuthoritiesChanged<SpatialOSExhaustiveBlittableSingular>),
+                typeof(ComponentAdded<SpatialOSExhaustiveBlittableSingular>),
+                typeof(ComponentRemoved<SpatialOSExhaustiveBlittableSingular>),
                 typeof(ComponentsUpdated<SpatialOSExhaustiveBlittableSingular.Update>), 
             };
 
@@ -89,6 +91,16 @@ namespace Generated.Improbable.TestSchema
 
                 view.AddComponent(entity, spatialOSExhaustiveBlittableSingular);
                 view.AddComponent(entity, new NotAuthoritative<SpatialOSExhaustiveBlittableSingular>());
+
+                if (view.HasComponent<ComponentRemoved<SpatialOSExhaustiveBlittableSingular>>(entity))
+                {
+                    view.RemoveComponent<ComponentRemoved<SpatialOSExhaustiveBlittableSingular>>(entity);
+                }
+                else if (!view.HasComponent<ComponentAdded<SpatialOSExhaustiveBlittableSingular>>(entity))
+                {
+                    var addedTag = new ComponentAdded<SpatialOSExhaustiveBlittableSingular>();
+                    view.AddComponent(entity, addedTag);
+                }
             }
 
             public void OnComponentUpdate(ComponentUpdateOp<global::Improbable.TestSchema.ExhaustiveBlittableSingular> op)
@@ -265,6 +277,16 @@ namespace Generated.Improbable.TestSchema
                 }
 
                 view.RemoveComponent<SpatialOSExhaustiveBlittableSingular>(entity);
+
+                if (view.HasComponent<ComponentAdded<SpatialOSExhaustiveBlittableSingular>>(entity))
+                {
+                    view.RemoveComponent<ComponentAdded<SpatialOSExhaustiveBlittableSingular>>(entity);
+                }
+                else if (!view.HasComponent<ComponentRemoved<SpatialOSExhaustiveBlittableSingular>>(entity))
+                {
+                    var removedTag = new ComponentRemoved<SpatialOSExhaustiveBlittableSingular>();
+                    view.AddComponent(entity, removedTag);
+                }
             }
 
             public void OnAuthorityChange(AuthorityChangeOp op)
@@ -319,7 +341,11 @@ namespace Generated.Improbable.TestSchema
             public override void CleanUpComponents(ref EntityCommandBuffer entityCommandBuffer)
             {
                 RemoveComponents(ref entityCommandBuffer, AuthsPool, groupIndex: 0);
-                RemoveComponents(ref entityCommandBuffer, UpdatesPool, groupIndex: 1);
+                RemoveComponents<ComponentAdded<SpatialOSExhaustiveBlittableSingular>>(ref entityCommandBuffer, groupIndex: 1);
+                RemoveComponents<ComponentRemoved<SpatialOSExhaustiveBlittableSingular>>(ref entityCommandBuffer, groupIndex: 2);
+                RemoveComponents(ref entityCommandBuffer, UpdatesPool, groupIndex: 3);
+                
+                
             }
 
             public override void SendCommands(Connection connection)

--- a/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/ExhaustiveMapKeyTranslation.cs
+++ b/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/ExhaustiveMapKeyTranslation.cs
@@ -28,6 +28,8 @@ namespace Generated.Improbable.TestSchema
             private static readonly ComponentType[] cleanUpComponentTypes = 
             { 
                 typeof(AuthoritiesChanged<SpatialOSExhaustiveMapKey>),
+                typeof(ComponentAdded<SpatialOSExhaustiveMapKey>),
+                typeof(ComponentRemoved<SpatialOSExhaustiveMapKey>),
                 typeof(ComponentsUpdated<SpatialOSExhaustiveMapKey.Update>), 
             };
 
@@ -89,6 +91,16 @@ namespace Generated.Improbable.TestSchema
 
                 view.SetComponentObject(entity, spatialOSExhaustiveMapKey);
                 view.AddComponent(entity, new NotAuthoritative<SpatialOSExhaustiveMapKey>());
+
+                if (view.HasComponent<ComponentRemoved<SpatialOSExhaustiveMapKey>>(entity))
+                {
+                    view.RemoveComponent<ComponentRemoved<SpatialOSExhaustiveMapKey>>(entity);
+                }
+                else if (!view.HasComponent<ComponentAdded<SpatialOSExhaustiveMapKey>>(entity))
+                {
+                    var addedTag = new ComponentAdded<SpatialOSExhaustiveMapKey>();
+                    view.AddComponent(entity, addedTag);
+                }
             }
 
             public void OnComponentUpdate(ComponentUpdateOp<global::Improbable.TestSchema.ExhaustiveMapKey> op)
@@ -265,6 +277,16 @@ namespace Generated.Improbable.TestSchema
                 }
 
                 view.RemoveComponent<SpatialOSExhaustiveMapKey>(entity);
+
+                if (view.HasComponent<ComponentAdded<SpatialOSExhaustiveMapKey>>(entity))
+                {
+                    view.RemoveComponent<ComponentAdded<SpatialOSExhaustiveMapKey>>(entity);
+                }
+                else if (!view.HasComponent<ComponentRemoved<SpatialOSExhaustiveMapKey>>(entity))
+                {
+                    var removedTag = new ComponentRemoved<SpatialOSExhaustiveMapKey>();
+                    view.AddComponent(entity, removedTag);
+                }
             }
 
             public void OnAuthorityChange(AuthorityChangeOp op)
@@ -319,7 +341,11 @@ namespace Generated.Improbable.TestSchema
             public override void CleanUpComponents(ref EntityCommandBuffer entityCommandBuffer)
             {
                 RemoveComponents(ref entityCommandBuffer, AuthsPool, groupIndex: 0);
-                RemoveComponents(ref entityCommandBuffer, UpdatesPool, groupIndex: 1);
+                RemoveComponents<ComponentAdded<SpatialOSExhaustiveMapKey>>(ref entityCommandBuffer, groupIndex: 1);
+                RemoveComponents<ComponentRemoved<SpatialOSExhaustiveMapKey>>(ref entityCommandBuffer, groupIndex: 2);
+                RemoveComponents(ref entityCommandBuffer, UpdatesPool, groupIndex: 3);
+                
+                
             }
 
             public override void SendCommands(Connection connection)

--- a/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/ExhaustiveMapKeyTranslation.cs
+++ b/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/ExhaustiveMapKeyTranslation.cs
@@ -98,8 +98,11 @@ namespace Generated.Improbable.TestSchema
                 }
                 else if (!view.HasComponent<ComponentAdded<SpatialOSExhaustiveMapKey>>(entity))
                 {
-                    var addedTag = new ComponentAdded<SpatialOSExhaustiveMapKey>();
-                    view.AddComponent(entity, addedTag);
+                    view.AddComponent(entity, new ComponentAdded<SpatialOSExhaustiveMapKey>());
+                }
+                else
+                {
+                    Debug.LogErrorFormat(TranslationErrors.ComponentAlreadyAdded, typeof(SpatialOSExhaustiveMapKey).Name, op.EntityId.Id);
                 }
             }
 
@@ -284,8 +287,11 @@ namespace Generated.Improbable.TestSchema
                 }
                 else if (!view.HasComponent<ComponentRemoved<SpatialOSExhaustiveMapKey>>(entity))
                 {
-                    var removedTag = new ComponentRemoved<SpatialOSExhaustiveMapKey>();
-                    view.AddComponent(entity, removedTag);
+                    view.AddComponent(entity, new ComponentRemoved<SpatialOSExhaustiveMapKey>());
+                }
+                else
+                {
+                    Debug.LogErrorFormat(TranslationErrors.ComponentAlreadyRemoved, typeof(SpatialOSExhaustiveMapKey).Name, op.EntityId.Id);
                 }
             }
 

--- a/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/ExhaustiveMapValueTranslation.cs
+++ b/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/ExhaustiveMapValueTranslation.cs
@@ -28,6 +28,8 @@ namespace Generated.Improbable.TestSchema
             private static readonly ComponentType[] cleanUpComponentTypes = 
             { 
                 typeof(AuthoritiesChanged<SpatialOSExhaustiveMapValue>),
+                typeof(ComponentAdded<SpatialOSExhaustiveMapValue>),
+                typeof(ComponentRemoved<SpatialOSExhaustiveMapValue>),
                 typeof(ComponentsUpdated<SpatialOSExhaustiveMapValue.Update>), 
             };
 
@@ -89,6 +91,16 @@ namespace Generated.Improbable.TestSchema
 
                 view.SetComponentObject(entity, spatialOSExhaustiveMapValue);
                 view.AddComponent(entity, new NotAuthoritative<SpatialOSExhaustiveMapValue>());
+
+                if (view.HasComponent<ComponentRemoved<SpatialOSExhaustiveMapValue>>(entity))
+                {
+                    view.RemoveComponent<ComponentRemoved<SpatialOSExhaustiveMapValue>>(entity);
+                }
+                else if (!view.HasComponent<ComponentAdded<SpatialOSExhaustiveMapValue>>(entity))
+                {
+                    var addedTag = new ComponentAdded<SpatialOSExhaustiveMapValue>();
+                    view.AddComponent(entity, addedTag);
+                }
             }
 
             public void OnComponentUpdate(ComponentUpdateOp<global::Improbable.TestSchema.ExhaustiveMapValue> op)
@@ -265,6 +277,16 @@ namespace Generated.Improbable.TestSchema
                 }
 
                 view.RemoveComponent<SpatialOSExhaustiveMapValue>(entity);
+
+                if (view.HasComponent<ComponentAdded<SpatialOSExhaustiveMapValue>>(entity))
+                {
+                    view.RemoveComponent<ComponentAdded<SpatialOSExhaustiveMapValue>>(entity);
+                }
+                else if (!view.HasComponent<ComponentRemoved<SpatialOSExhaustiveMapValue>>(entity))
+                {
+                    var removedTag = new ComponentRemoved<SpatialOSExhaustiveMapValue>();
+                    view.AddComponent(entity, removedTag);
+                }
             }
 
             public void OnAuthorityChange(AuthorityChangeOp op)
@@ -319,7 +341,11 @@ namespace Generated.Improbable.TestSchema
             public override void CleanUpComponents(ref EntityCommandBuffer entityCommandBuffer)
             {
                 RemoveComponents(ref entityCommandBuffer, AuthsPool, groupIndex: 0);
-                RemoveComponents(ref entityCommandBuffer, UpdatesPool, groupIndex: 1);
+                RemoveComponents<ComponentAdded<SpatialOSExhaustiveMapValue>>(ref entityCommandBuffer, groupIndex: 1);
+                RemoveComponents<ComponentRemoved<SpatialOSExhaustiveMapValue>>(ref entityCommandBuffer, groupIndex: 2);
+                RemoveComponents(ref entityCommandBuffer, UpdatesPool, groupIndex: 3);
+                
+                
             }
 
             public override void SendCommands(Connection connection)

--- a/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/ExhaustiveMapValueTranslation.cs
+++ b/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/ExhaustiveMapValueTranslation.cs
@@ -98,8 +98,11 @@ namespace Generated.Improbable.TestSchema
                 }
                 else if (!view.HasComponent<ComponentAdded<SpatialOSExhaustiveMapValue>>(entity))
                 {
-                    var addedTag = new ComponentAdded<SpatialOSExhaustiveMapValue>();
-                    view.AddComponent(entity, addedTag);
+                    view.AddComponent(entity, new ComponentAdded<SpatialOSExhaustiveMapValue>());
+                }
+                else
+                {
+                    Debug.LogErrorFormat(TranslationErrors.ComponentAlreadyAdded, typeof(SpatialOSExhaustiveMapValue).Name, op.EntityId.Id);
                 }
             }
 
@@ -284,8 +287,11 @@ namespace Generated.Improbable.TestSchema
                 }
                 else if (!view.HasComponent<ComponentRemoved<SpatialOSExhaustiveMapValue>>(entity))
                 {
-                    var removedTag = new ComponentRemoved<SpatialOSExhaustiveMapValue>();
-                    view.AddComponent(entity, removedTag);
+                    view.AddComponent(entity, new ComponentRemoved<SpatialOSExhaustiveMapValue>());
+                }
+                else
+                {
+                    Debug.LogErrorFormat(TranslationErrors.ComponentAlreadyRemoved, typeof(SpatialOSExhaustiveMapValue).Name, op.EntityId.Id);
                 }
             }
 

--- a/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/ExhaustiveOptionalTranslation.cs
+++ b/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/ExhaustiveOptionalTranslation.cs
@@ -28,6 +28,8 @@ namespace Generated.Improbable.TestSchema
             private static readonly ComponentType[] cleanUpComponentTypes = 
             { 
                 typeof(AuthoritiesChanged<SpatialOSExhaustiveOptional>),
+                typeof(ComponentAdded<SpatialOSExhaustiveOptional>),
+                typeof(ComponentRemoved<SpatialOSExhaustiveOptional>),
                 typeof(ComponentsUpdated<SpatialOSExhaustiveOptional.Update>), 
             };
 
@@ -88,6 +90,16 @@ namespace Generated.Improbable.TestSchema
 
                 view.SetComponentObject(entity, spatialOSExhaustiveOptional);
                 view.AddComponent(entity, new NotAuthoritative<SpatialOSExhaustiveOptional>());
+
+                if (view.HasComponent<ComponentRemoved<SpatialOSExhaustiveOptional>>(entity))
+                {
+                    view.RemoveComponent<ComponentRemoved<SpatialOSExhaustiveOptional>>(entity);
+                }
+                else if (!view.HasComponent<ComponentAdded<SpatialOSExhaustiveOptional>>(entity))
+                {
+                    var addedTag = new ComponentAdded<SpatialOSExhaustiveOptional>();
+                    view.AddComponent(entity, addedTag);
+                }
             }
 
             public void OnComponentUpdate(ComponentUpdateOp<global::Improbable.TestSchema.ExhaustiveOptional> op)
@@ -255,6 +267,16 @@ namespace Generated.Improbable.TestSchema
                 }
 
                 view.RemoveComponent<SpatialOSExhaustiveOptional>(entity);
+
+                if (view.HasComponent<ComponentAdded<SpatialOSExhaustiveOptional>>(entity))
+                {
+                    view.RemoveComponent<ComponentAdded<SpatialOSExhaustiveOptional>>(entity);
+                }
+                else if (!view.HasComponent<ComponentRemoved<SpatialOSExhaustiveOptional>>(entity))
+                {
+                    var removedTag = new ComponentRemoved<SpatialOSExhaustiveOptional>();
+                    view.AddComponent(entity, removedTag);
+                }
             }
 
             public void OnAuthorityChange(AuthorityChangeOp op)
@@ -308,7 +330,11 @@ namespace Generated.Improbable.TestSchema
             public override void CleanUpComponents(ref EntityCommandBuffer entityCommandBuffer)
             {
                 RemoveComponents(ref entityCommandBuffer, AuthsPool, groupIndex: 0);
-                RemoveComponents(ref entityCommandBuffer, UpdatesPool, groupIndex: 1);
+                RemoveComponents<ComponentAdded<SpatialOSExhaustiveOptional>>(ref entityCommandBuffer, groupIndex: 1);
+                RemoveComponents<ComponentRemoved<SpatialOSExhaustiveOptional>>(ref entityCommandBuffer, groupIndex: 2);
+                RemoveComponents(ref entityCommandBuffer, UpdatesPool, groupIndex: 3);
+                
+                
             }
 
             public override void SendCommands(Connection connection)

--- a/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/ExhaustiveOptionalTranslation.cs
+++ b/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/ExhaustiveOptionalTranslation.cs
@@ -97,8 +97,11 @@ namespace Generated.Improbable.TestSchema
                 }
                 else if (!view.HasComponent<ComponentAdded<SpatialOSExhaustiveOptional>>(entity))
                 {
-                    var addedTag = new ComponentAdded<SpatialOSExhaustiveOptional>();
-                    view.AddComponent(entity, addedTag);
+                    view.AddComponent(entity, new ComponentAdded<SpatialOSExhaustiveOptional>());
+                }
+                else
+                {
+                    Debug.LogErrorFormat(TranslationErrors.ComponentAlreadyAdded, typeof(SpatialOSExhaustiveOptional).Name, op.EntityId.Id);
                 }
             }
 
@@ -274,8 +277,11 @@ namespace Generated.Improbable.TestSchema
                 }
                 else if (!view.HasComponent<ComponentRemoved<SpatialOSExhaustiveOptional>>(entity))
                 {
-                    var removedTag = new ComponentRemoved<SpatialOSExhaustiveOptional>();
-                    view.AddComponent(entity, removedTag);
+                    view.AddComponent(entity, new ComponentRemoved<SpatialOSExhaustiveOptional>());
+                }
+                else
+                {
+                    Debug.LogErrorFormat(TranslationErrors.ComponentAlreadyRemoved, typeof(SpatialOSExhaustiveOptional).Name, op.EntityId.Id);
                 }
             }
 

--- a/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/ExhaustiveRepeatedTranslation.cs
+++ b/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/ExhaustiveRepeatedTranslation.cs
@@ -98,8 +98,11 @@ namespace Generated.Improbable.TestSchema
                 }
                 else if (!view.HasComponent<ComponentAdded<SpatialOSExhaustiveRepeated>>(entity))
                 {
-                    var addedTag = new ComponentAdded<SpatialOSExhaustiveRepeated>();
-                    view.AddComponent(entity, addedTag);
+                    view.AddComponent(entity, new ComponentAdded<SpatialOSExhaustiveRepeated>());
+                }
+                else
+                {
+                    Debug.LogErrorFormat(TranslationErrors.ComponentAlreadyAdded, typeof(SpatialOSExhaustiveRepeated).Name, op.EntityId.Id);
                 }
             }
 
@@ -284,8 +287,11 @@ namespace Generated.Improbable.TestSchema
                 }
                 else if (!view.HasComponent<ComponentRemoved<SpatialOSExhaustiveRepeated>>(entity))
                 {
-                    var removedTag = new ComponentRemoved<SpatialOSExhaustiveRepeated>();
-                    view.AddComponent(entity, removedTag);
+                    view.AddComponent(entity, new ComponentRemoved<SpatialOSExhaustiveRepeated>());
+                }
+                else
+                {
+                    Debug.LogErrorFormat(TranslationErrors.ComponentAlreadyRemoved, typeof(SpatialOSExhaustiveRepeated).Name, op.EntityId.Id);
                 }
             }
 

--- a/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/ExhaustiveRepeatedTranslation.cs
+++ b/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/ExhaustiveRepeatedTranslation.cs
@@ -28,6 +28,8 @@ namespace Generated.Improbable.TestSchema
             private static readonly ComponentType[] cleanUpComponentTypes = 
             { 
                 typeof(AuthoritiesChanged<SpatialOSExhaustiveRepeated>),
+                typeof(ComponentAdded<SpatialOSExhaustiveRepeated>),
+                typeof(ComponentRemoved<SpatialOSExhaustiveRepeated>),
                 typeof(ComponentsUpdated<SpatialOSExhaustiveRepeated.Update>), 
             };
 
@@ -89,6 +91,16 @@ namespace Generated.Improbable.TestSchema
 
                 view.SetComponentObject(entity, spatialOSExhaustiveRepeated);
                 view.AddComponent(entity, new NotAuthoritative<SpatialOSExhaustiveRepeated>());
+
+                if (view.HasComponent<ComponentRemoved<SpatialOSExhaustiveRepeated>>(entity))
+                {
+                    view.RemoveComponent<ComponentRemoved<SpatialOSExhaustiveRepeated>>(entity);
+                }
+                else if (!view.HasComponent<ComponentAdded<SpatialOSExhaustiveRepeated>>(entity))
+                {
+                    var addedTag = new ComponentAdded<SpatialOSExhaustiveRepeated>();
+                    view.AddComponent(entity, addedTag);
+                }
             }
 
             public void OnComponentUpdate(ComponentUpdateOp<global::Improbable.TestSchema.ExhaustiveRepeated> op)
@@ -265,6 +277,16 @@ namespace Generated.Improbable.TestSchema
                 }
 
                 view.RemoveComponent<SpatialOSExhaustiveRepeated>(entity);
+
+                if (view.HasComponent<ComponentAdded<SpatialOSExhaustiveRepeated>>(entity))
+                {
+                    view.RemoveComponent<ComponentAdded<SpatialOSExhaustiveRepeated>>(entity);
+                }
+                else if (!view.HasComponent<ComponentRemoved<SpatialOSExhaustiveRepeated>>(entity))
+                {
+                    var removedTag = new ComponentRemoved<SpatialOSExhaustiveRepeated>();
+                    view.AddComponent(entity, removedTag);
+                }
             }
 
             public void OnAuthorityChange(AuthorityChangeOp op)
@@ -319,7 +341,11 @@ namespace Generated.Improbable.TestSchema
             public override void CleanUpComponents(ref EntityCommandBuffer entityCommandBuffer)
             {
                 RemoveComponents(ref entityCommandBuffer, AuthsPool, groupIndex: 0);
-                RemoveComponents(ref entityCommandBuffer, UpdatesPool, groupIndex: 1);
+                RemoveComponents<ComponentAdded<SpatialOSExhaustiveRepeated>>(ref entityCommandBuffer, groupIndex: 1);
+                RemoveComponents<ComponentRemoved<SpatialOSExhaustiveRepeated>>(ref entityCommandBuffer, groupIndex: 2);
+                RemoveComponents(ref entityCommandBuffer, UpdatesPool, groupIndex: 3);
+                
+                
             }
 
             public override void SendCommands(Connection connection)

--- a/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/ExhaustiveSingularTranslation.cs
+++ b/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/ExhaustiveSingularTranslation.cs
@@ -99,8 +99,11 @@ namespace Generated.Improbable.TestSchema
                 }
                 else if (!view.HasComponent<ComponentAdded<SpatialOSExhaustiveSingular>>(entity))
                 {
-                    var addedTag = new ComponentAdded<SpatialOSExhaustiveSingular>();
-                    view.AddComponent(entity, addedTag);
+                    view.AddComponent(entity, new ComponentAdded<SpatialOSExhaustiveSingular>());
+                }
+                else
+                {
+                    Debug.LogErrorFormat(TranslationErrors.ComponentAlreadyAdded, typeof(SpatialOSExhaustiveSingular).Name, op.EntityId.Id);
                 }
             }
 
@@ -294,8 +297,11 @@ namespace Generated.Improbable.TestSchema
                 }
                 else if (!view.HasComponent<ComponentRemoved<SpatialOSExhaustiveSingular>>(entity))
                 {
-                    var removedTag = new ComponentRemoved<SpatialOSExhaustiveSingular>();
-                    view.AddComponent(entity, removedTag);
+                    view.AddComponent(entity, new ComponentRemoved<SpatialOSExhaustiveSingular>());
+                }
+                else
+                {
+                    Debug.LogErrorFormat(TranslationErrors.ComponentAlreadyRemoved, typeof(SpatialOSExhaustiveSingular).Name, op.EntityId.Id);
                 }
             }
 

--- a/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/ExhaustiveSingularTranslation.cs
+++ b/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/ExhaustiveSingularTranslation.cs
@@ -28,6 +28,8 @@ namespace Generated.Improbable.TestSchema
             private static readonly ComponentType[] cleanUpComponentTypes = 
             { 
                 typeof(AuthoritiesChanged<SpatialOSExhaustiveSingular>),
+                typeof(ComponentAdded<SpatialOSExhaustiveSingular>),
+                typeof(ComponentRemoved<SpatialOSExhaustiveSingular>),
                 typeof(ComponentsUpdated<SpatialOSExhaustiveSingular.Update>), 
             };
 
@@ -90,6 +92,16 @@ namespace Generated.Improbable.TestSchema
 
                 view.SetComponentObject(entity, spatialOSExhaustiveSingular);
                 view.AddComponent(entity, new NotAuthoritative<SpatialOSExhaustiveSingular>());
+
+                if (view.HasComponent<ComponentRemoved<SpatialOSExhaustiveSingular>>(entity))
+                {
+                    view.RemoveComponent<ComponentRemoved<SpatialOSExhaustiveSingular>>(entity);
+                }
+                else if (!view.HasComponent<ComponentAdded<SpatialOSExhaustiveSingular>>(entity))
+                {
+                    var addedTag = new ComponentAdded<SpatialOSExhaustiveSingular>();
+                    view.AddComponent(entity, addedTag);
+                }
             }
 
             public void OnComponentUpdate(ComponentUpdateOp<global::Improbable.TestSchema.ExhaustiveSingular> op)
@@ -275,6 +287,16 @@ namespace Generated.Improbable.TestSchema
                 }
 
                 view.RemoveComponent<SpatialOSExhaustiveSingular>(entity);
+
+                if (view.HasComponent<ComponentAdded<SpatialOSExhaustiveSingular>>(entity))
+                {
+                    view.RemoveComponent<ComponentAdded<SpatialOSExhaustiveSingular>>(entity);
+                }
+                else if (!view.HasComponent<ComponentRemoved<SpatialOSExhaustiveSingular>>(entity))
+                {
+                    var removedTag = new ComponentRemoved<SpatialOSExhaustiveSingular>();
+                    view.AddComponent(entity, removedTag);
+                }
             }
 
             public void OnAuthorityChange(AuthorityChangeOp op)
@@ -330,7 +352,11 @@ namespace Generated.Improbable.TestSchema
             public override void CleanUpComponents(ref EntityCommandBuffer entityCommandBuffer)
             {
                 RemoveComponents(ref entityCommandBuffer, AuthsPool, groupIndex: 0);
-                RemoveComponents(ref entityCommandBuffer, UpdatesPool, groupIndex: 1);
+                RemoveComponents<ComponentAdded<SpatialOSExhaustiveSingular>>(ref entityCommandBuffer, groupIndex: 1);
+                RemoveComponents<ComponentRemoved<SpatialOSExhaustiveSingular>>(ref entityCommandBuffer, groupIndex: 2);
+                RemoveComponents(ref entityCommandBuffer, UpdatesPool, groupIndex: 3);
+                
+                
             }
 
             public override void SendCommands(Connection connection)

--- a/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/NestedComponentTranslation.cs
+++ b/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/NestedComponentTranslation.cs
@@ -84,8 +84,11 @@ namespace Generated.Improbable.TestSchema
                 }
                 else if (!view.HasComponent<ComponentAdded<SpatialOSNestedComponent>>(entity))
                 {
-                    var addedTag = new ComponentAdded<SpatialOSNestedComponent>();
-                    view.AddComponent(entity, addedTag);
+                    view.AddComponent(entity, new ComponentAdded<SpatialOSNestedComponent>());
+                }
+                else
+                {
+                    Debug.LogErrorFormat(TranslationErrors.ComponentAlreadyAdded, typeof(SpatialOSNestedComponent).Name, op.EntityId.Id);
                 }
             }
 
@@ -144,8 +147,11 @@ namespace Generated.Improbable.TestSchema
                 }
                 else if (!view.HasComponent<ComponentRemoved<SpatialOSNestedComponent>>(entity))
                 {
-                    var removedTag = new ComponentRemoved<SpatialOSNestedComponent>();
-                    view.AddComponent(entity, removedTag);
+                    view.AddComponent(entity, new ComponentRemoved<SpatialOSNestedComponent>());
+                }
+                else
+                {
+                    Debug.LogErrorFormat(TranslationErrors.ComponentAlreadyRemoved, typeof(SpatialOSNestedComponent).Name, op.EntityId.Id);
                 }
             }
 

--- a/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/NestedComponentTranslation.cs
+++ b/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/NestedComponentTranslation.cs
@@ -28,6 +28,8 @@ namespace Generated.Improbable.TestSchema
             private static readonly ComponentType[] cleanUpComponentTypes = 
             { 
                 typeof(AuthoritiesChanged<SpatialOSNestedComponent>),
+                typeof(ComponentAdded<SpatialOSNestedComponent>),
+                typeof(ComponentRemoved<SpatialOSNestedComponent>),
                 typeof(ComponentsUpdated<SpatialOSNestedComponent.Update>), 
             };
 
@@ -75,6 +77,16 @@ namespace Generated.Improbable.TestSchema
 
                 view.AddComponent(entity, spatialOSNestedComponent);
                 view.AddComponent(entity, new NotAuthoritative<SpatialOSNestedComponent>());
+
+                if (view.HasComponent<ComponentRemoved<SpatialOSNestedComponent>>(entity))
+                {
+                    view.RemoveComponent<ComponentRemoved<SpatialOSNestedComponent>>(entity);
+                }
+                else if (!view.HasComponent<ComponentAdded<SpatialOSNestedComponent>>(entity))
+                {
+                    var addedTag = new ComponentAdded<SpatialOSNestedComponent>();
+                    view.AddComponent(entity, addedTag);
+                }
             }
 
             public void OnComponentUpdate(ComponentUpdateOp<global::Improbable.TestSchema.NestedComponent> op)
@@ -125,6 +137,16 @@ namespace Generated.Improbable.TestSchema
                 }
 
                 view.RemoveComponent<SpatialOSNestedComponent>(entity);
+
+                if (view.HasComponent<ComponentAdded<SpatialOSNestedComponent>>(entity))
+                {
+                    view.RemoveComponent<ComponentAdded<SpatialOSNestedComponent>>(entity);
+                }
+                else if (!view.HasComponent<ComponentRemoved<SpatialOSNestedComponent>>(entity))
+                {
+                    var removedTag = new ComponentRemoved<SpatialOSNestedComponent>();
+                    view.AddComponent(entity, removedTag);
+                }
             }
 
             public void OnAuthorityChange(AuthorityChangeOp op)
@@ -165,7 +187,11 @@ namespace Generated.Improbable.TestSchema
             public override void CleanUpComponents(ref EntityCommandBuffer entityCommandBuffer)
             {
                 RemoveComponents(ref entityCommandBuffer, AuthsPool, groupIndex: 0);
-                RemoveComponents(ref entityCommandBuffer, UpdatesPool, groupIndex: 1);
+                RemoveComponents<ComponentAdded<SpatialOSNestedComponent>>(ref entityCommandBuffer, groupIndex: 1);
+                RemoveComponents<ComponentRemoved<SpatialOSNestedComponent>>(ref entityCommandBuffer, groupIndex: 2);
+                RemoveComponents(ref entityCommandBuffer, UpdatesPool, groupIndex: 3);
+                
+                
             }
 
             public override void SendCommands(Connection connection)

--- a/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/blittable/BlittableComponentTranslation.cs
+++ b/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/blittable/BlittableComponentTranslation.cs
@@ -28,6 +28,8 @@ namespace Generated.Improbable.TestSchema.Blittable
             private static readonly ComponentType[] cleanUpComponentTypes = 
             { 
                 typeof(AuthoritiesChanged<SpatialOSBlittableComponent>),
+                typeof(ComponentAdded<SpatialOSBlittableComponent>),
+                typeof(ComponentRemoved<SpatialOSBlittableComponent>),
                 typeof(ComponentsUpdated<SpatialOSBlittableComponent.Update>), 
                 typeof(CommandRequests<FirstCommand.Request>), typeof(CommandResponses<FirstCommand.Response>),
                 typeof(CommandRequests<SecondCommand.Request>), typeof(CommandResponses<SecondCommand.Response>),
@@ -123,6 +125,16 @@ namespace Generated.Improbable.TestSchema.Blittable
 
                 view.AddComponent(entity, spatialOSBlittableComponent);
                 view.AddComponent(entity, new NotAuthoritative<SpatialOSBlittableComponent>());
+
+                if (view.HasComponent<ComponentRemoved<SpatialOSBlittableComponent>>(entity))
+                {
+                    view.RemoveComponent<ComponentRemoved<SpatialOSBlittableComponent>>(entity);
+                }
+                else if (!view.HasComponent<ComponentAdded<SpatialOSBlittableComponent>>(entity))
+                {
+                    var addedTag = new ComponentAdded<SpatialOSBlittableComponent>();
+                    view.AddComponent(entity, addedTag);
+                }
             }
 
             public void OnComponentUpdate(ComponentUpdateOp<global::Improbable.TestSchema.Blittable.BlittableComponent> op)
@@ -229,6 +241,16 @@ namespace Generated.Improbable.TestSchema.Blittable
                 }
 
                 view.RemoveComponent<SpatialOSBlittableComponent>(entity);
+
+                if (view.HasComponent<ComponentAdded<SpatialOSBlittableComponent>>(entity))
+                {
+                    view.RemoveComponent<ComponentAdded<SpatialOSBlittableComponent>>(entity);
+                }
+                else if (!view.HasComponent<ComponentRemoved<SpatialOSBlittableComponent>>(entity))
+                {
+                    var removedTag = new ComponentRemoved<SpatialOSBlittableComponent>();
+                    view.AddComponent(entity, removedTag);
+                }
             }
 
             public void OnAuthorityChange(AuthorityChangeOp op)
@@ -301,13 +323,17 @@ namespace Generated.Improbable.TestSchema.Blittable
             public override void CleanUpComponents(ref EntityCommandBuffer entityCommandBuffer)
             {
                 RemoveComponents(ref entityCommandBuffer, AuthsPool, groupIndex: 0);
-                RemoveComponents(ref entityCommandBuffer, UpdatesPool, groupIndex: 1);
-                RemoveComponents(ref entityCommandBuffer, FirstCommandRequestPool, groupIndex: 2);
-                RemoveComponents(ref entityCommandBuffer, FirstCommandResponsePool, groupIndex: 3);
-                RemoveComponents(ref entityCommandBuffer, SecondCommandRequestPool, groupIndex: 4);
-                RemoveComponents(ref entityCommandBuffer, SecondCommandResponsePool, groupIndex: 5);
-                RemoveComponents(ref entityCommandBuffer, FirstEventEventPool, groupIndex: 6);
-                RemoveComponents(ref entityCommandBuffer, SecondEventEventPool, groupIndex: 7);
+                RemoveComponents<ComponentAdded<SpatialOSBlittableComponent>>(ref entityCommandBuffer, groupIndex: 1);
+                RemoveComponents<ComponentRemoved<SpatialOSBlittableComponent>>(ref entityCommandBuffer, groupIndex: 2);
+                RemoveComponents(ref entityCommandBuffer, UpdatesPool, groupIndex: 3);
+                
+                RemoveComponents(ref entityCommandBuffer, FirstCommandRequestPool, groupIndex: 4);
+                RemoveComponents(ref entityCommandBuffer, FirstCommandResponsePool, groupIndex: 5);
+                RemoveComponents(ref entityCommandBuffer, SecondCommandRequestPool, groupIndex: 6);
+                RemoveComponents(ref entityCommandBuffer, SecondCommandResponsePool, groupIndex: 7);
+                RemoveComponents(ref entityCommandBuffer, FirstEventEventPool, groupIndex: 8);
+                RemoveComponents(ref entityCommandBuffer, SecondEventEventPool, groupIndex: 9);
+                
             }
 
             public void OnCommandRequestFirstCommand(CommandRequestOp<global::Improbable.TestSchema.Blittable.BlittableComponent.Commands.FirstCommand> op)

--- a/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/blittable/BlittableComponentTranslation.cs
+++ b/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/blittable/BlittableComponentTranslation.cs
@@ -132,8 +132,11 @@ namespace Generated.Improbable.TestSchema.Blittable
                 }
                 else if (!view.HasComponent<ComponentAdded<SpatialOSBlittableComponent>>(entity))
                 {
-                    var addedTag = new ComponentAdded<SpatialOSBlittableComponent>();
-                    view.AddComponent(entity, addedTag);
+                    view.AddComponent(entity, new ComponentAdded<SpatialOSBlittableComponent>());
+                }
+                else
+                {
+                    Debug.LogErrorFormat(TranslationErrors.ComponentAlreadyAdded, typeof(SpatialOSBlittableComponent).Name, op.EntityId.Id);
                 }
             }
 
@@ -248,8 +251,11 @@ namespace Generated.Improbable.TestSchema.Blittable
                 }
                 else if (!view.HasComponent<ComponentRemoved<SpatialOSBlittableComponent>>(entity))
                 {
-                    var removedTag = new ComponentRemoved<SpatialOSBlittableComponent>();
-                    view.AddComponent(entity, removedTag);
+                    view.AddComponent(entity, new ComponentRemoved<SpatialOSBlittableComponent>());
+                }
+                else
+                {
+                    Debug.LogErrorFormat(TranslationErrors.ComponentAlreadyRemoved, typeof(SpatialOSBlittableComponent).Name, op.EntityId.Id);
                 }
             }
 

--- a/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/nonblittable/NonBlittableComponentTranslation.cs
+++ b/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/nonblittable/NonBlittableComponentTranslation.cs
@@ -28,6 +28,8 @@ namespace Generated.Improbable.TestSchema.Nonblittable
             private static readonly ComponentType[] cleanUpComponentTypes = 
             { 
                 typeof(AuthoritiesChanged<SpatialOSNonBlittableComponent>),
+                typeof(ComponentAdded<SpatialOSNonBlittableComponent>),
+                typeof(ComponentRemoved<SpatialOSNonBlittableComponent>),
                 typeof(ComponentsUpdated<SpatialOSNonBlittableComponent.Update>), 
                 typeof(CommandRequests<FirstCommand.Request>), typeof(CommandResponses<FirstCommand.Response>),
                 typeof(CommandRequests<SecondCommand.Request>), typeof(CommandResponses<SecondCommand.Response>),
@@ -127,6 +129,16 @@ namespace Generated.Improbable.TestSchema.Nonblittable
 
                 view.SetComponentObject(entity, spatialOSNonBlittableComponent);
                 view.AddComponent(entity, new NotAuthoritative<SpatialOSNonBlittableComponent>());
+
+                if (view.HasComponent<ComponentRemoved<SpatialOSNonBlittableComponent>>(entity))
+                {
+                    view.RemoveComponent<ComponentRemoved<SpatialOSNonBlittableComponent>>(entity);
+                }
+                else if (!view.HasComponent<ComponentAdded<SpatialOSNonBlittableComponent>>(entity))
+                {
+                    var addedTag = new ComponentAdded<SpatialOSNonBlittableComponent>();
+                    view.AddComponent(entity, addedTag);
+                }
             }
 
             public void OnComponentUpdate(ComponentUpdateOp<global::Improbable.TestSchema.Nonblittable.NonBlittableComponent> op)
@@ -269,6 +281,16 @@ namespace Generated.Improbable.TestSchema.Nonblittable
                 }
 
                 view.RemoveComponent<SpatialOSNonBlittableComponent>(entity);
+
+                if (view.HasComponent<ComponentAdded<SpatialOSNonBlittableComponent>>(entity))
+                {
+                    view.RemoveComponent<ComponentAdded<SpatialOSNonBlittableComponent>>(entity);
+                }
+                else if (!view.HasComponent<ComponentRemoved<SpatialOSNonBlittableComponent>>(entity))
+                {
+                    var removedTag = new ComponentRemoved<SpatialOSNonBlittableComponent>();
+                    view.AddComponent(entity, removedTag);
+                }
             }
 
             public void OnAuthorityChange(AuthorityChangeOp op)
@@ -345,13 +367,17 @@ namespace Generated.Improbable.TestSchema.Nonblittable
             public override void CleanUpComponents(ref EntityCommandBuffer entityCommandBuffer)
             {
                 RemoveComponents(ref entityCommandBuffer, AuthsPool, groupIndex: 0);
-                RemoveComponents(ref entityCommandBuffer, UpdatesPool, groupIndex: 1);
-                RemoveComponents(ref entityCommandBuffer, FirstCommandRequestPool, groupIndex: 2);
-                RemoveComponents(ref entityCommandBuffer, FirstCommandResponsePool, groupIndex: 3);
-                RemoveComponents(ref entityCommandBuffer, SecondCommandRequestPool, groupIndex: 4);
-                RemoveComponents(ref entityCommandBuffer, SecondCommandResponsePool, groupIndex: 5);
-                RemoveComponents(ref entityCommandBuffer, FirstEventEventPool, groupIndex: 6);
-                RemoveComponents(ref entityCommandBuffer, SecondEventEventPool, groupIndex: 7);
+                RemoveComponents<ComponentAdded<SpatialOSNonBlittableComponent>>(ref entityCommandBuffer, groupIndex: 1);
+                RemoveComponents<ComponentRemoved<SpatialOSNonBlittableComponent>>(ref entityCommandBuffer, groupIndex: 2);
+                RemoveComponents(ref entityCommandBuffer, UpdatesPool, groupIndex: 3);
+                
+                RemoveComponents(ref entityCommandBuffer, FirstCommandRequestPool, groupIndex: 4);
+                RemoveComponents(ref entityCommandBuffer, FirstCommandResponsePool, groupIndex: 5);
+                RemoveComponents(ref entityCommandBuffer, SecondCommandRequestPool, groupIndex: 6);
+                RemoveComponents(ref entityCommandBuffer, SecondCommandResponsePool, groupIndex: 7);
+                RemoveComponents(ref entityCommandBuffer, FirstEventEventPool, groupIndex: 8);
+                RemoveComponents(ref entityCommandBuffer, SecondEventEventPool, groupIndex: 9);
+                
             }
 
             public void OnCommandRequestFirstCommand(CommandRequestOp<global::Improbable.TestSchema.Nonblittable.NonBlittableComponent.Commands.FirstCommand> op)

--- a/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/nonblittable/NonBlittableComponentTranslation.cs
+++ b/code_generator/End2End/GeneratedDependencies/Generated/improbable/testschema/nonblittable/NonBlittableComponentTranslation.cs
@@ -136,8 +136,11 @@ namespace Generated.Improbable.TestSchema.Nonblittable
                 }
                 else if (!view.HasComponent<ComponentAdded<SpatialOSNonBlittableComponent>>(entity))
                 {
-                    var addedTag = new ComponentAdded<SpatialOSNonBlittableComponent>();
-                    view.AddComponent(entity, addedTag);
+                    view.AddComponent(entity, new ComponentAdded<SpatialOSNonBlittableComponent>());
+                }
+                else
+                {
+                    Debug.LogErrorFormat(TranslationErrors.ComponentAlreadyAdded, typeof(SpatialOSNonBlittableComponent).Name, op.EntityId.Id);
                 }
             }
 
@@ -288,8 +291,11 @@ namespace Generated.Improbable.TestSchema.Nonblittable
                 }
                 else if (!view.HasComponent<ComponentRemoved<SpatialOSNonBlittableComponent>>(entity))
                 {
-                    var removedTag = new ComponentRemoved<SpatialOSNonBlittableComponent>();
-                    view.AddComponent(entity, removedTag);
+                    view.AddComponent(entity, new ComponentRemoved<SpatialOSNonBlittableComponent>());
+                }
+                else
+                {
+                    Debug.LogErrorFormat(TranslationErrors.ComponentAlreadyRemoved, typeof(SpatialOSNonBlittableComponent).Name, op.EntityId.Id);
                 }
             }
 

--- a/code_generator/GdkCodeGenerator/Templates/UnityComponentConversionGenerator.tt
+++ b/code_generator/GdkCodeGenerator/Templates/UnityComponentConversionGenerator.tt
@@ -141,8 +141,11 @@ namespace <#= qualifiedNamespace #>
                 }
                 else if (!view.HasComponent<ComponentAdded<<#= componentDetails.TypeName #>>>(entity))
                 {
-                    var addedTag = new ComponentAdded<<#= componentDetails.TypeName #>>();
-                    view.AddComponent(entity, addedTag);
+                    view.AddComponent(entity, new ComponentAdded<<#= componentDetails.TypeName #>>());
+                }
+                else
+                {
+                    Debug.LogErrorFormat(TranslationErrors.ComponentAlreadyAdded, typeof(<#= componentDetails.TypeName #>).Name, op.EntityId.Id);
                 }
             }
 
@@ -231,8 +234,11 @@ namespace <#= qualifiedNamespace #>
                 }
                 else if (!view.HasComponent<ComponentRemoved<<#= componentDetails.TypeName #>>>(entity))
                 {
-                    var removedTag = new ComponentRemoved<<#= componentDetails.TypeName #>>();
-                    view.AddComponent(entity, removedTag);
+                    view.AddComponent(entity, new ComponentRemoved<<#= componentDetails.TypeName #>>());
+                }
+                else
+                {
+                    Debug.LogErrorFormat(TranslationErrors.ComponentAlreadyRemoved, typeof(<#= componentDetails.TypeName #>).Name, op.EntityId.Id);
                 }
             }
 

--- a/code_generator/GdkCodeGenerator/Templates/UnityComponentConversionGenerator.tt
+++ b/code_generator/GdkCodeGenerator/Templates/UnityComponentConversionGenerator.tt
@@ -35,6 +35,7 @@ namespace <#= qualifiedNamespace #>
             private static readonly ComponentType[] cleanUpComponentTypes = 
             { 
                 typeof(AuthoritiesChanged<<#= componentDetails.TypeName #>>),
+                typeof(ComponentAdded<<#= componentDetails.TypeName #>>),
 <# if (fieldDetailsList.Count > 0) { #>
                 typeof(ComponentsUpdated<<#= componentDetails.TypeName #>.Update>), 
 <# } #>
@@ -132,6 +133,16 @@ namespace <#= qualifiedNamespace #>
                 view.SetComponentObject(entity, <#= componentDetails.CamelCaseTypeName #>);
 <# } #>
                 view.AddComponent(entity, new NotAuthoritative<<#= componentDetails.TypeName #>>());
+
+                if (view.HasComponent<ComponentRemoved<<#= componentDetails.TypeName #>>>(entity))
+                {
+                    view.RemoveComponent<ComponentRemoved<<#= componentDetails.TypeName #>>>(entity);
+                }
+                else if (!view.HasComponent<ComponentAdded<<#= componentDetails.TypeName #>>>(entity))
+                {
+                    var addedTag = new ComponentAdded<<#= componentDetails.TypeName #>>();
+                    view.AddComponent(entity, addedTag);
+                }
             }
 
             public void OnComponentUpdate(ComponentUpdateOp<<#= componentDetails.FullyQualifiedSpatialTypeName #>> op)
@@ -292,16 +303,18 @@ namespace <#= qualifiedNamespace #>
             public override void CleanUpComponents(ref EntityCommandBuffer entityCommandBuffer)
             {
                 RemoveComponents(ref entityCommandBuffer, AuthsPool, groupIndex: 0);
+                RemoveComponents<ComponentAdded<<#= componentDetails.TypeName #>>>(ref entityCommandBuffer, groupIndex: 1);
 <# if (fieldDetailsList.Count > 0) { #>
-                RemoveComponents(ref entityCommandBuffer, UpdatesPool, groupIndex: 1);
+                RemoveComponents(ref entityCommandBuffer, UpdatesPool, groupIndex: 2);
 <# } #>
+                
 <# for(var i = 0; i < commandDetailsList.Count; i++) { #>
-                RemoveComponents(ref entityCommandBuffer, <#= commandDetailsList[i].CommandName #>RequestPool, groupIndex: <#= i * 2 + (fieldDetailsList.Count == 0 ? 1 : 2) #>);
-                RemoveComponents(ref entityCommandBuffer, <#= commandDetailsList[i].CommandName #>ResponsePool, groupIndex: <#= i * 2 + (fieldDetailsList.Count == 0 ? 2 : 3) #>);
+                RemoveComponents(ref entityCommandBuffer, <#= commandDetailsList[i].CommandName #>RequestPool, groupIndex: <#= i * 2 + (fieldDetailsList.Count == 0 ? 2 : 3) #>);
+                RemoveComponents(ref entityCommandBuffer, <#= commandDetailsList[i].CommandName #>ResponsePool, groupIndex: <#= i * 2 + (fieldDetailsList.Count == 0 ? 3 : 4) #>);
 <# } #>
 <# for(var i = 0; i < eventDetailsList.Count; i++) { #>
-                RemoveComponents(ref entityCommandBuffer, <#= eventDetailsList[i].EventName #>EventPool, groupIndex: <#= i + commandDetailsList.Count * 2 + (fieldDetailsList.Count == 0 ? 1 : 2) #>);
-<# } #>
+                RemoveComponents(ref entityCommandBuffer, <#= eventDetailsList[i].EventName #>EventPool, groupIndex: <#= i + commandDetailsList.Count * 2 + (fieldDetailsList.Count == 0 ? 2 : 3) #>);
+<# } #>                
             }
 
 <# foreach (var commandDetails in commandDetailsList) { #>

--- a/code_generator/GdkCodeGenerator/Templates/UnityComponentConversionGenerator.tt
+++ b/code_generator/GdkCodeGenerator/Templates/UnityComponentConversionGenerator.tt
@@ -36,6 +36,7 @@ namespace <#= qualifiedNamespace #>
             { 
                 typeof(AuthoritiesChanged<<#= componentDetails.TypeName #>>),
                 typeof(ComponentAdded<<#= componentDetails.TypeName #>>),
+                typeof(ComponentRemoved<<#= componentDetails.TypeName #>>),
 <# if (fieldDetailsList.Count > 0) { #>
                 typeof(ComponentsUpdated<<#= componentDetails.TypeName #>.Update>), 
 <# } #>
@@ -223,6 +224,16 @@ namespace <#= qualifiedNamespace #>
                 }
 
                 view.RemoveComponent<<#= componentDetails.TypeName #>>(entity);
+
+                if (view.HasComponent<ComponentAdded<<#= componentDetails.TypeName #>>>(entity))
+                {
+                    view.RemoveComponent<ComponentAdded<<#= componentDetails.TypeName #>>>(entity);
+                }
+                else if (!view.HasComponent<ComponentRemoved<<#= componentDetails.TypeName #>>>(entity))
+                {
+                    var removedTag = new ComponentRemoved<<#= componentDetails.TypeName #>>();
+                    view.AddComponent(entity, removedTag);
+                }
             }
 
             public void OnAuthorityChange(AuthorityChangeOp op)
@@ -304,16 +315,17 @@ namespace <#= qualifiedNamespace #>
             {
                 RemoveComponents(ref entityCommandBuffer, AuthsPool, groupIndex: 0);
                 RemoveComponents<ComponentAdded<<#= componentDetails.TypeName #>>>(ref entityCommandBuffer, groupIndex: 1);
+                RemoveComponents<ComponentRemoved<<#= componentDetails.TypeName #>>>(ref entityCommandBuffer, groupIndex: 2);
 <# if (fieldDetailsList.Count > 0) { #>
-                RemoveComponents(ref entityCommandBuffer, UpdatesPool, groupIndex: 2);
+                RemoveComponents(ref entityCommandBuffer, UpdatesPool, groupIndex: 3);
 <# } #>
                 
 <# for(var i = 0; i < commandDetailsList.Count; i++) { #>
-                RemoveComponents(ref entityCommandBuffer, <#= commandDetailsList[i].CommandName #>RequestPool, groupIndex: <#= i * 2 + (fieldDetailsList.Count == 0 ? 2 : 3) #>);
-                RemoveComponents(ref entityCommandBuffer, <#= commandDetailsList[i].CommandName #>ResponsePool, groupIndex: <#= i * 2 + (fieldDetailsList.Count == 0 ? 3 : 4) #>);
+                RemoveComponents(ref entityCommandBuffer, <#= commandDetailsList[i].CommandName #>RequestPool, groupIndex: <#= i * 2 + (fieldDetailsList.Count == 0 ? 3 : 4) #>);
+                RemoveComponents(ref entityCommandBuffer, <#= commandDetailsList[i].CommandName #>ResponsePool, groupIndex: <#= i * 2 + (fieldDetailsList.Count == 0 ? 4 : 5) #>);
 <# } #>
 <# for(var i = 0; i < eventDetailsList.Count; i++) { #>
-                RemoveComponents(ref entityCommandBuffer, <#= eventDetailsList[i].EventName #>EventPool, groupIndex: <#= i + commandDetailsList.Count * 2 + (fieldDetailsList.Count == 0 ? 2 : 3) #>);
+                RemoveComponents(ref entityCommandBuffer, <#= eventDetailsList[i].EventName #>EventPool, groupIndex: <#= i + commandDetailsList.Count * 2 + (fieldDetailsList.Count == 0 ? 3 : 4) #>);
 <# } #>                
             }
 

--- a/docs/content/reactive-components.md
+++ b/docs/content/reactive-components.md
@@ -23,7 +23,14 @@ These are the types of reactive component available:
 4. `CommandRequests`: All received [command](https://docs.improbable.io/reference/13.0/shared/design/commands) requests. See [Commands](commands.md) for information on how this works.
 5. `CommandResponses`: All received [command](https://docs.improbable.io/reference/13.0/shared/design/commands) responses. See [Commands](commands.md) for information on how this works.
 
-Here's an example of a system using a reactive component:
+### Component Lifecycle tags
+
+There are tags for handling the addition and removal of components:
+
+1. `ComponentAdded`: SpatialOS component has been added to the local view of a SpatialOS entity due to checkout of an entity or a change in interest.
+2. `ComponentRemoved`: SpatialOS component has been removed from the local view of a SpatialOS entity due to a change in interest.
+
+### Example of a system using a reactive component
 
 ```csharp
 public class ReactiveSystem : ComponentSystem

--- a/workers/unity/Assets/Gdk/Core/Components/ComponentTranslation.cs
+++ b/workers/unity/Assets/Gdk/Core/Components/ComponentTranslation.cs
@@ -57,6 +57,13 @@ namespace Improbable.Gdk.Core.Components
 
             public const string RequestDoesNotExist =
                 "Cannot find request with ID {0}, response type {1}.";
+                "Cannot find entity {0} locally to receive command response {1}.";
+
+            public const string ComponentAlreadyAdded =
+                "Received ComponentAdded op for {0} on entity {1}, but have already received one.";
+
+            public const string ComponentAlreadyRemoved =
+                "Received ComponentRemoved op for {0} on entity {1}, but have already received one.";
         }
 
         public static readonly Dictionary<uint, ComponentTranslation> HandleToTranslation =

--- a/workers/unity/Assets/Gdk/Core/Components/ComponentTranslation.cs
+++ b/workers/unity/Assets/Gdk/Core/Components/ComponentTranslation.cs
@@ -57,7 +57,6 @@ namespace Improbable.Gdk.Core.Components
 
             public const string RequestDoesNotExist =
                 "Cannot find request with ID {0}, response type {1}.";
-                "Cannot find entity {0} locally to receive command response {1}.";
 
             public const string ComponentAlreadyAdded =
                 "Received ComponentAdded op for {0} on entity {1}, but have already received one.";

--- a/workers/unity/Assets/Gdk/Core/Components/ReactiveComponents.cs
+++ b/workers/unity/Assets/Gdk/Core/Components/ReactiveComponents.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using Improbable.Worker;
+using Unity.Entities;
 using UnityEngine;
 
 namespace Improbable.Gdk.Core
@@ -26,6 +27,14 @@ namespace Improbable.Gdk.Core
     }
 
     public class AuthoritiesChanged<T> : MessagesReceived<Authority>
+    {
+    }
+
+    public struct ComponentAdded<T> : IComponentData
+    {
+    }
+
+    public struct ComponentRemoved<T> : IComponentData
     {
     }
 }

--- a/workers/unity/Assets/Gdk/Core/Components/ReactiveComponents.cs
+++ b/workers/unity/Assets/Gdk/Core/Components/ReactiveComponents.cs
@@ -30,11 +30,11 @@ namespace Improbable.Gdk.Core
     {
     }
 
-    public struct ComponentAdded<T> : IComponentData
+    public struct ComponentAdded<T> : IComponentData where T : ISpatialComponentData
     {
     }
 
-    public struct ComponentRemoved<T> : IComponentData
+    public struct ComponentRemoved<T> : IComponentData where T : ISpatialComponentData
     {
     }
 }


### PR DESCRIPTION
#### Description
Created 2 new tag components, (ComponentAdded<T>, ComponentRemoved<T>) that are added to ECS entities for one frame when the SpatialOSComponent T is added / removed.
#### Tests
Tested locally by injecting the ComponentAdded tag into a system and verifying they are present during initial checkout for a single frame.
Used Connection.SendComponentInterest on UnityClient to unregister interest of a SpatialOSComponent and verified the 
#### Documentation
Updated reactive-components.md
#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.