### PR TITLE
UTY-555: Add emulator support for Android

### DIFF
--- a/android_launch.json
+++ b/android_launch.json
@@ -1,0 +1,37 @@
+{
+  "template": "small",
+  "world": {
+    "chunkEdgeLengthMeters": 50,
+    "snapshots": {
+      "snapshotWritePeriodSeconds": 0
+    },
+    "dimensions": {
+      "xMeters": 5000,
+      "zMeters": 5000
+    }
+  },
+  "workers": [
+    {
+      "worker_type": "UnityGameLogic",
+      "permissions": [
+        {
+          "all": {}
+        }
+      ],
+      "load_balancing": {
+        "auto_hex_grid": {
+          "num_workers": 1
+        }
+      }
+    },
+    {
+      "worker_type": "UnityClient",
+      "permissions": [{
+          "all": {}
+      }],
+      "load_balancing": {
+        "singleton_worker": {}
+      }
+    }
+  ]
+}

--- a/tools/DocsLinter/Tests/LinkCheckingTests.cs
+++ b/tools/DocsLinter/Tests/LinkCheckingTests.cs
@@ -16,8 +16,14 @@ namespace DocsLinter.Tests
 
         private static RemoteLink GetUrlForStatusCode(int statusCode)
         {
-            var url = $"https://httpstat.us/{statusCode}";
+            var url = $"http://httpstat.us/{statusCode}";
             return new RemoteLink(new LinkInline(url, ""));
+        }
+
+        [OneTimeSetUp]
+        public void IgnoreSslErrors() {
+            System.Net.ServicePointManager.ServerCertificateValidationCallback += 
+                (sender, cert, chain, sslPolicyErrors) => true;
         }
 
         [Test]

--- a/tools/DocsLinter/Tests/LinkCheckingTests.cs
+++ b/tools/DocsLinter/Tests/LinkCheckingTests.cs
@@ -21,8 +21,9 @@ namespace DocsLinter.Tests
         }
 
         [OneTimeSetUp]
