### PR TITLE
[Experimental][CSharp Core SDK] Blittable list and map

### DIFF
--- a/workers/unity/Assets/Gdk/Core/Collections.meta
+++ b/workers/unity/Assets/Gdk/Core/Collections.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 62e193b06f994c2087d82301a43e6a73
+timeCreated: 1531314766

--- a/workers/unity/Assets/Gdk/Core/Collections/BlittableList.cs
+++ b/workers/unity/Assets/Gdk/Core/Collections/BlittableList.cs
@@ -1,0 +1,52 @@
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Assets.Gdk.Core.Collections
+{
+    public struct BlittableList<T> : IList<T>
+    {
+        private readonly uint handle;
+
+        internal List<T> Internal => ListProvider<T>.Get(handle);
+
+        internal BlittableList(uint handle)
+        {
+            this.handle = handle;
+        }
+
+        public static implicit operator List<T>(BlittableList<T> bl) => bl.Internal;
+
+        #region IList<T>
+        public T this[int index] {
+            get { return Internal[index]; }
+            set { Internal[index] = value; }
+        }
+
+        public int Count => Internal.Count;
+
+        public bool IsReadOnly => ((ICollection<T>)Internal).IsReadOnly;
+
+        public void Add(T item) => Internal.Add(item);
+
+        public void Insert(int index, T item) => Internal.Insert(index, item);
+
+        public void Clear() => Internal.Clear();
+
+        public bool Contains(T item) => Internal.Contains(item);
+
+        public void CopyTo(T[] array, int arrayIndex) => Internal.CopyTo(array, arrayIndex);
+
+        public int IndexOf(T item) => Internal.IndexOf(item);
+
+        public bool Remove(T item) => Internal.Remove(item);
+
+        public void RemoveAt(int index) => Internal.RemoveAt(index);
+
+        public List<T>.Enumerator GetEnumerator() => Internal.GetEnumerator();
+
+        IEnumerator<T> IEnumerable<T>.GetEnumerator() => ((IEnumerable<T>)Internal).GetEnumerator();
+
+        IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable)Internal).GetEnumerator();
+        #endregion
+    }
+}

--- a/workers/unity/Assets/Gdk/Core/Collections/BlittableList.cs.meta
+++ b/workers/unity/Assets/Gdk/Core/Collections/BlittableList.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fbae09ff434822b46961bc512da9717b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Assets/Gdk/Core/Collections/BlittableMap.cs
+++ b/workers/unity/Assets/Gdk/Core/Collections/BlittableMap.cs
@@ -1,0 +1,71 @@
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Assets.Gdk.Core.Collections
+{
+    public struct BlittableMap<TKey, TValue> : IDictionary<TKey, TValue>
+    {
+        private readonly uint handle;
+        internal Dictionary<TKey, TValue> Internal => MapProvider<TKey, TValue>.Get(handle);
+
+        internal BlittableMap(uint handle)
+        {
+            this.handle = handle;
+        }
+
+        #region IDictionary
+
+        public void Clear() => Internal.Clear();
+
+        public int Count => Internal.Count;
+
+        public void Add(TKey key, TValue value) => Internal.Add(key, value);
+
+        public bool ContainsKey(TKey key) => Internal.ContainsKey(key);
+
+        public bool Remove(TKey key) => Internal.Remove(key);
+
+        public bool TryGetValue(TKey key, out TValue value) => Internal.TryGetValue(key, out value);
+
+        public TValue this[TKey key]
+        {
+            get { return Internal[key]; }
+            set { Internal[key] = value; }
+        }
+
+        public ICollection<TKey> Keys => Internal.Keys;
+        public ICollection<TValue> Values => Internal.Values;
+
+        public Dictionary<TKey, TValue>.Enumerator GetEnumerator() => Internal.GetEnumerator();
+
+        IEnumerator<KeyValuePair<TKey, TValue>> IEnumerable<KeyValuePair<TKey, TValue>>.GetEnumerator()
+        {
+            return ((IEnumerable<KeyValuePair<TKey, TValue>>) Internal).GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable)Internal).GetEnumerator();
+
+        void ICollection<KeyValuePair<TKey, TValue>>.Add(KeyValuePair<TKey, TValue> item)
+        {
+            ((ICollection<KeyValuePair<TKey, TValue>>) Internal).Add(item);
+        }
+
+        bool ICollection<KeyValuePair<TKey, TValue>>.Contains(KeyValuePair<TKey, TValue> item)
+        {
+            return ((ICollection<KeyValuePair<TKey, TValue>>) Internal).Contains(item);
+        }
+
+        void ICollection<KeyValuePair<TKey, TValue>>.CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)
+        {
+            ((ICollection<KeyValuePair<TKey, TValue>>) Internal).CopyTo(array, arrayIndex);
+        }
+
+        bool ICollection<KeyValuePair<TKey, TValue>>.Remove(KeyValuePair<TKey, TValue> item)
+        {
+            return ((ICollection<KeyValuePair<TKey, TValue>>)Internal).Remove(item);
+        }
+
+        bool ICollection<KeyValuePair<TKey, TValue>>.IsReadOnly => ((ICollection<KeyValuePair<TKey, TValue>>)Internal).IsReadOnly;
+        #endregion
+    }
+}

