### PR TITLE
UTY-375: Add ComponentUpdated when a component is added.

### DIFF
--- a/code_generator/GdkCodeGenerator/Templates/UnityComponentConversionGenerator.tt
+++ b/code_generator/GdkCodeGenerator/Templates/UnityComponentConversionGenerator.tt
@@ -125,11 +125,14 @@ namespace <#= qualifiedNamespace #>
                 }
 <# if(fieldDetailsList.Count > 0) { #>
                 var data = op.Data.Get().Value;
+                var <#= componentDetails.CamelCaseTypeName#>Update = new <#= componentDetails.TypeName #>.Update();
 <# } #>
 
                 var <#= componentDetails.CamelCaseTypeName #> = new <#= componentDetails.TypeName#>();
 <# foreach (var fieldDetails in fieldDetailsList) { #>
                 <#= componentDetails.CamelCaseTypeName#>.<#= fieldDetails.PascalCaseName #> = <#= UnityTypeMappings.GetNativeTypeMethod(fieldDetails.RawFieldDefinition, "data." + fieldDetails.CamelCaseName, enumSet) #>;
+                <#= componentDetails.CamelCaseTypeName#>Update.<#= fieldDetails.PascalCaseName #> = new Option<<#= fieldDetails.Type #>>(<#= UnityTypeMappings.GetNativeTypeMethod(fieldDetails.RawFieldDefinition, "data." + fieldDetails.CamelCaseName, enumSet) #>);
+
 <# } #>
                 <#= componentDetails.CamelCaseTypeName#>.DirtyBit = false;
 