-        public void IgnoreSslErrors() {
-            System.Net.ServicePointManager.ServerCertificateValidationCallback += 
+        public void IgnoreSslErrors()
+        {
+            System.Net.ServicePointManager.ServerCertificateValidationCallback +=
                 (sender, cert, chain, sslPolicyErrors) => true;
         }
 

--- a/workers/unity/Assets/Gdk/Android.meta
+++ b/workers/unity/Assets/Gdk/Android.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b6cb7a9d0e33c89489abc3fa8e3726f3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Assets/Gdk/Android/Editor.meta
+++ b/workers/unity/Assets/Gdk/Android/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f1ec3f0975c8f174da2bc15c9a421278
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Assets/Gdk/Android/Editor/AndroidSpatialRunner.cs
+++ b/workers/unity/Assets/Gdk/Android/Editor/AndroidSpatialRunner.cs
@@ -9,15 +9,16 @@ using System.Net.Sockets;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.Experimental.UIElements;
+using Debug = UnityEngine.Debug;
 
 namespace Improbable.Gdk.Android.Editor
 {
     internal class AndroidSpatialRunner
     {
         private static readonly string ProjectDirectory = Path.Combine(Application.dataPath, "..", "..", "..");
-        private static readonly string ProcessName = "spatial";
-        private static readonly string ProcessParams = "local launch";
-        private static readonly string Config = "android_launch.json";
+        private const string ProcessName = "spatial";
+        private const string ProcessParams = "local launch";
+        private const string Config = "android_launch.json";
 
         [MenuItem("Improbable/Run Spatial for Android")]
         public static void RunAndroidSpatial()
@@ -34,6 +35,7 @@ namespace Improbable.Gdk.Android.Editor
                 throw new NullReferenceException("Could not find local IP Address. Make sure you are connected to the Internet.");
             }
 
+            Debug.Log(ipAddress.ToString());
             return ipAddress.ToString();
         }
 

--- a/workers/unity/Assets/Gdk/Android/Editor/AndroidSpatialRunner.cs
+++ b/workers/unity/Assets/Gdk/Android/Editor/AndroidSpatialRunner.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Net.Sockets;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.Experimental.UIElements;
+
+namespace Improbable.Gdk.Android.Editor
+{
+    internal class AndroidSpatialRunner
+    {
+        private static readonly string ProjectDirectory = Path.Combine(Application.dataPath, "..", "..", "..");
+        private static readonly string ProcessName = "spatial";
+        private static readonly string ProcessParams = "local launch";
+        private static readonly string Config = "android_launch.json";
+
+        [MenuItem("Improbable/Run Spatial for Android")]
+        public static void RunAndroidSpatial()
+        {
+            Process.Start(GetProcessStartInfo());
+        }
+
+        private static string GetLocalIpAddress()
+        {
+            var host = Dns.GetHostEntry(Dns.GetHostName());
+            var ipAddress = host.AddressList.FirstOrDefault(ip => ip.AddressFamily == AddressFamily.InterNetwork);
+            if (ipAddress == null)
+            {
+                throw new NullReferenceException("Could not find local IP Address. Make sure you are connected to the Internet.");
+            }
+
+            return ipAddress.ToString();
+        }
+
+        private static ProcessStartInfo GetProcessStartInfo()
+        {
+            return new ProcessStartInfo
+            {
+                FileName = ProcessName,
+                Arguments = $"{ProcessParams} {Config} --runtime_ip={GetLocalIpAddress()}",
+                WorkingDirectory = ProjectDirectory,
+                UseShellExecute = true
+            };
+        }
+    }
+}

--- a/workers/unity/Assets/Gdk/Android/Editor/AndroidSpatialRunner.cs
+++ b/workers/unity/Assets/Gdk/Android/Editor/AndroidSpatialRunner.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -8,7 +6,6 @@ using System.Net;
 using System.Net.Sockets;
 using UnityEditor;
 using UnityEngine;
-using UnityEngine.Experimental.UIElements;
 using Debug = UnityEngine.Debug;
 
 namespace Improbable.Gdk.Android.Editor
@@ -32,7 +29,8 @@ namespace Improbable.Gdk.Android.Editor
             var ipAddress = host.AddressList.FirstOrDefault(ip => ip.AddressFamily == AddressFamily.InterNetwork);
             if (ipAddress == null)
             {
-                throw new NullReferenceException("Could not find local IP Address. Make sure you are connected to the Internet.");
+                throw new NullReferenceException(
+                    "Could not find local IP Address. Make sure you are connected to the Internet.");
             }
 
             Debug.Log(ipAddress.ToString());

--- a/workers/unity/Assets/Gdk/Android/Editor/AndroidSpatialRunner.cs
+++ b/workers/unity/Assets/Gdk/Android/Editor/AndroidSpatialRunner.cs
@@ -20,6 +20,7 @@ namespace Improbable.Gdk.Android.Editor
         [MenuItem("Improbable/Run Spatial for Android")]
         public static void RunAndroidSpatial()
         {
+            Debug.Log($"Connect phone to IP: {GetLocalIpAddress()}");
             Process.Start(GetProcessStartInfo());
         }
 
@@ -33,7 +34,6 @@ namespace Improbable.Gdk.Android.Editor
                     "Could not find local IP Address. Make sure you are connected to the Internet.");
             }
 
-            Debug.Log($"Runtime IP: {ipAddress}");
             return ipAddress;
         }
 

--- a/workers/unity/Assets/Gdk/Android/Editor/AndroidSpatialRunner.cs
+++ b/workers/unity/Assets/Gdk/Android/Editor/AndroidSpatialRunner.cs
@@ -33,7 +33,7 @@ namespace Improbable.Gdk.Android.Editor
                     "Could not find local IP Address. Make sure you are connected to the Internet.");
             }
 
-            Debug.Log(ipAddress.ToString());
+            Debug.Log($"Runtime IP: {ipAddress}");
             return ipAddress.ToString();
         }
 

--- a/workers/unity/Assets/Gdk/Android/Editor/AndroidSpatialRunner.cs
+++ b/workers/unity/Assets/Gdk/Android/Editor/AndroidSpatialRunner.cs
@@ -23,7 +23,7 @@ namespace Improbable.Gdk.Android.Editor
             Process.Start(GetProcessStartInfo());
         }
 
-        private static string GetLocalIpAddress()
+        private static IPAddress GetLocalIpAddress()
         {
             var host = Dns.GetHostEntry(Dns.GetHostName());
             var ipAddress = host.AddressList.FirstOrDefault(ip => ip.AddressFamily == AddressFamily.InterNetwork);
@@ -34,7 +34,7 @@ namespace Improbable.Gdk.Android.Editor
             }
 
             Debug.Log($"Runtime IP: {ipAddress}");
-            return ipAddress.ToString();
+            return ipAddress;
         }
 
         private static ProcessStartInfo GetProcessStartInfo()

