### PR TITLE
Bugfix/linter typo

### DIFF
--- a/ci/lint.sh
+++ b/ci/lint.sh
@@ -40,7 +40,7 @@ ${LINTER} --profile="IW Code Cleanup" --settings=./workers/unity/ReSharper2017.D
 markEndOfBlock "Linting GDK Code Generator"
 
 markStartOfBlock "Linting Unity GDK"
-${LINTER} --profile="IW Code Cleanup" --settings=./workers/unity/ReSharper2017.DotSettings --exclude=/Assets/Generated/**/* --exlude=/Assets/improbable/**/* ./workers/unity/unity.sln
+${LINTER} --profile="IW Code Cleanup" --settings=./workers/unity/ReSharper2017.DotSettings --exclude=/Assets/Generated/**/* --exclude=/Assets/improbable/**/* ./workers/unity/unity.sln
 markEndOfBlock "Linting Unity GDK"
 
 markEndOfBlock "$0"

--- a/workers/unity/Assets/Gdk/Core/Components/WorldCommandsTranslation.cs
+++ b/workers/unity/Assets/Gdk/Core/Components/WorldCommandsTranslation.cs
@@ -364,7 +364,8 @@ namespace Improbable.Gdk.Core
             }
             else if (!view.TryGetEntity(entityId, out entity))
             {
-                Debug.LogWarningFormat(TranslationErrors.CannotFindEntityForWorldCommandResponse, entityId, responseName);
+                Debug.LogWarningFormat(TranslationErrors.CannotFindEntityForWorldCommandResponse, entityId,
+                    responseName);
                 return false;
             }
 


### PR DESCRIPTION
#### Description
There was a typo in the "exlude" parameter.
Drive-by change: Linted the WorldCommandsTranslation.cs file as it was giving the TeamCity linter troubles.
#### Tests
./ci/lint-check.sh works
#### Documentation
#### Primary reviewers