### PR TITLE
UTY-639 Fix test failures

### DIFF
--- a/workers/unity/Assets/Gdk/TestUtils/HybridGdkSystemTestBase.cs
+++ b/workers/unity/Assets/Gdk/TestUtils/HybridGdkSystemTestBase.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Reflection;
 using NUnit.Framework;
 using Unity.Entities;
 
@@ -40,6 +42,20 @@ namespace Improbable.Gdk.TestUtils
             InjectionHookSupport.UnregisterHook(gameobjectArrayInjectionHook);
             InjectionHookSupport.UnregisterHook(transformAccessArrayInjectionHook);
             InjectionHookSupport.UnregisterHook(componentArrayInjectionHook);
+        }
+
+        public static void CleanupAllInjectionHooks()
+        {
+            var hooksFieldInfo = typeof(InjectionHookSupport).GetField("k_Hooks", BindingFlags.Static | BindingFlags.NonPublic);
+
+            var staticValue = hooksFieldInfo.GetValue(null);
+
+            var hooks = ((List<InjectionHook>) staticValue).ToArray();
+
+            foreach (var injectionHook in hooks)
+            {
+                InjectionHookSupport.UnregisterHook(injectionHook);
+            }
         }
     }
 }

--- a/workers/unity/Assets/Gdk/TestUtils/Tests/Editmode/HybridGdkSystemTestBaseTests.cs
+++ b/workers/unity/Assets/Gdk/TestUtils/Tests/Editmode/HybridGdkSystemTestBaseTests.cs
@@ -66,26 +66,36 @@ namespace Improbable.Gdk.TestUtils.EditmodeTests
             public static void
                 HybridSystems_will_result_in_errors_when_created_if_fixture_does_not_extend_HybridGdkSystemTestBase()
             {
+                // Need to clean up hooks here because this file does not clean up hooks:
+                // Packages/com.unity.entities@0.0.12-preview.8/Unity.Entities.Hybrid.Tests/DefaultWorldInitializationTests.cs:22
+                //   (Initialize_ShouldLogNothing)
+                HybridGdkSystemTestBase.CleanupAllInjectionHooks();
+
                 using (var world = new World("test-world"))
                 {
                     var system = new ExampleHybridSystem();
 
-                    var argumentException = Assert.Throws<ArgumentException>(() =>
-                        {
-                            // This is basically the same action as world.GetOrCreateManager<ExampleHybridSystem>();
-                            // However, if we actually called the above it would cause memory leaks and make other tests fail.
-                            system.TestInjection(world);
-                        },
-                        "The `{0}` class may no longer be necessary, since an `{1}` system could be created without InjectionHooks.",
-                        nameof(HybridGdkSystemTestBase),
-                        nameof(ExampleHybridSystem));
+                    try
+                    {
+                        var argumentException = Assert.Throws<ArgumentException>(() =>
+                            {
+                                // This is basically the same action as world.GetOrCreateManager<ExampleHybridSystem>();
+                                // However, if we actually called the above it would cause memory leaks and make other tests fail.
+                                system.TestInjection(world);
+                            },
+                            "The `{0}` class may no longer be necessary, since an `{1}` system could be created without InjectionHooks.",
+                            nameof(HybridGdkSystemTestBase),
+                            nameof(ExampleHybridSystem));
 
-                    Assert.IsTrue(argumentException.Message.Contains("[Inject]"),
-                        "The error message ({0}) was not about an injection annotation.",
-                        argumentException.Message);
-
-                    // Ensure that the system does not leak.
-                    system.ManualDispose();
+                        Assert.IsTrue(argumentException.Message.Contains("[Inject]"),
+                            "The error message ({0}) was not about an injection annotation.",
+                            argumentException.Message);
+                    }
+                    finally
+                    {
+                        // Ensure that the system does not leak.
+                        system.ManualDispose();
+                    }
                 }
             }
         }


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
If the `DefaultWorldInitializationTestsInitialize_ShouldLogNothing` test runs before `HybridGdkSystemTestBaseTests.HybridSystems_will_result_in_errors_when_created_if_fixture_does_not_extend_HybridGdkSystemTestBase` then the injection hooks would not be cleaned up.

This means the `HybridGdkSystemTestBase` would find itself unneeded and be sad. But it's still needed.

So we clean up the hooks now.

Also, when the test fails, it would leak parts of the system. Moved the system dispose call into a finally block to ensure it will not leak in failure cases.

#### Tests
The tests were having an existential crisis.