### PR TITLE
Fixed incorrect error messages reported for world commands

### DIFF
--- a/workers/unity/Assets/Gdk/Core/Components/ComponentTranslation.cs
+++ b/workers/unity/Assets/Gdk/Core/Components/ComponentTranslation.cs
@@ -51,6 +51,9 @@ namespace Improbable.Gdk.Core.Components
 
             public const string CannotFindEntityForCommandResponse =
                 "Cannot find entity {0} locally to receive command response {1}.";
+
+            public const string RequestDoesNotExist =
+                "Cannot find request with ID {0}, response type {1}.";
         }
 
         public static readonly Dictionary<uint, ComponentTranslation> HandleToTranslation =

--- a/workers/unity/Assets/Gdk/Core/Components/ComponentTranslation.cs
+++ b/workers/unity/Assets/Gdk/Core/Components/ComponentTranslation.cs
@@ -50,7 +50,10 @@ namespace Improbable.Gdk.Core.Components
                 "Cannot find entity {0} locally to receive command request {1}.";
 
             public const string CannotFindEntityForCommandResponse =
-                "Cannot find entity {0} locally to receive command response {1}.";
+                "Cannot find entity {0} locally to receive command response for {1}.";
+
+            public const string CannotFindEntityForWorldCommandResponse =
+                "Cannot find entity {0} locally to receive world command response for {1}.";
 
             public const string RequestDoesNotExist =
                 "Cannot find request with ID {0}, response type {1}.";

--- a/workers/unity/Assets/Gdk/Core/Components/WorldCommandsTranslation.cs
+++ b/workers/unity/Assets/Gdk/Core/Components/WorldCommandsTranslation.cs
@@ -300,7 +300,7 @@ namespace Improbable.Gdk.Core
         public void OnDeleteEntityResponse(DeleteEntityResponseOp op)
         {
             Entity entity;
-            if (!TryGetEntityFromRequestId(op.RequestId.Id, "CreateEntityResponse", out entity))
+            if (!TryGetEntityFromRequestId(op.RequestId.Id, "DeleteEntityResponse", out entity))
             {
                 return;
             }
@@ -314,7 +314,7 @@ namespace Improbable.Gdk.Core
         public void OnReserveEntityIdResponse(ReserveEntityIdsResponseOp op)
         {
             Entity entity;
-            if (!TryGetEntityFromRequestId(op.RequestId.Id, "CreateEntityResponse", out entity))
+            if (!TryGetEntityFromRequestId(op.RequestId.Id, "ReserveEntityIdsResponse", out entity))
             {
                 return;
             }
@@ -328,7 +328,7 @@ namespace Improbable.Gdk.Core
         public void OnEntityQueryResponse(EntityQueryResponseOp op)
         {
             Entity entity;
-            if (!TryGetEntityFromRequestId(op.RequestId.Id, "CreateEntityResponse", out entity))
+            if (!TryGetEntityFromRequestId(op.RequestId.Id, "EntityQueryResponse", out entity))
             {
                 return;
             }
@@ -352,7 +352,7 @@ namespace Improbable.Gdk.Core
             long entityId;
             if (!RequestIdToEntityId.TryGetValue(requestId, out entityId))
             {
-                Debug.LogErrorFormat(TranslationErrors.CannotFindEntityForCommandResponse, requestId, responseName);
+                Debug.LogErrorFormat(TranslationErrors.RequestDoesNotExist, requestId, responseName);
                 return false;
             }
 
@@ -364,7 +364,7 @@ namespace Improbable.Gdk.Core
             }
             else if (!view.TryGetEntity(entityId, out entity))
             {
-                Debug.LogErrorFormat(TranslationErrors.CannotFindEntityForCommandResponse, requestId, responseName);
+                Debug.LogWarningFormat(TranslationErrors.CannotFindEntityForCommandResponse, entityId, responseName);
                 return false;
             }
 

--- a/workers/unity/Assets/Gdk/Core/Components/WorldCommandsTranslation.cs
+++ b/workers/unity/Assets/Gdk/Core/Components/WorldCommandsTranslation.cs
@@ -286,7 +286,7 @@ namespace Improbable.Gdk.Core
         public void OnCreateEntityResponse(CreateEntityResponseOp op)
         {
             Entity entity;
-            if (!TryGetEntityFromRequestId(op.RequestId.Id, "CreateEntityResponse", out entity))
+            if (!TryGetEntityFromRequestId(op.RequestId.Id, "CreateEntity", out entity))
             {
                 return;
             }
@@ -300,7 +300,7 @@ namespace Improbable.Gdk.Core
         public void OnDeleteEntityResponse(DeleteEntityResponseOp op)
         {
             Entity entity;
-            if (!TryGetEntityFromRequestId(op.RequestId.Id, "DeleteEntityResponse", out entity))
+            if (!TryGetEntityFromRequestId(op.RequestId.Id, "DeleteEntity", out entity))
             {
                 return;
             }
@@ -314,7 +314,7 @@ namespace Improbable.Gdk.Core
         public void OnReserveEntityIdResponse(ReserveEntityIdsResponseOp op)
         {
             Entity entity;
-            if (!TryGetEntityFromRequestId(op.RequestId.Id, "ReserveEntityIdsResponse", out entity))
+            if (!TryGetEntityFromRequestId(op.RequestId.Id, "ReserveEntityIds", out entity))
             {
                 return;
             }
@@ -328,7 +328,7 @@ namespace Improbable.Gdk.Core
         public void OnEntityQueryResponse(EntityQueryResponseOp op)
         {
             Entity entity;
-            if (!TryGetEntityFromRequestId(op.RequestId.Id, "EntityQueryResponse", out entity))
+            if (!TryGetEntityFromRequestId(op.RequestId.Id, "EntityQuery", out entity))
             {
                 return;
             }
@@ -364,7 +364,7 @@ namespace Improbable.Gdk.Core
             }
             else if (!view.TryGetEntity(entityId, out entity))
             {
-                Debug.LogWarningFormat(TranslationErrors.CannotFindEntityForCommandResponse, entityId, responseName);
+                Debug.LogWarningFormat(TranslationErrors.CannotFindEntityForWorldCommandResponse, entityId, responseName);
                 return false;
             }
 


### PR DESCRIPTION
#### Description
Fixed a bug where incorrect errors were reported when a response arrived for a world command and the entity that sent the command is gone. Incorrect command names were being reported, and requests IDs were passed in place of entity IDs, this is now corrected.

Also differentiated between a request ID not existing in the dictionary, and the entity for a request not existing on the worker anymore. The latter is expected to happen occasionally under normal circumstances, so lowered the error to a warning.

#### Tests
Minor bugfix
#### Documentation
Minor bugfix
#### Primary reviewers
@samiwh @jamiebrynes7 