### PR TITLE
FOR DISPLAY PURPOSES ONLY local timer design idea

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -41,5 +41,6 @@ We are currently not accepting public contributions. However, we are accepting i
 * [Creating entities](content/create-entity.md)
 * [Entity checkout process](content/entity-checkout-process.md)
 * [The code generator](content/code-generator.md)
+* [Temporary components](content/temporary-components.md)
 
 &copy; 2018 Improbable

--- a/docs/content/reactive-components.md
+++ b/docs/content/reactive-components.md
@@ -3,7 +3,7 @@
 -----
 
 
-## Receiving updates from SpatialOS: reactive components
+## Receiving entity updates from SpatialOS: reactive components
 
 To represent state changes or messages from SpatialOS, the Unity GDK uses something we're calling "reactive components": ECS components that it adds to the relevant ECS entity for the duration of a tick.
 

--- a/docs/content/temporary-components.md
+++ b/docs/content/temporary-components.md
@@ -1,0 +1,43 @@
+**Warning:** The [pre-alpha](https://docs.improbable.io/reference/latest/shared/release-policy#maturity-stages) release is for evaluation purposes only, with limited documentation - see the guidance on [Recommended use](../../README.md#recommended-use).
+
+-----
+
+
+## Temporary components
+
+The attribute `Improbable.Gdk.Core.RemoveAtEndOfTick`, can be applied to any ECS component, extending either `IComponentData` or `ISharedComponentData`.
+All components with this attribute will be removed from all entities during the `InternalSpatialOSCleanGroup` at the end of `SpatialOSSendGroup`.
+
+Note: The `InternalSpatialOSCleanGroup` runs after both the `SpatialOSUpdateGroup` and the `CustomSpatialOSSendGroup`.
+
+### Example
+```csharp
+[RemoveAtEndOfTick]
+struct SomeTemporaryComponent : IComponentData
+{
+}
+```
+
+If a system, `AddComponentSystem`, adds `SomeTemporaryComponent` to some entities, then `ReadComponentSystem.OnUpdate()` (see the sample below) will run during the same update loop.
+
+```csharp
+[UpdateAfter(typeof(AddComponentSystem))]
+[UpdateInGroup(typeof(SpatialOSUpdateGroup))]
+class ReadComponentSystem : ComponentSystem
+{
+    private struct Data
+    {
+        int Length;
+        [Readonly] ComponentDataArray<SomeTemporaryComponent> TemporaryComponent;
+    }
+
+    [Inject] Data data;
+
+    protected override void OnUpdate()
+    {
+        // perform work related to the temporary component
+    }
+}
+``` 
+
+At the end of the update loop, `SomeTemporaryComponent` will automatically be removed from all entities.

--- a/workers/unity/Assets/Gdk/Core/Attributes.meta
+++ b/workers/unity/Assets/Gdk/Core/Attributes.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0a6c8a19ce040a44eb1aeead93a0794f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Assets/Gdk/Core/Attributes/RemoveAtEndOfTick.cs
+++ b/workers/unity/Assets/Gdk/Core/Attributes/RemoveAtEndOfTick.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using Unity.Entities;
+
+namespace Improbable.Gdk.Core
+{
+    /// <summary>
+    /// Any component with this attribute will be removed from all entities by the CleanReactiveComponentSystem
+    /// Can be added to components extending either <see cref="IComponentData" /> or <see cref="ISharedComponentData" />
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Struct | AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+    public class RemoveAtEndOfTick : Attribute
+    {
+    }
+}
+

--- a/workers/unity/Assets/Gdk/Core/Attributes/RemoveAtEndOfTick.cs.meta
+++ b/workers/unity/Assets/Gdk/Core/Attributes/RemoveAtEndOfTick.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9ccc6baaacb1059488f5ffa4e0a358ba
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Assets/Gdk/Core/Collections.meta
+++ b/workers/unity/Assets/Gdk/Core/Collections.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: da93d49b2d7c4f92a0451021b96b77ea
+timeCreated: 1530463373

--- a/workers/unity/Assets/Gdk/Core/Collections/PriorityQueue.cs
+++ b/workers/unity/Assets/Gdk/Core/Collections/PriorityQueue.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Improbable.Gdk.Core
+{
+    /// <summary>
+    /// Priority queue implemented with a max heap
+    /// </summary>
+    /// <typeparam name="T"> Comparable data type </typeparam>
+    public class PriorityQueue<T>
+    {
+        private readonly List<T> heap = new List<T>();
+        private readonly IComparer<T> comparer;
+
+        public PriorityQueue()
+        {
+            comparer = Comparer<T>.Default;
+        }
+
+        public PriorityQueue(IComparer<T> comparer) : this()
+        {
+            if (comparer != null)
+            {
+                this.comparer = comparer;
+            }
+        }
+
+        public int Count()
+        {
+            return heap.Count;
+        }
+
+        public T Peak()
+        {
+            if (heap.Count == 0)
+            {
+                throw new Exception($"Tried to peak value from empty {typeof(PriorityQueue<T>).Name}");
+            }
+            return heap[0];
+        }
+
+        public T Pop()
+        {
+            if (heap.Count == 0)
+            {
+                throw new Exception($"Tried to pop value from empty {typeof(PriorityQueue<T>).Name}");
+            }
+
+            T head = heap[0];
+            heap[0] = heap[heap.Count - 1];
+            heap.RemoveAt(heap.Count - 1);
+            var currentIndex = 0;
+
+            while (TrySwapWithChild(ref currentIndex))
+            {
+            }
+
+            return head;
+        }
+
+        public void Push(T element)
+        {
+            heap.Add(element);
+            var currentIndex = heap.Count - 1;
+            while (TrySwapWithParent(ref currentIndex))
+            {
+            }
+        }
+
+        private bool TrySwapWithChild(ref int currentIndex)
+        {
+            var leftChildIndex = (currentIndex * 2) + 1;
+            var rightChildIndex = leftChildIndex + 1;
+
+            // Get the index of the largest child, or return false if there are no children
+            int indexOfLargestChild;
+            if (heap.Count > rightChildIndex)
+            {
+                indexOfLargestChild = comparer.Compare(heap[rightChildIndex], heap[leftChildIndex]) > 0
+                    ? rightChildIndex
+                    : leftChildIndex;
+            }
+            else if (heap.Count > leftChildIndex)
+            {
+                indexOfLargestChild = leftChildIndex;
+            }
+            else
+            {
+                return false;
+            }
+
+            // Swap if the largest child is larger than the parent
+            if (comparer.Compare(heap[indexOfLargestChild], heap[currentIndex]) > 0)
+            {
+                T temp = heap[currentIndex];
+                heap[currentIndex] = heap[indexOfLargestChild];
+                heap[indexOfLargestChild] = temp;
+                currentIndex = indexOfLargestChild;
+                return true;
+            }
+            return false;
+        }
+
+        private bool TrySwapWithParent(ref int currentIndex)
+        {
+            if (currentIndex == 0)
+            {
+                return false;
+            }
+            var parentIndex = currentIndex % 2 == 0
+                ? (currentIndex - 2) / 2
+                : (currentIndex - 1) % 2;
+
+            if (comparer.Compare(heap[currentIndex], heap[parentIndex]) > 0)
+            {
+                T temp = heap[parentIndex];
+                heap[parentIndex] = heap[currentIndex];
+                heap[currentIndex] = temp;
+                currentIndex = parentIndex;
+                return true;
+            }
+            return false;
+        }
+    }
+}

--- a/workers/unity/Assets/Gdk/Core/Collections/PriorityQueue.cs.meta
+++ b/workers/unity/Assets/Gdk/Core/Collections/PriorityQueue.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 27506c4a30b84468b8634eb434746253
+timeCreated: 1530463384

--- a/workers/unity/Assets/Gdk/Core/Components/NewlyAddedSpatialOSEntity.cs
+++ b/workers/unity/Assets/Gdk/Core/Components/NewlyAddedSpatialOSEntity.cs
@@ -7,6 +7,7 @@ namespace Improbable.Gdk.Core
     ///     This component is automatically added to an entity upon its creation and automatically removed at the end of the
     ///     same frame.
     /// </summary>
+    [RemoveAtEndOfTick]
     public struct NewlyAddedSpatialOSEntity : IComponentData
     {
     }

--- a/workers/unity/Assets/Gdk/Core/Components/WorkerEntityComponents.cs
+++ b/workers/unity/Assets/Gdk/Core/Components/WorkerEntityComponents.cs
@@ -2,20 +2,40 @@ using Unity.Entities;
 
 namespace Improbable.Gdk.Core
 {
+    /// <summary>
+    /// Component denoting a worker entity
+    /// </summary>
     public struct WorkerEntityTag : IComponentData
     {
     }
 
+    /// <summary>
+    /// Component added to the worker entity immediately after establishing a connection to a SpatialOS deployment
+    /// Removed immediately after disconnecting
+    /// </summary>
     public struct IsConnected : IComponentData
     {
     }
 
+    /// <summary>
+    /// Component added to the worker entity immediately after establishing a connection to a SpatialOS deployment
+    /// Removed at the end of the tick it was added
+    /// </summary>
+    [RemoveAtEndOfTick]
     public struct OnConnected : IComponentData
     {
     }
 
+    /// <summary>
+    /// Component added to the worker entity immediately after disconnecting from SpatialOS
+    /// Removed at the end of the tick it was added
+    /// </summary>
+    [RemoveAtEndOfTick]
     public struct OnDisconnected : ISharedComponentData
     {
+        /// <summary>
+        /// The reported reason for disconnecting
+        /// </summary>
         public string ReasonForDisconnect;
     }
 }

--- a/workers/unity/Assets/Gdk/Core/Tests/Editmode/Collections.meta
+++ b/workers/unity/Assets/Gdk/Core/Tests/Editmode/Collections.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 4670352b14434ead8a956f735009e362
+timeCreated: 1530467037

--- a/workers/unity/Assets/Gdk/Core/Tests/Editmode/Collections/PriorityQueueTests.cs
+++ b/workers/unity/Assets/Gdk/Core/Tests/Editmode/Collections/PriorityQueueTests.cs
@@ -1,0 +1,47 @@
+﻿using NUnit.Framework;
+
+namespace Improbable.Gdk.Core.EditmodeTests
+{
+    [TestFixture]
+    public class PriorityQueueTests
+    {
+        [Test]
+        public void Pop_values_added_in_ascending_order_in_correct_order()
+        {
+            var queue = new PriorityQueue<int>();
+
+            queue.Push(1);
+            Assert.AreEqual(1, queue.Peak());
+
+            queue.Push(2);
+            Assert.AreEqual(2, queue.Peak());
+
+            queue.Push(3);
+            Assert.AreEqual(3, queue.Peak());
+
+            Assert.AreEqual(3, queue.Pop());
+            Assert.AreEqual(2, queue.Pop());
+            Assert.AreEqual(1, queue.Pop());
+        }
+
+        [Test]
+        public void Pop_values_added_in_descending_order_in_correct_order()
+        {
+            var queue = new PriorityQueue<int>();
+
+            queue.Push(3);
+            Assert.AreEqual(3, queue.Peak());
+
+            queue.Push(2);
+            Assert.AreEqual(3, queue.Peak());
+
+            queue.Push(1);
+            Assert.AreEqual(3, queue.Peak());
+
+            Assert.AreEqual(3, queue.Pop());
+            Assert.AreEqual(2, queue.Pop());
+            Assert.AreEqual(1, queue.Pop());
+        }
+    }
+}
+

--- a/workers/unity/Assets/Gdk/Core/Tests/Editmode/Collections/PriorityQueueTests.cs.meta
+++ b/workers/unity/Assets/Gdk/Core/Tests/Editmode/Collections/PriorityQueueTests.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: dda55a1b228d45029c58d82ba711f901
+timeCreated: 1530467060

--- a/workers/unity/Assets/Gdk/Timing.meta
+++ b/workers/unity/Assets/Gdk/Timing.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e4884498144c3e64dbc05b6235e18888
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Assets/Gdk/Timing/ComponentToAddAtLocalTime.cs
+++ b/workers/unity/Assets/Gdk/Timing/ComponentToAddAtLocalTime.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using Unity.Entities;
+
+namespace Improbable.Gdk.Timing
+{
+    public struct ComponentToAddAtLocalTime : IComparable<ComponentToAddAtLocalTime>
+    {
+        public Action<EntityCommandBuffer> AddComponentAction;
+        public float TimerEndTime;
+
+        public int CompareTo(ComponentToAddAtLocalTime other)
+        {
+            return TimerEndTime.CompareTo(other.TimerEndTime);
+        }
+
+        public static ComponentToAddAtLocalTime Create<T>(T component, Entity entity, float time)
+            where T : struct, IComponentData
+        {
+            return new ComponentToAddAtLocalTime
+            {
+                AddComponentAction = commandBuffer => commandBuffer.AddComponent(entity, component),
+                TimerEndTime = time
+            };
+        }
+    }
+}

--- a/workers/unity/Assets/Gdk/Timing/ComponentToAddAtLocalTime.cs.meta
+++ b/workers/unity/Assets/Gdk/Timing/ComponentToAddAtLocalTime.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: fc7bb5871a0249e19c4ae161b42ccf71
+timeCreated: 1531060563

--- a/workers/unity/Assets/Gdk/Timing/Components.meta
+++ b/workers/unity/Assets/Gdk/Timing/Components.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 15e855261f308fe488a0ec828583b6a1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Assets/Gdk/Timing/Components/LocalTimerComponents.cs
+++ b/workers/unity/Assets/Gdk/Timing/Components/LocalTimerComponents.cs
@@ -1,0 +1,32 @@
+﻿using Improbable.Gdk.Core;
+using Unity.Entities;
+
+namespace Improbable.Gdk.Timing
+{
+    public struct ActiveTimer : IComponentData
+    {
+        private uint handle;
+
+        public PriorityQueue<ComponentToAddAtLocalTime> Queue =>
+            LocalTimerLifecycleSystem.GetOrCreateComponentTimer(handle);
+
+        public ActiveTimer(uint handle)
+        {
+            this.handle = handle;
+        }
+    }
+
+    public struct PersistantLocalTimerHandle : ISystemStateComponentData
+    {
+        public uint Handle;
+    }
+
+    public struct HasHadLocalTimerTag : IComponentData
+    {
+    }
+
+    public struct CheckForEmptyTimer : IComponentData
+    {
+    }
+}
+

--- a/workers/unity/Assets/Gdk/Timing/Components/LocalTimerComponents.cs.meta
+++ b/workers/unity/Assets/Gdk/Timing/Components/LocalTimerComponents.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 48e98d5c4384b9e4cbf252db634627bc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Assets/Gdk/Timing/Improbable.Gdk.Timing.asmdef
+++ b/workers/unity/Assets/Gdk/Timing/Improbable.Gdk.Timing.asmdef
@@ -1,16 +1,12 @@
 {
-    "name": "Improbable.Playground",
+    "name": "Improbable.Gdk.Timing",
     "references": [
         "Improbable.Gdk.Core",
-        "Improbable.Gdk.Physics",
-        "Improbable.Gdk.PlayerLifecycle",
-        "Improbable.Gdk.Legacy",
         "Improbable.Gdk.Generated",
         "Unity.Entities",
         "Unity.Entities.Hybrid",
-        "Improbable.CSharp",
         "Unity.Mathematics",
-        "Improbable.Gdk.Timing"
+        "Improbable.CSharp"
     ],
     "optionalUnityReferences": [],
     "includePlatforms": [],

--- a/workers/unity/Assets/Gdk/Timing/Improbable.Gdk.Timing.asmdef.meta
+++ b/workers/unity/Assets/Gdk/Timing/Improbable.Gdk.Timing.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8689d342c7861264e9eca854719874e5
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Assets/Gdk/Timing/LocalTimer.cs
+++ b/workers/unity/Assets/Gdk/Timing/LocalTimer.cs
@@ -1,0 +1,19 @@
+﻿using Unity.Entities;
+
+namespace Improbable.Gdk.Timing
+{
+    public static class LocalTimer
+    {
+        public static void AddComponentAtLocalTime<T>(float time, Entity entity, World world)
+            where T : struct, IComponentData
+        {
+            world.GetExistingManager<LocalTimerLifecycleSystem>().AddComponentAtLocalTime(default(T), time, entity);
+        }
+
+        public static void AddComponentAtLocalTime<T>(T component, float time, Entity entity, World world)
+            where T : struct, IComponentData
+        {
+            world.GetExistingManager<LocalTimerLifecycleSystem>().AddComponentAtLocalTime(component, time, entity);
+        }
+    }
+}

--- a/workers/unity/Assets/Gdk/Timing/LocalTimer.cs.meta
+++ b/workers/unity/Assets/Gdk/Timing/LocalTimer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 4cd38cf7829d42498fd6cc01efd630c5
+timeCreated: 1530869339

--- a/workers/unity/Assets/Gdk/Timing/Systems.meta
+++ b/workers/unity/Assets/Gdk/Timing/Systems.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1dbb24e3641a4794fbccb96b6cd7dbee
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Assets/Gdk/Timing/Systems/AddComponentAtLocalTimeSystem.cs
+++ b/workers/unity/Assets/Gdk/Timing/Systems/AddComponentAtLocalTimeSystem.cs
@@ -1,0 +1,39 @@
+﻿using Improbable.Gdk.Core;
+using Unity.Collections;
+using Unity.Entities;
+using UnityEngine;
+
+namespace Improbable.Gdk.Timing
+{
+    [UpdateInGroup(typeof(SpatialOSReceiveGroup))]
+    public class AddComponentAtLocalTimeSystem : ComponentSystem
+    {
+        public struct Data
+        {
+            public int Length;
+            [ReadOnly] public ComponentDataArray<ActiveTimer> Timer;
+            [ReadOnly] public EntityArray Entities;
+        }
+
+        [Inject] private Data data;
+
+        protected override void OnUpdate()
+        {
+            for (int i = 0; i < data.Length; ++i)
+            {
+                // Iterate over completed timesr and add the relevant components
+                var queue = data.Timer[i].Queue;
+                while (queue.Count() > 0 && queue.Peak().TimerEndTime < Time.time)
+                {
+                    queue.Pop().AddComponentAction(PostUpdateCommands);
+                }
+
+                // If the buffer is empty, remove the timer tag
+                if (queue.Count() == 0)
+                {
+                    PostUpdateCommands.AddComponent(data.Entities[i], new CheckForEmptyTimer());
+                }
+            }
+        }
+    }
+}

--- a/workers/unity/Assets/Gdk/Timing/Systems/AddComponentAtLocalTimeSystem.cs.meta
+++ b/workers/unity/Assets/Gdk/Timing/Systems/AddComponentAtLocalTimeSystem.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 7535ea3c86604a7bb8aa3879626af4a8
+timeCreated: 1530470086

--- a/workers/unity/Assets/Gdk/Timing/Systems/LocalTimerLifecycleSystem.cs
+++ b/workers/unity/Assets/Gdk/Timing/Systems/LocalTimerLifecycleSystem.cs
@@ -1,0 +1,163 @@
+﻿using System;
+using System.Collections.Generic;
+using Improbable.Gdk.Core;
+using Unity.Collections;
+using Unity.Entities;
+
+namespace Improbable.Gdk.Timing
+{
+    /// <summary>
+    ///     Responsible for adding and removing timers
+    /// </summary>
+    [AlwaysUpdateSystem]
+    [UpdateInGroup(typeof(SpatialOSReceiveGroup))]
+    [UpdateBefore(typeof(AddComponentAtLocalTimeSystem))]
+    public class LocalTimerLifecycleSystem : ComponentSystem
+    {
+        // Can add an extra layer in if we want to seperate out workers - likely a good idea for debugging
+        internal static readonly Dictionary<uint, PriorityQueue<ComponentToAddAtLocalTime>> HandleToTimerQueue
+            = new Dictionary<uint, PriorityQueue<ComponentToAddAtLocalTime>>();
+
+        private static readonly Dictionary<LocalTimerLifecycleSystem, List<Action<EntityCommandBuffer>>> systemToDelayedAddTimerActions
+            = new Dictionary<LocalTimerLifecycleSystem, List<Action<EntityCommandBuffer>>>();
+
+        private static uint nextAvailableHandle = 1u;
+
+        public struct RemovedEntityData
+        {
+            public int Length;
+            [ReadOnly] public ComponentDataArray<PersistantLocalTimerHandle> LocalTimerHandles;
+            [ReadOnly] public SubtractiveComponent<HasHadLocalTimerTag> DenotesEntityRemoved;
+            [ReadOnly] public EntityArray RemovedEntities;
+        }
+
+        public struct EmptyTimerData
+        {
+            public int Length;
+            [ReadOnly] public ComponentDataArray<ActiveTimer> ActiveTimers;
+            [ReadOnly] public ComponentDataArray<CheckForEmptyTimer> DenotesShouldRemoveTimerHandle;
+            [ReadOnly] public EntityArray Entites;
+        }
+
+        [Inject] private RemovedEntityData removedEntityData;
+        [Inject] private EmptyTimerData emptyTimerData;
+
+        protected override void OnUpdate()
+        {
+            List<Action<EntityCommandBuffer>> addTimerActions;
+            if (systemToDelayedAddTimerActions.TryGetValue(this, out addTimerActions))
+            {
+                foreach (var addTimerAction in addTimerActions)
+                {
+                    addTimerAction(PostUpdateCommands);
+                }
+
+                addTimerActions.Clear();
+            }
+
+            for (int i = 0; i < removedEntityData.Length; ++i)
+            {
+                ReleaseHandle(removedEntityData.LocalTimerHandles[i].Handle);
+                PostUpdateCommands.RemoveSystemStateComponent<PersistantLocalTimerHandle>(removedEntityData.RemovedEntities[i]);
+            }
+
+            for (int i = 0; i < emptyTimerData.Length; ++i)
+            {
+                if (emptyTimerData.ActiveTimers[i].Queue.Count() == 0)
+                {
+                    PostUpdateCommands.RemoveComponent<ActiveTimer>(emptyTimerData.Entites[i]);
+                }
+                PostUpdateCommands.RemoveComponent<CheckForEmptyTimer>(emptyTimerData.Entites[i]);
+            }
+        }
+
+        // todo Could get rid of the command buffer argument by creating an add timer to entity system
+        // could also just add the component via the entity manager
+        internal void AddComponentAtLocalTime<T>(T component, float time, Entity entity)
+            where T : struct, IComponentData
+        {
+            var manager = World.GetExistingManager<EntityManager>();
+
+            uint timerHandle;
+            if (manager.HasComponent<PersistantLocalTimerHandle>(entity))
+            {
+                timerHandle = manager.GetComponentData<PersistantLocalTimerHandle>(entity).Handle;
+                if (!manager.HasComponent<ActiveTimer>(entity))
+                {
+                    var delayedAddTimerActions = GetelayedAddTimerAction();
+
+                    delayedAddTimerActions.Add(commandBuffer =>
+                    {
+                        if (!manager.Exists(entity))
+                        {
+                            ReleaseHandle(timerHandle);
+                            return;
+                        }
+
+                        if (!manager.HasComponent<ActiveTimer>(entity))
+                        {
+                            commandBuffer.AddComponent(entity, new ActiveTimer(timerHandle));
+                        }
+                    });
+                }
+            }
+            else
+            {
+                timerHandle = GetAvailableHandle();
+                var delayedAddTimerActions = GetelayedAddTimerAction();
+
+                delayedAddTimerActions.Add(commandBuffer =>
+                {
+                    if (!manager.Exists(entity))
+                    {
+                        ReleaseHandle(timerHandle);
+                        return;
+                    }
+
+                    if (!manager.HasComponent<ActiveTimer>(entity))
+                    {
+                        commandBuffer.AddComponent(entity, new ActiveTimer(timerHandle));
+                        commandBuffer.AddComponent(entity, new PersistantLocalTimerHandle { Handle = timerHandle });
+                        commandBuffer.AddComponent(entity, new HasHadLocalTimerTag());
+                    }
+                });
+            }
+
+            GetOrCreateComponentTimer(timerHandle).Push(ComponentToAddAtLocalTime.Create(component, entity, time));
+        }
+
+        internal static PriorityQueue<ComponentToAddAtLocalTime> GetOrCreateComponentTimer(uint handle)
+        {
+            PriorityQueue<ComponentToAddAtLocalTime> queue;
+            if (!HandleToTimerQueue.TryGetValue(handle, out queue))
+            {
+                queue = new PriorityQueue<ComponentToAddAtLocalTime>();
+                HandleToTimerQueue.Add(handle, queue);
+            }
+
+            return queue;
+        }
+
+        private uint GetAvailableHandle()
+        {
+            return nextAvailableHandle++;
+        }
+
+        private void ReleaseHandle(uint handle)
+        {
+            HandleToTimerQueue.Remove(handle);
+        }
+
+        private List<Action<EntityCommandBuffer>> GetelayedAddTimerAction()
+        {
+            List<Action<EntityCommandBuffer>> delayedAddTimerActions;
+            if (!systemToDelayedAddTimerActions.TryGetValue(this, out delayedAddTimerActions))
+            {
+                delayedAddTimerActions = new List<Action<EntityCommandBuffer>>();
+                systemToDelayedAddTimerActions.Add(this, delayedAddTimerActions);
+            }
+
+            return delayedAddTimerActions;
+        }
+    }
+}

--- a/workers/unity/Assets/Gdk/Timing/Systems/LocalTimerLifecycleSystem.cs.meta
+++ b/workers/unity/Assets/Gdk/Timing/Systems/LocalTimerLifecycleSystem.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: c0f9960259ea4686bb5fc1ae6a271125
+timeCreated: 1530866311

--- a/workers/unity/Assets/Gdk/Timing/TimingSystemHelper.cs
+++ b/workers/unity/Assets/Gdk/Timing/TimingSystemHelper.cs
@@ -1,0 +1,20 @@
+﻿using Unity.Entities;
+
+namespace Improbable.Gdk.Timing
+{
+    public static class TimingSystemHelper
+    {
+        public static void RegisterClientSystems(World world)
+        {
+            world.GetOrCreateManager<LocalTimerLifecycleSystem>();
+            world.GetOrCreateManager<AddComponentAtLocalTimeSystem>();
+        }
+
+        public static void RegisterServerSystems(World world)
+        {
+            world.GetOrCreateManager<LocalTimerLifecycleSystem>();
+            world.GetOrCreateManager<AddComponentAtLocalTimeSystem>();
+        }
+    }
+}
+

--- a/workers/unity/Assets/Gdk/Timing/TimingSystemHelper.cs.meta
+++ b/workers/unity/Assets/Gdk/Timing/TimingSystemHelper.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 62d7f89eeda34290af5c6195d768c7a0
+timeCreated: 1530473742

--- a/workers/unity/Assets/Playground/Config/ArchetypeConfig.cs
+++ b/workers/unity/Assets/Playground/Config/ArchetypeConfig.cs
@@ -17,7 +17,7 @@ namespace Playground
                     new Dictionary<string, ComponentType[]>()
                     {
                         { CharacterArchetype, new ComponentType[] { typeof(BufferedTransform) } },
-                        { CubeArchetype, new ComponentType[] { typeof(BufferedTransform) } }
+                        { CubeArchetype, new ComponentType[] { typeof(BufferedTransform), typeof(ColorChangeComponent) } }
                     }
                 },
                 {

--- a/workers/unity/Assets/Playground/Scripts/Cubes/ColorChangeComponents.cs
+++ b/workers/unity/Assets/Playground/Scripts/Cubes/ColorChangeComponents.cs
@@ -1,0 +1,21 @@
+﻿using Improbable.Gdk.Core;
+using Unity.Entities;
+
+namespace Playground
+{
+    /// <summary>
+    /// Tag used to enable and disable sending color change events
+    /// </summary>
+    public struct ColorChangeComponent : IComponentData
+    {
+        public float TimeBetweenEvents;
+    }
+
+    /// <summary>
+    /// Denotes that a color change event should happen this tick
+    /// </summary>
+    [RemoveAtEndOfTick]
+    public struct ShouldSendColorChangeTemporary : IComponentData
+    {
+    }
+}

--- a/workers/unity/Assets/Playground/Scripts/Cubes/ColorChangeComponents.cs.meta
+++ b/workers/unity/Assets/Playground/Scripts/Cubes/ColorChangeComponents.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: ed5f037f2a2840d4a054532dc4e99e9a
+timeCreated: 1530472906

--- a/workers/unity/Assets/Playground/Scripts/Cubes/InitializeColorChangeSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/Cubes/InitializeColorChangeSystem.cs
@@ -1,0 +1,35 @@
+﻿using Improbable.Gdk.Core;
+using Unity.Collections;
+using Unity.Entities;
+using UnityEngine;
+
+namespace Playground
+{
+    [UpdateInGroup(typeof(SpatialOSUpdateGroup))]
+    [UpdateBefore(typeof(TriggerColorChangeSystem))]
+    public class InitializeColorChangeSystem : ComponentSystem
+    {
+        public struct Data
+        {
+            public int Length;
+            public ComponentDataArray<ColorChangeComponent> ColorChangeConfig;
+            [ReadOnly] public ComponentDataArray<NewlyAddedSpatialOSEntity> DenotesNewEntity;
+            [ReadOnly] public EntityArray Entities;
+        }
+
+        [Inject] private Data data;
+
+        protected override void OnUpdate()
+        {
+            // Intialize behaviour on entity according to config or delay the start
+            for (int i = 0; i < data.Length; ++i)
+            {
+                var config = data.ColorChangeConfig[i];
+                config.TimeBetweenEvents = 2.0f;
+                data.ColorChangeConfig[i] = config;
+
+                PostUpdateCommands.AddComponent(data.Entities[i], new ShouldSendColorChangeTemporary());
+            }
+        }
+    }
+}

--- a/workers/unity/Assets/Playground/Scripts/Cubes/InitializeColorChangeSystem.cs.meta
+++ b/workers/unity/Assets/Playground/Scripts/Cubes/InitializeColorChangeSystem.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 0ebd4563f97a4d22959ee3831ce5ba86
+timeCreated: 1530474471

--- a/workers/unity/Assets/Playground/Scripts/Workers/UnityClient.cs
+++ b/workers/unity/Assets/Playground/Scripts/Workers/UnityClient.cs
@@ -1,5 +1,6 @@
 using Improbable.Gdk.Core;
 using Improbable.Gdk.PlayerLifecycle;
+using Improbable.Gdk.Timing;
 using Improbable.Gdk.TransformSynchronization;
 using UnityEngine;
 
@@ -19,6 +20,7 @@ namespace Playground
         {
             base.RegisterSystems();
             TransfromSynchronizationSystemHelper.RegisterClientSystems(World);
+            TimingSystemHelper.RegisterClientSystems(World);
             PlayerLifecycleConfig.RegisterClientSystems(World);
 
             // Entity initialization systems

--- a/workers/unity/Assets/Playground/Scripts/Workers/UnityGameLogic.cs
+++ b/workers/unity/Assets/Playground/Scripts/Workers/UnityGameLogic.cs
@@ -1,5 +1,6 @@
 using Improbable.Gdk.Core;
 using Improbable.Gdk.PlayerLifecycle;
+using Improbable.Gdk.Timing;
 using Improbable.Gdk.TransformSynchronization;
 using UnityEngine;
 
@@ -20,6 +21,7 @@ namespace Playground
         {
             base.RegisterSystems();
             TransfromSynchronizationSystemHelper.RegisterServerSystems(World);
+            TimingSystemHelper.RegisterServerSystems(World);
             PlayerLifecycleConfig.RegisterServerSystems(World);
 
             // Entity initialization systems
@@ -36,6 +38,7 @@ namespace Playground
             World.GetOrCreateManager<MoveLocalPlayerSystem>();
 
             // Server test event systems
+            World.GetOrCreateManager<InitializeColorChangeSystem>();
             World.GetOrCreateManager<TriggerColorChangeSystem>();
 
             // Server test command systems


### PR DESCRIPTION
#### Description
This is here for illustrative purposes and is not the primary place to discuss. That will be done in a design doc.

Best read in more or less the order files are displayed in the change log.

Here to show an idea for creating a timer system.
Also shows a potential pattern for dealing with things that require managed memory, that do not persist.


Adds a component to an entity at a specified time. The interface to do so it
LocalTimer.AddComponentAtLocalTime(component, time, entity, world);

It does not deal with things like adding the same component twice, that is on the user to ensure you don't do (although this could do it). It does handle it's own memory and deals with the entity being removed.

Not optimised and errors and tests are just written for my own benefit while hacking around.

#### Tests
N.A. Although there is a small priority queue test.
#### Documentation
N.A.
#### Primary reviewers
N.A. - Not for merging now.