@@ -147,6 +150,9 @@ namespace <#= qualifiedNamespace #>
                 else if (!view.HasComponent<ComponentAdded<<#= componentDetails.TypeName #>>>(entity))
                 {
                     view.AddComponent(entity, new ComponentAdded<<#= componentDetails.TypeName #>>());
+<# if(fieldDetailsList.Count > 0) { #>
+                    view.AddComponentsUpdated(entity, <#= componentDetails.CamelCaseTypeName#>Update, UpdatesPool);
+<# } #>
                 }
                 else
                 {

--- a/code_generator/GdkCodeGenerator/Templates/UnityComponentConversionGenerator.tt
+++ b/code_generator/GdkCodeGenerator/Templates/UnityComponentConversionGenerator.tt
@@ -86,6 +86,8 @@ namespace <#= qualifiedNamespace #>
                 new ComponentPool<ComponentsUpdated<<#= componentDetails.TypeName #>.Update>>(
                     () => new ComponentsUpdated<<#= componentDetails.TypeName #>.Update>(),
                     (component) => component.Buffer.Clear());
+                    
+            private readonly Dictionary<Unity.Entities.Entity, <#= componentDetails.TypeName #>.Update> possibleUpdates = new Dictionary<Unity.Entities.Entity, <#= componentDetails.TypeName #>.Update>();
 <# } #>
 
             public Translation(MutableView view) : base(view)
@@ -151,7 +153,7 @@ namespace <#= qualifiedNamespace #>
                 {
                     view.AddComponent(entity, new ComponentAdded<<#= componentDetails.TypeName #>>());
 <# if(fieldDetailsList.Count > 0) { #>
-                    view.AddComponentsUpdated(entity, <#= componentDetails.CamelCaseTypeName#>Update, UpdatesPool);
+                    possibleUpdates.Add(entity, <#= componentDetails.CamelCaseTypeName#>Update);
 <# } #>
                 }
                 else
@@ -270,13 +272,23 @@ namespace <#= qualifiedNamespace #>
             public void OnAuthorityChange(AuthorityChangeOp op)
             {
                 var entityId = op.EntityId.Id;
+                Unity.Entities.Entity entity;
+                if (!view.TryGetEntity(entityId, out entity))
+                {
+                    LogDispatcher.HandleLog(LogType.Error, new LogEvent("Entity not found during authority change.")
+                        .WithField(LoggingUtils.LoggerName, LoggerName)
+                        .WithField(LoggingUtils.EntityId, entityId)
+                        .WithField(MutableView.Component, "<#= componentDetails.TypeName #>"));
+                    return;
+                }
+            
 <# if(eventDetailsList.Count > 0) { #>
                 if (op.Authority == Authority.Authoritative)
                 {
 <# foreach(var eventDetails in eventDetailsList) { #>
                     EntityIdTo<#= eventDetails.EventName #>Events[entityId] = new List<<#= eventDetails.FullyQualifiedPayloadTypeName #>>();
 <# } #>
-                    view.AddComponent(entityId, new EventSender<<#= componentDetails.TypeName #>>(entityId, translationHandle));
+                    view.AddComponent(entity, new EventSender<<#= componentDetails.TypeName #>>(entityId, translationHandle));
                 }
                 else if (op.Authority == Authority.NotAuthoritative)
                 {
@@ -286,9 +298,28 @@ namespace <#= qualifiedNamespace #>
                     view.RemoveComponent<EventSender<<#= componentDetails.TypeName #>>>(entityId);
                 }
 <# } #>
-                view.HandleAuthorityChange(entityId, op.Authority, AuthsPool);
+                view.HandleAuthorityChange(entity, op.Authority, AuthsPool);
+
+<# if (fieldDetailsList.Count > 0) { #>                
+                if (op.Authority == Authority.Authoritative)
+                {
+                    possibleUpdates.Remove(entity);
+                }
+<# } #>
             }
 
+            public override void PostReceive()
+            {
+<# if (fieldDetailsList.Count > 0) { #> 
+                foreach (var update in possibleUpdates)
+                {
+                    view.AddComponentsUpdated(update.Key, update.Value, UpdatesPool);
+                }
+
+                possibleUpdates.Clear();
+<# } #>
+            }
+            
             public override void ExecuteReplication(Connection connection)
             {
 <# if (componentDetails.IsBlittable) { #>

--- a/code_generator/GdkCodeGenerator/Templates/UnityComponentConversionGenerator.tt
+++ b/code_generator/GdkCodeGenerator/Templates/UnityComponentConversionGenerator.tt
@@ -131,7 +131,7 @@ namespace <#= qualifiedNamespace #>
                 var <#= componentDetails.CamelCaseTypeName #> = new <#= componentDetails.TypeName#>();
 <# foreach (var fieldDetails in fieldDetailsList) { #>
                 <#= componentDetails.CamelCaseTypeName#>.<#= fieldDetails.PascalCaseName #> = <#= UnityTypeMappings.GetNativeTypeMethod(fieldDetails.RawFieldDefinition, "data." + fieldDetails.CamelCaseName, enumSet) #>;
-                <#= componentDetails.CamelCaseTypeName#>Update.<#= fieldDetails.PascalCaseName #> = new Option<<#= fieldDetails.Type #>>(<#= UnityTypeMappings.GetNativeTypeMethod(fieldDetails.RawFieldDefinition, "data." + fieldDetails.CamelCaseName, enumSet) #>);
+                <#= componentDetails.CamelCaseTypeName#>Update.<#= fieldDetails.PascalCaseName #> = new Option<<#= fieldDetails.Type #>>(<#= componentDetails.CamelCaseTypeName#>.<#= fieldDetails.PascalCaseName #>);
 
 <# } #>
                 <#= componentDetails.CamelCaseTypeName#>.DirtyBit = false;

--- a/workers/unity/Packages/com.improbable.gdk.core/Components/ComponentTranslation.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Components/ComponentTranslation.cs
@@ -54,6 +54,7 @@ namespace Improbable.Gdk.Core.Components
 
         public abstract ComponentType[] ReplicationComponentTypes { get; }
         public ComponentGroup ReplicationComponentGroup { get; set; }
+        public abstract void PostReceive();
         public abstract void ExecuteReplication(Connection connection);
 
         public abstract ComponentType[] CleanUpComponentTypes { get; }

--- a/workers/unity/Packages/com.improbable.gdk.core/Components/WorldCommandsTranslation.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Components/WorldCommandsTranslation.cs
@@ -249,6 +249,10 @@ namespace Improbable.Gdk.Core
             view.AddComponent(entity, new WorldCommandSender(EntityId, translationHandle));
         }
 
+        public override void PostReceive()
+        {
+        }
+
         public override void ExecuteReplication(Connection connection)
         {
         }

--- a/workers/unity/Packages/com.improbable.gdk.core/MutableView/MutableView.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/MutableView/MutableView.cs
@@ -205,19 +205,9 @@ namespace Improbable.Gdk.Core
             return entityMapping.TryGetValue(entityId, out entity);
         }
 
-        public void HandleAuthorityChange<T>(long entityId, Authority authority,
+        public void HandleAuthorityChange<T>(Entity entity, Authority authority,
             ComponentPool<AuthoritiesChanged<T>> pool)
         {
-            Entity entity;
-            if (!TryGetEntity(entityId, out entity))
-            {
-                LogDispatcher.HandleLog(LogType.Error, new LogEvent(Errors.EntityNotFoundOnAuthotityChange)
-                    .WithField(LoggingUtils.LoggerName, LoggerName)
-                    .WithField(LoggingUtils.EntityId, entityId)
-                    .WithField(Component, typeof(T).Name));
-                return;
-            }
-
             switch (authority)
             {
                 case Authority.Authoritative:
@@ -362,8 +352,6 @@ namespace Improbable.Gdk.Core
 
             public const string EntityNotFoundOnSetComponentObject =
                 "Entity not found when attempting to set component object.";
-
-            public const string EntityNotFoundOnAuthotityChange = "Entity not found during authority change.";
 
             public const string DuplicateAdditionOfEntity =
                 "Tried to add an entity but there is already an entity associated with that EntityId.";

--- a/workers/unity/Packages/com.improbable.gdk.core/Systems/SpatialOSReceiveSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Systems/SpatialOSReceiveSystem.cs
@@ -38,6 +38,11 @@ namespace Improbable.Gdk.Core
                 }
             }
             while (inCriticalSection);
+
+            foreach (var translationUnit in view.TranslationUnits.Values)
+            {
+                translationUnit.PostReceive();
+            }
         }
 
         private void OnAddEntity(AddEntityOp op)


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
We should add ComponentUpdated when a new component is added.

Example generated translation code:

```csharp
public partial class Position
{
    public class Translation : ComponentTranslation, IDispatcherCallbacks<global::Improbable.Position>
    {
        private readonly Dictionary<Unity.Entities.Entity, SpatialOSPosition.Update> possibleUpdates 
            = new Dictionary<Unity.Entities.Entity, SpatialOSPosition.Update>();


        public void OnAddComponent(AddComponentOp<global::Improbable.Position> op)
        {
            var spatialOSPositionUpdate = new SpatialOSPosition.Update();

            var spatialOSPosition = new SpatialOSPosition();
            spatialOSPosition.Coords = global::Generated.Improbable.Coordinates.ToNative(data.coords);
            
            if (view.HasComponent<ComponentRemoved<SpatialOSPosition>>(entity))
            {
                ...
            }
            else if (!view.HasComponent<ComponentAdded<SpatialOSPosition>>(entity))
            {
                possibleUpdates.Add(entity, spatialOSPositionUpdate);
            }
        }

        public void OnAuthorityChange(AuthorityChangeOp op)
        {
            ...
            
            if (op.Authority == Authority.Authoritative)
            {
                possibleUpdates.Remove(entity);
            }
        }

        public override void PostReceive()
        {

            foreach (var update in possibleUpdates)
            {
                view.AddComponentsUpdated(update.Key, update.Value, UpdatesPool);
            }

            possibleUpdates.Clear();
        }
    }
}
```
```csharp
public class SpatialOSReceiveSystem : ComponentSystem
{
    protected override void OnUpdate()
    {
        if (worker.Connection == null)
        {
            return;
        }

        do
        {
            using (var opList = worker.Connection.GetOpList(0))
            {
                dispatcher.Process(opList);
            }
        }
        while (inCriticalSection);

        foreach (var translationUnit in view.TranslationUnits.Values)
        {
            translationUnit.PostReceive();
        }
    }
}
```

#### Tests
Run code, nothing broke.

#### Documentation
Will add documentation in a separate PR.

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