--- a/workers/unity/Assets/Gdk/Android/Editor/AndroidSpatialRunner.cs.meta
+++ b/workers/unity/Assets/Gdk/Android/Editor/AndroidSpatialRunner.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6030bf79f5cfc2447bff2c56c76ecd68
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Assets/Gdk/Android/Editor/Improbable.Gdk.Android.Editor.asmdef
+++ b/workers/unity/Assets/Gdk/Android/Editor/Improbable.Gdk.Android.Editor.asmdef
@@ -1,0 +1,10 @@
+{
+    "name": "Improbable.Gdk.Android.Editor",
+    "references": [],
+    "optionalUnityReferences": [],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false
+}

--- a/workers/unity/Assets/Gdk/Android/Editor/Improbable.Gdk.Android.Editor.asmdef.meta
+++ b/workers/unity/Assets/Gdk/Android/Editor/Improbable.Gdk.Android.Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: de659988febec1849af80cae2cb42680
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Assets/Gdk/Android/Improbable.Gdk.Android.asmdef
+++ b/workers/unity/Assets/Gdk/Android/Improbable.Gdk.Android.asmdef
@@ -1,0 +1,11 @@
+{
+    "name": "Improbable.Gdk.Android",
+    "references": [],
+    "optionalUnityReferences": [],
+    "includePlatforms": [
+        "Android",
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false
+}

--- a/workers/unity/Assets/Gdk/Android/Improbable.Gdk.Android.asmdef.meta
+++ b/workers/unity/Assets/Gdk/Android/Improbable.Gdk.Android.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 9eadd91049779c7438d40cb4b255f0ff
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Assets/Gdk/Android/Utility.meta
+++ b/workers/unity/Assets/Gdk/Android/Utility.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 031ec6cb280c2614c822c4238c466552
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Assets/Gdk/Android/Utility/DeviceInfo.cs
+++ b/workers/unity/Assets/Gdk/Android/Utility/DeviceInfo.cs
@@ -1,0 +1,32 @@
+using System.Collections;
+using System.Collections.Generic;
+using JetBrains.Annotations;
+using UnityEngine;
+
+namespace Improbable.Gdk.Android
+{
+    public class DeviceInfo
+    {
+        private static readonly AndroidJavaObject Build = new AndroidJavaObject("android.os.Build");
+        private static readonly string Fingerprint = GetValue("FINGERPRINT");
+        private static readonly string Model = GetValue("MODEL");
+        private static readonly string Manufacturer = GetValue("MANUFACTURER");
+        private static readonly string Brand = GetValue("BRAND");
+        private static readonly string Device = GetValue("DEVICE");
+        private static readonly string Product = GetValue("PRODUCT");
+
+        public static bool isEmulator()
+        {
+            return Fingerprint.StartsWith("generic") || Fingerprint.StartsWith("unknown") ||
+                Model.Contains("google_sdk") || Model.Contains("Emulator") ||
+                Model.Contains("Android SDK built for x86") || Manufacturer.Contains("Genymotion") ||
+                (Brand.StartsWith("generic") && Device.StartsWith("generic")) ||
+                "google_sdk".Equals(Product);
+        }
+
+        private static string GetValue(string parameter)
+        {
+            return Build.GetStatic<string>(parameter);
+        }
+    }
+}

--- a/workers/unity/Assets/Gdk/Android/Utility/DeviceInfo.cs
+++ b/workers/unity/Assets/Gdk/Android/Utility/DeviceInfo.cs
@@ -1,6 +1,3 @@
-using System.Collections;
-using System.Collections.Generic;
-using JetBrains.Annotations;
 using UnityEngine;
 
 namespace Improbable.Gdk.Android
@@ -15,7 +12,7 @@ namespace Improbable.Gdk.Android
         private static readonly string Device = GetValue("DEVICE");
         private static readonly string Product = GetValue("PRODUCT");
 
-        public static bool isEmulator()
+        public static bool IsEmulator()
         {
             return Fingerprint.StartsWith("generic") || Fingerprint.StartsWith("unknown") ||
                 Model.Contains("google_sdk") || Model.Contains("Emulator") ||

--- a/workers/unity/Assets/Gdk/Android/Utility/DeviceInfo.cs
+++ b/workers/unity/Assets/Gdk/Android/Utility/DeviceInfo.cs
@@ -12,12 +12,12 @@ namespace Improbable.Gdk.Android
         private static readonly string Device = GetValue("DEVICE");
         private static readonly string Product = GetValue("PRODUCT");
 
-        public static bool IsEmulator()
+        public static bool IsAndroidStudioEmulator()
         {
             return Fingerprint.StartsWith("generic") || Fingerprint.StartsWith("unknown") ||
                 Model.Contains("google_sdk") || Model.Contains("Emulator") ||
-                Model.Contains("Android SDK built for x86") || Manufacturer.Contains("Genymotion") ||
-                (Brand.StartsWith("generic") && Device.StartsWith("generic")) ||
+                Model.Contains("Android SDK built for x86") ||
+                Brand.StartsWith("generic") && Device.StartsWith("generic") ||
                 "google_sdk".Equals(Product);
         }
 

--- a/workers/unity/Assets/Gdk/Android/Utility/DeviceInfo.cs.meta
+++ b/workers/unity/Assets/Gdk/Android/Utility/DeviceInfo.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d8ff0a4ec488dc64e8bb1fd506dcf019
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Assets/Gdk/Core/Components/WorldCommandsTranslation.cs
+++ b/workers/unity/Assets/Gdk/Core/Components/WorldCommandsTranslation.cs
@@ -364,7 +364,8 @@ namespace Improbable.Gdk.Core
             }
             else if (!view.TryGetEntity(entityId, out entity))
             {
-                Debug.LogWarningFormat(TranslationErrors.CannotFindEntityForWorldCommandResponse, entityId, responseName);
+                Debug.LogWarningFormat(TranslationErrors.CannotFindEntityForWorldCommandResponse, entityId,
+                    responseName);
                 return false;
             }
 

--- a/workers/unity/Assets/Gdk/Core/Config/ReceptionistConfig.cs
+++ b/workers/unity/Assets/Gdk/Core/Config/ReceptionistConfig.cs
@@ -23,5 +23,15 @@ namespace Improbable.Gdk.Core
                 parsedArgs, RuntimeConfigNames.LinkProtocol, RuntimeConfigDefaults.LinkProtocol);
             return config;
         }
