### PR TITLE
[Mac] Fixing crash of Unity when running tests in CI

### DIFF
--- a/ci/test.sh
+++ b/ci/test.sh
@@ -42,7 +42,6 @@ markStartOfBlock "Editmode Testing"
 
 pushd "workers/unity"
   dotnet run -p ../../tools/RunUnity/RunUnity.csproj -- \
-    -nographics \
     -batchmode \
     -projectPath "${PROJECT_DIR}/workers/unity" \
     -runTests \
@@ -61,7 +60,6 @@ markStartOfBlock "Playmode Testing"
 
 pushd "workers/unity"
   dotnet run -p ../../tools/RunUnity/RunUnity.csproj -- \
-    -nographics \
     -batchmode \
     -projectPath "${PROJECT_DIR}/workers/unity" \
     -runTests \

--- a/workers/unity/spatialos.UnityGameLogic.worker.json
+++ b/workers/unity/spatialos.UnityGameLogic.worker.json
@@ -49,7 +49,6 @@
         "+linkProtocol",
         "RakNet",
         "-batchmode",
-        "-nographics",
         "-logfile",
         "${IMPROBABLE_LOG_FILE}"
       ]
@@ -71,7 +70,6 @@
         "+linkProtocol",
         "RakNet",
         "-batchmode",
-        "-nographics",
         "-logfile",
         "${IMPROBABLE_LOG_FILE}"
       ]


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
The Unity.entities tests will crash when run from CI with `-nographics` enabled. Removing all instances of this flag as it's not the first time that `-nographics` has caused problems.

#### Tests
ran it multiple times on a Mac using different projects.

#### Documentation
no doc needed

#### Primary reviewers
