### PR TITLE
UTY 714: schema-compiler-path fixes

### DIFF
--- a/ci/codegen.sh
+++ b/ci/codegen.sh
@@ -20,8 +20,6 @@ if isWindows;
   then SCHEMA_COMPILER="tools/schema_compiler/win/schema_compiler.exe"
 elif isMacOS;
   then SCHEMA_COMPILER="tools/schema_compiler/macos/schema_compiler"
-elif isLinux;
-  then SCHEMA_COMPILER="tools/schema_compiler/linux/schema_compiler"
 fi
 
 dotnet run -p code_generator/GdkCodeGenerator/GdkCodeGenerator.csproj -- \

--- a/code_generator/GdkCodeGenerator/src/CodeGenerator.cs
+++ b/code_generator/GdkCodeGenerator/src/CodeGenerator.cs
@@ -143,6 +143,12 @@ namespace Improbable.Gdk.CodeGenerator
                 return false;
             }
 
+            if (options.SchemaCompiler == null)
+            {
+                Console.WriteLine("Schema compiler path not specified");
+                return false;
+            }
+
             if (options.SchemaInputDirs == null || options.SchemaInputDirs.Count == 0)
             {
                 Console.WriteLine("Schema input directories not specified");


### PR DESCRIPTION
#### Description
Fixes a few small issues with schema-compiler-path:
1. Removes isLinux check since linux is not currently supported.
2. Checks for schema-compiler-path flag as it is required.
#### Tests
Ran codegen tests, and ran ci/codegen.sh