### PR TITLE
UTY-476: Log error if users attempt to respond to a command request twice.

### DIFF
--- a/code_generator/GdkCodeGenerator/Templates/UnityCommandPayloadGenerator.tt
+++ b/code_generator/GdkCodeGenerator/Templates/UnityCommandPayloadGenerator.tt
@@ -9,6 +9,7 @@
 
 using Improbable.Gdk.Core;
 using System.Collections.Generic;
+using UnityEngine;
 
 namespace <#= qualifiedNamespace #>
 {
@@ -44,6 +45,17 @@ namespace <#= qualifiedNamespace #>
 
                 public void Send<#= commandDetails.CommandName #>Response(<#= commandDetails.ResponseType #> response)
                 {
+                    if (Translation.<#= commandDetails.CommandName #>ResponsesToSend.Contains(RequestId))
+                    {
+                        Translation.LogDispatcher.HandleLog(LogType.Error, new LogEvent(
+                                "Attempting to send a duplicate response.")
+                            .WithField(LoggingUtils.LoggerName, Translation.LoggerName)
+                            .WithField("CommandName", "<#= commandDetails.CommandName #>")
+                            .WithField("RequestId", RequestId));
+                        return;
+                    }
+                
+                    Translation.<#= commandDetails.CommandName #>ResponsesToSend.Add(RequestId);
                     Translation.<#= commandDetails.CommandName #>Responses.Add(
                         new OutgoingResponse(RequestId, response));
                 }

--- a/code_generator/GdkCodeGenerator/Templates/UnityComponentConversionGenerator.tt
+++ b/code_generator/GdkCodeGenerator/Templates/UnityComponentConversionGenerator.tt
@@ -25,7 +25,7 @@ namespace <#= qualifiedNamespace #>
     {
         public class Translation : ComponentTranslation, IDispatcherCallbacks<<#= componentDetails.FullyQualifiedSpatialTypeName #>>
         {
-            private const string LoggerName = "<#= componentDetails.ComponentName #>.Translation";
+            internal const string LoggerName = "<#= componentDetails.ComponentName #>.Translation";
         
             public override ComponentType TargetComponentType => targetComponentType;
             private static readonly ComponentType targetComponentType = typeof(<#= componentDetails.TypeName #>);
@@ -56,6 +56,7 @@ namespace <#= qualifiedNamespace #>
 <# foreach(var commandDetails in commandDetailsList) { #>
             internal List<<#= commandDetails.CommandName #>.OutgoingRequest> <#= commandDetails.CommandName #>Requests = new List<<#= commandDetails.CommandName #>.OutgoingRequest>();
             internal List<<#= commandDetails.CommandName #>.OutgoingResponse> <#= commandDetails.CommandName #>Responses = new List<<#= commandDetails.CommandName #>.OutgoingResponse>();
+            internal HashSet<uint> <#= commandDetails.CommandName #>ResponsesToSend = new HashSet<uint>();
             private static readonly ComponentPool<CommandRequests<<#= commandDetails.CommandName #>.Request>> <#= commandDetails.CommandName #>RequestPool =
                 new ComponentPool<CommandRequests<<#= commandDetails.CommandName #>.Request>>(
                     () => new CommandRequests<<#= commandDetails.CommandName #>.Request>(),
@@ -348,6 +349,7 @@ namespace <#= qualifiedNamespace #>
 <# for(var i = 0; i < commandDetailsList.Count; i++) { #>
                 RemoveComponents(ref entityCommandBuffer, <#= commandDetailsList[i].CommandName #>RequestPool, groupIndex: <#= i * 2 + (fieldDetailsList.Count == 0 ? 3 : 4) #>);
                 RemoveComponents(ref entityCommandBuffer, <#= commandDetailsList[i].CommandName #>ResponsePool, groupIndex: <#= i * 2 + (fieldDetailsList.Count == 0 ? 4 : 5) #>);
+                <#= commandDetailsList[i].CommandName #>ResponsesToSend.Clear();
 <# } #>
 <# for(var i = 0; i < eventDetailsList.Count; i++) { #>
                 RemoveComponents(ref entityCommandBuffer, <#= eventDetailsList[i].EventName #>EventPool, groupIndex: <#= i + commandDetailsList.Count * 2 + (fieldDetailsList.Count == 0 ? 3 : 4) #>);

--- a/workers/unity/Packages/com.improbable.gdk.core/Components/ComponentTranslation.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Components/ComponentTranslation.cs
@@ -23,7 +23,7 @@ namespace Improbable.Gdk.Core.Components
 
         public abstract ComponentType TargetComponentType { get; }
         protected readonly MutableView view;
-        protected readonly ILogDispatcher LogDispatcher;
+        public readonly ILogDispatcher LogDispatcher;
 
         protected ComponentTranslation(MutableView view)
         {


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
If two systems each inject for command requests and attempt to respond to command requests, we currently respond to a command requests twice. In this case one of the two responses is dropped by the bridge. We want to avoid the situation where something goes wrong and the user can't tell why and we want to help users debug their issues through meaningful error messages.

#### Tests
Send two responses to a command, got an error warning.

#### Documentation
N/A

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.