--- a/workers/unity/Assets/Gdk/Core/Collections/BlittableMap.cs.meta
+++ b/workers/unity/Assets/Gdk/Core/Collections/BlittableMap.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 3324211b880141fdb36e89a4e8a17c51
+timeCreated: 1531321956

--- a/workers/unity/Assets/Gdk/Core/Collections/HandleProvider.cs
+++ b/workers/unity/Assets/Gdk/Core/Collections/HandleProvider.cs
@@ -23,5 +23,10 @@ namespace Assets.Gdk.Core.Collections
             freeActions.Add(handle, MapProvider<TValue, TKey>.FreeHandle);
             return handle;
         }
+
+        public static void FreeHandle(uint handle)
+        {
+            freeActions[handle](handle);
+        }
     }
 }

--- a/workers/unity/Assets/Gdk/Core/Collections/HandleProvider.cs
+++ b/workers/unity/Assets/Gdk/Core/Collections/HandleProvider.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+
+namespace Assets.Gdk.Core.Collections
+{
+    internal static class HandleProvider
+    {
+        private static uint nextHandle = 0;
+        private static Dictionary<uint, Action<uint>> freeActions;
+
+        public static uint AllocateListHandle<TValue>()
+        {
+            var handle = nextHandle++;
+            ListProvider<TValue>.AllocateHandle(handle);
+            freeActions.Add(handle, ListProvider<TValue>.FreeHandle);
+            return handle;
+        }
+
+        public static uint AllocateMapHandle<TValue, TKey>()
+        {
+            var handle = nextHandle++;
+            MapProvider<TValue, TKey>.AllocateHandle(handle);
+            freeActions.Add(handle, MapProvider<TValue, TKey>.FreeHandle);
+            return handle;
+        }
+    }
+}

--- a/workers/unity/Assets/Gdk/Core/Collections/HandleProvider.cs.meta
+++ b/workers/unity/Assets/Gdk/Core/Collections/HandleProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 827d3fb73fc832a409513b2e83a7b056
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Assets/Gdk/Core/Collections/ListProvider.cs
+++ b/workers/unity/Assets/Gdk/Core/Collections/ListProvider.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+
+namespace Assets.Gdk.Core.Collections
+{
+    internal static class ListProvider<T>
+    {
+        private static readonly Dictionary<uint, List<T>> Storage = new Dictionary<uint, List<T>>();
+
+        internal static void AllocateHandle(uint handle)
+        {
+            var item = new List<T>();
+            Storage.Add(handle, item);
+        }
+
+        internal static List<T> Get(uint handle)
+        {
+            return Storage[handle];
+        }
+
+        internal static void FreeHandle(uint handle)
+        {
+            List<T> list;
+            if (!Storage.TryGetValue(handle, out list))
+            {
+                throw new ArgumentException($"ListProvider<{typeof(T).Name}> does not contain handle `{handle}`");
+            }
+
+            list.Clear();
+            Storage.Remove(handle);
+        }
+    }
+}

--- a/workers/unity/Assets/Gdk/Core/Collections/ListProvider.cs.meta
+++ b/workers/unity/Assets/Gdk/Core/Collections/ListProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: bb5f455aee17c6943a9d7a6a0674b1d1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Assets/Gdk/Core/Collections/MapProvider.cs
+++ b/workers/unity/Assets/Gdk/Core/Collections/MapProvider.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+
+namespace Assets.Gdk.Core.Collections
+{
+    internal static class MapProvider<TKey, TValue>
+    {
+        private static readonly Dictionary<uint, Dictionary<TKey, TValue>> Storage = new Dictionary<uint, Dictionary<TKey, TValue>>();
+
+        internal static void AllocateHandle(uint handle)
+        {
+            var item = new Dictionary<TKey, TValue>();
+            Storage.Add(handle, item);
+        }
+
+        internal static Dictionary<TKey, TValue> Get(uint handle)
+        {
+            return Storage[handle];
+        }
+
+        internal static void FreeHandle(uint handle)
+        {
+            Dictionary<TKey, TValue> item;
+            if (!Storage.TryGetValue(handle, out item))
+            {
+                throw new ArgumentException($"MapProvider<{typeof(TKey)}, {typeof(TValue)}> does not contain handle `{handle}`");
+            }
+
+            item.Clear();
+            Storage.Remove(handle);
+        }
+    }
+}

--- a/workers/unity/Assets/Gdk/Core/Collections/MapProvider.cs.meta
+++ b/workers/unity/Assets/Gdk/Core/Collections/MapProvider.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 9448b6430998481caf31f2e692242c7e
+timeCreated: 1531321956


### PR DESCRIPTION
#### Description
Added an initial implementation of the BlittableList and BlittableMap.
Both are simple structs with a handle to their underlying data storage, wrapping their respective IList and IDictionary interfaces.

Creation should only be used in code generation through the following example snipped
```csharp
var listHandle = HandleProvider.AllocateListHandle<int>();
var list = new BlittableList<int>(listHandle);

var mapHandle = HandleProvider.AllocateMapHandle<int, float>();
var map = new BlittableMap<int, float>(mapHandle);
```

Cleanup can only be done through:

```csharp
HandleProvider.FreeHandle(listHandle);
HandleProvider.FreeHandle(mapHandle);
```