### PR TITLE
UTY-581: Bugfix Support UNITY_HOME with spaces in ci/lint.sh

### DIFF
--- a/ci/lint.sh
+++ b/ci/lint.sh
@@ -27,7 +27,7 @@ if [ ! -f workers/unity/Assembly-CSharp.csproj ]; then
     markStartOfBlock "Generating Solution Files"
     PROJECT_DIR="$(pwd)"
     touch "workers/unity/unity.sln"
-    eval "${UNITY_EXE} -projectPath \"${PROJECT_DIR}\"/workers/unity -batchmode -quit"
+    "${UNITY_EXE}" -projectPath "${PROJECT_DIR}/workers/unity" -batchmode -quit
     markEndOfBlock "Generating Solution Files"
 fi
 


### PR DESCRIPTION
#### Description
ci/lint.sh doesn't like spaces in UNITY_HOME