+
+        public static ReceptionistConfig CreateConnectionConfigForAndroidEmulator()
+        {
+            var config = new ReceptionistConfig
+            {
+                ReceptionistHost = "10.0.2.2",
+                UseExternalIp = true
+            };
+            return config;
+        }
     }
 }

--- a/workers/unity/Assets/Gdk/Core/Config/ReceptionistConfig.cs
+++ b/workers/unity/Assets/Gdk/Core/Config/ReceptionistConfig.cs
@@ -7,6 +7,9 @@ namespace Improbable.Gdk.Core
         public string ReceptionistHost = RuntimeConfigDefaults.ReceptionistHost;
         public ushort ReceptionistPort = RuntimeConfigDefaults.ReceptionistPort;
 
+        // Default Android emulator host IP alias
+        private const string AndroidEmulatorHostDeviceIp = "10.0.2.2";
+
         public override void Validate()
         {
             ValidateConfig(ReceptionistHost, RuntimeConfigNames.ReceptionistHost);
@@ -28,7 +31,7 @@ namespace Improbable.Gdk.Core
         {
             return new ReceptionistConfig
             {
-                ReceptionistHost = "10.0.2.2",
+                ReceptionistHost = AndroidEmulatorHostDeviceIp,
                 UseExternalIp = true
             };
         }

--- a/workers/unity/Assets/Gdk/Core/Config/ReceptionistConfig.cs
+++ b/workers/unity/Assets/Gdk/Core/Config/ReceptionistConfig.cs
@@ -26,12 +26,11 @@ namespace Improbable.Gdk.Core
 
         public static ReceptionistConfig CreateConnectionConfigForAndroidEmulator()
         {
-            var config = new ReceptionistConfig
+            return new ReceptionistConfig
             {
                 ReceptionistHost = "10.0.2.2",
                 UseExternalIp = true
             };
-            return config;
         }
     }
 }

--- a/workers/unity/Assets/Playground/Improbable.Playground.asmdef
+++ b/workers/unity/Assets/Playground/Improbable.Playground.asmdef
@@ -6,11 +6,11 @@
         "Improbable.Gdk.PlayerLifecycle",
         "Improbable.Gdk.Legacy",
         "Improbable.Gdk.Generated",
+        "Improbable.Gdk.Android",
+        "Improbable.CSharp",
         "Unity.Entities",
         "Unity.Entities.Hybrid",
-        "Improbable.CSharp",
-        "Unity.Mathematics",
-        "Improbable.Gdk.Android"
+        "Unity.Mathematics"
     ],
     "optionalUnityReferences": [],
     "includePlatforms": [],

