### PR TITLE
Update Unity Version in setup-and-installing.md

### DIFF
--- a/docs/setup-and-installing.md
+++ b/docs/setup-and-installing.md
@@ -7,8 +7,8 @@
 ## Short version (for SpatialOS local deployment only)
 
 1. Set up your machine by installing: 
-* (For Windows) [Unity 2018.2.0b10](https://unity3d.com/unity/beta-download), [Visual Studio 2017](https://www.visualstudio.com/downloads/), [.NET Core 2.1](https://www.microsoft.com/net/download/), [SpatialOS](https://console.improbable.io/installer/download/stable/latest/win), [ReSharper](https://www.jetbrains.com/resharper/) (optional), and [ReSharper Command Line Tools](https://www.jetbrains.com/resharper/download/index.html#section=resharper-clt) (optional)
-* (For Mac) [Unity 2018.2.0b10](https://unity3d.com/unity/beta-download), [Rider](https://www.jetbrains.com/rider/) (optional; alternatively [Visual Studio 2017](https://www.visualstudio.com/downloads/)), [.NET Core 2.1](https://www.microsoft.com/net/download/), [SpatialOS](https://console.improbable.io/installer/download/stable/latest/win)
+* (For Windows) [Unity 2018.2.0f2](https://unity3d.com/get-unity/download/archive), [Visual Studio 2017](https://www.visualstudio.com/downloads/), [.NET Core 2.1](https://www.microsoft.com/net/download/), [SpatialOS](https://console.improbable.io/installer/download/stable/latest/win), [ReSharper](https://www.jetbrains.com/resharper/) (optional), and [ReSharper Command Line Tools](https://www.jetbrains.com/resharper/download/index.html#section=resharper-clt) (optional)
+* (For Mac) [Unity 2018.2.0f2](https://unity3d.com/get-unity/download/archive), [Rider](https://www.jetbrains.com/rider/) (optional; alternatively [Visual Studio 2017](https://www.visualstudio.com/downloads/)), [.NET Core 2.1](https://www.microsoft.com/net/download/), [SpatialOS](https://console.improbable.io/installer/download/stable/latest/win)
 
 
 1. Clone the repository: `git clone git@github.com:spatialos/UnityGDK.git`  or `git clone  https://github.com/spatialos/UnityGDK.git`
@@ -29,9 +29,9 @@
 
     #### Windows
 
-	- [Unity 2018.2.0b10](https://unity3d.com/unity/beta-download)
+	- [Unity 2018.2.0f2](https://unity3d.com/get-unity/download/archive)
 	- [Visual Studio 2017](https://www.visualstudio.com/downloads/)
-	    > Within Visual Studio Installer, on the Workloads tab, select **Game development with Unity** and **.NET Core cross-platform development**. In the summary on the right, deselect **Unity 2017.2 64-bit Editor** (the SpatialOS Unity GDK requires Unity 2018.2.0b10). Make sure **Visual Studio Tools for Unity** is selected.
+	    > Within Visual Studio Installer, on the Workloads tab, select **Game development with Unity** and **.NET Core cross-platform development**. In the summary on the right, deselect **Unity 2017.2 64-bit Editor** (the SpatialOS Unity GDK requires Unity 2018.2.0f2). Make sure **Visual Studio Tools for Unity** is selected.
     - [.NET Core 2.1](https://www.microsoft.com/net/download/)
 	- SpatialOS, using the the [SpatialOS installer](https://console.improbable.io/installer/download/stable/latest/win)
 	<br>This installs:
@@ -46,7 +46,7 @@
 
     #### Mac
 
-	- [Unity 2018.2.0b10](https://unity3d.com/unity/beta-download)
+	- [Unity 2018.2.0f2](https://unity3d.com/get-unity/download/archive)
     - [Rider](https://www.jetbrains.com/rider/) (optional)
       <br>You can also use [Visual Studio 2017](https://www.visualstudio.com/downloads/) for development, however to lint your code according to our linting rules, you need to use Rider.
     - [.NET Core 2.1](https://www.microsoft.com/net/download/)


### PR DESCRIPTION
#### Description
I have made this change because, not that 2018.2.0 is out of page we previously linked to, [/unity/beta-download](https://unity3d.com/unity/beta-download) no longer contains any download links.
#### Tests
I'm manually testing 2018.2.0 now.
#### Documentation
This is documentation.