### PR TITLE
UTY 714: Add schema-compiler flag to CodeGenerator

### DIFF
--- a/ci/codegen.sh
+++ b/ci/codegen.sh
@@ -16,7 +16,16 @@ markEndOfBlock "Copying Packages Schema"
 
 markStartOfBlock "Generating code"
 
+if isWindows;
+  then SCHEMA_COMPILER="tools/schema_compiler/win/schema_compiler.exe"
+elif isMacOS;
+  then SCHEMA_COMPILER="tools/schema_compiler/macos/schema_compiler"
+elif isLinux;
+  then SCHEMA_COMPILER="tools/schema_compiler/linux/schema_compiler"
+fi
+
 dotnet run -p code_generator/GdkCodeGenerator/GdkCodeGenerator.csproj -- \
+  --schema-compiler="$SCHEMA_COMPILER" \
   --schema-path="schema" \
   --schema-path="build/dependencies/schema/standard_library" \
   --json-dir="workers/unity/Temp/ImprobableJson" \

--- a/code_generator/GdkCodeGenerator/src/CodeGenerator.cs
+++ b/code_generator/GdkCodeGenerator/src/CodeGenerator.cs
@@ -12,10 +12,6 @@ namespace Improbable.Gdk.CodeGenerator
         private readonly CodeGeneratorOptions options;
         private readonly IFileSystem fileSystem;
 
-        private readonly string schemaCompilerPath = RuntimeInformation.IsOSPlatform(OSPlatform.OSX)
-            ? @"tools/schema_compiler/macos/schema_compiler"
-            : @"tools\schema_compiler\win\schema_compiler.exe";
-
         public static int Main(string[] args)
         {
             try
@@ -92,7 +88,7 @@ namespace Improbable.Gdk.CodeGenerator
                 $@"--ast_json_out={options.JsonDirectory}"
             }.Union(inputPaths).Union(files).ToList();
 
-            SystemTools.RunRedirected(schemaCompilerPath, arguments);
+            SystemTools.RunRedirected(options.SchemaCompiler, arguments);
         }
 
         private HashSet<string> ExtractEnums(ICollection<UnitySchemaFile> schemas)

--- a/code_generator/GdkCodeGenerator/src/CodeGeneratorOptions.cs
+++ b/code_generator/GdkCodeGenerator/src/CodeGeneratorOptions.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.IO;
 using Mono.Options;
 
@@ -12,6 +12,7 @@ namespace Improbable.Gdk.CodeGenerator
         public string JsonDirectory { get; private set; }
         public string NativeOutputDirectory { get; private set; }
         public string NetworkTypesOutputDirectory { get; private set; }
+        public string SchemaCompiler { get; private set; }
         public bool ShouldShowHelp { get; private set; }
         public string HelpText { get; private set; }
         public List<string> SchemaInputDirs { get; } = new List<string>();
@@ -33,6 +34,10 @@ namespace Improbable.Gdk.CodeGenerator
                     "network-types-output-dir=",
                     "REQUIRED: the directory to output the network types and serialization code to",
                     u => options.NetworkTypesOutputDirectory = u
+                },
+                {
+                    "schema-compiler=", "REQUIRED: the schema compiler executable to use",
+                    s => options.SchemaCompiler = s
                 },
                 {
                     "schema-path=", "REQUIRED: a comma-separated list of directories that contain schema files",


### PR DESCRIPTION
#### Description
Adds schema-compiler flag to the code generator instead of the hardcoded path. This will allow running the code generator from a different directory.
#### Tests
Ran GdkCodeGenerator Tests, and verified ci/codegen.sh works on windows. need to test other platforms:
- [ ] MacOS
- [ ] Linux
#### Documentation
How is this documented (for example: release note, upgrade guide, feature page, in-code documentation)?
#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.