--- a/workers/unity/Assets/Playground/Improbable.Playground.asmdef
+++ b/workers/unity/Assets/Playground/Improbable.Playground.asmdef
@@ -9,7 +9,8 @@
         "Unity.Entities",
         "Unity.Entities.Hybrid",
         "Improbable.CSharp",
-        "Unity.Mathematics"
+        "Unity.Mathematics",
+        "Improbable.Gdk.Android"
     ],
     "optionalUnityReferences": [],
     "includePlatforms": [],

--- a/workers/unity/Assets/Playground/Scripts/Bootstrap.cs
+++ b/workers/unity/Assets/Playground/Scripts/Bootstrap.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Improbable.Gdk.Android;
 using Improbable.Gdk.Core;
 using Unity.Entities;
 using UnityEngine;
@@ -51,6 +52,17 @@ namespace Playground
                 connectionConfig.UseExternalIp = workerConfigurations.UseExternalIp;
 #endif
             }
+#if UNITY_ANDROID
+            else if (Application.isMobilePlatform)
+            {
+                var worker = WorkerRegistry.CreateWorker<UnityClient>($"Client-{Guid.NewGuid()}", new Vector3(0, 0, 0));
+                Workers.Add(worker);
+                if (DeviceInfo.isEmulator())
+                {
+                    connectionConfig = ReceptionistConfig.CreateConnectionConfigForAndroidEmulator();
+                }
+            }
+#endif
             else
             {
                 var commandLineArguments = System.Environment.GetCommandLineArgs();

--- a/workers/unity/Assets/Playground/Scripts/Bootstrap.cs
+++ b/workers/unity/Assets/Playground/Scripts/Bootstrap.cs
@@ -61,7 +61,7 @@ namespace Playground
                 Workers.Add(worker);
 
                 // TODO: UTY-555 logic for when device is not an emulator
-                if (DeviceInfo.IsEmulator())
+                if (DeviceInfo.IsAndroidStudioEmulator())
                 {
                     connectionConfig = ReceptionistConfig.CreateConnectionConfigForAndroidEmulator();
                 }

--- a/workers/unity/Assets/Playground/Scripts/Bootstrap.cs
+++ b/workers/unity/Assets/Playground/Scripts/Bootstrap.cs
@@ -59,6 +59,8 @@ namespace Playground
             {
                 var worker = WorkerRegistry.CreateWorker<UnityClient>($"Client-{Guid.NewGuid()}", new Vector3(0, 0, 0));
                 Workers.Add(worker);
+
+                // TODO: UTY-555 logic for when device is not an emulator
                 if (DeviceInfo.IsEmulator())
                 {
                     connectionConfig = ReceptionistConfig.CreateConnectionConfigForAndroidEmulator();

--- a/workers/unity/Assets/Playground/Scripts/Bootstrap.cs
+++ b/workers/unity/Assets/Playground/Scripts/Bootstrap.cs
@@ -1,10 +1,12 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Improbable.Gdk.Android;
 using Improbable.Gdk.Core;
 using Unity.Entities;
 using UnityEngine;
+#if UNITY_ANDROID
+using Improbable.Gdk.Android;
+#endif
 #if UNITY_EDITOR
 using UnityEditor;
 
@@ -57,7 +59,7 @@ namespace Playground
             {
                 var worker = WorkerRegistry.CreateWorker<UnityClient>($"Client-{Guid.NewGuid()}", new Vector3(0, 0, 0));
                 Workers.Add(worker);
-                if (DeviceInfo.isEmulator())
+                if (DeviceInfo.IsEmulator())
                 {
                     connectionConfig = ReceptionistConfig.CreateConnectionConfigForAndroidEmulator();
                 }

--- a/workers/unity/ProjectSettings/ProjectSettings.asset
+++ b/workers/unity/ProjectSettings/ProjectSettings.asset
@@ -624,6 +624,7 @@ PlayerSettings:
     27: UNITY_POST_PROCESSING_STACK_V2
   platformArchitecture: {}
   scriptingBackend:
+    Android: 0
     Standalone: 0
   il2cppCompilerConfiguration: {}
   incrementalIl2cppBuild: {}


### PR DESCRIPTION
#### Description
- Added logic that detects whether the device that the game is currently running on is an Android emulator (widely accepted way of checking, should work for all popular emulators).
- Added an Improbable menu item to run spatial locally with all required parameters to improve workflow.

#### Tests
- Code gets executed on Android emulator device only.

#### Documentation
-
#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.