### PR TITLE
UTY-622 Allow `spatial local worker launch` and reconnections

### DIFF
--- a/workers/unity/Assets/Playground/Scripts/Bootstrap.cs
+++ b/workers/unity/Assets/Playground/Scripts/Bootstrap.cs
@@ -66,7 +66,7 @@ namespace Playground
                         string.Empty);
                 var useDynamicWorkerId = CommandLineUtility.GetCommandLineValue(commandLineArgs,
                     RuntimeConfigNames.UseDynamicWorkerId,
-                    "false") == "true";
+                    false);
 
                 // because the launcher does not pass in the worker type as an argument
                 var worker = workerType.Equals(string.Empty)
@@ -75,7 +75,7 @@ namespace Playground
 
                 if (useDynamicWorkerId)
                 {
-                    worker.AllowDynamicId = true;
+                    worker.UseDynamicId = true;
                 }
 
                 Workers.Add(worker);

--- a/workers/unity/Assets/Playground/Scripts/Bootstrap.cs
+++ b/workers/unity/Assets/Playground/Scripts/Bootstrap.cs
@@ -64,19 +64,13 @@ namespace Playground
                 var workerId =
                     CommandLineUtility.GetCommandLineValue(commandLineArgs, RuntimeConfigNames.WorkerId,
                         string.Empty);
-                var forceDynamicWorkerId = CommandLineUtility.GetCommandLineValue(commandLineArgs,
-                    RuntimeConfigNames.ForceDynamicWorkerId,
-                    false);
 
                 // because the launcher does not pass in the worker type as an argument
                 var worker = workerType.Equals(string.Empty)
-                    ? WorkerRegistry.CreateWorker<UnityClient>($"{workerType}-{Guid.NewGuid()}", new Vector3(0, 0, 0))
+                    ? WorkerRegistry.CreateWorker<UnityClient>(
+                        workerId: null, // The worker id for the UnityClient will be auto-generated.
+                        origin: new Vector3(0, 0, 0))
                     : WorkerRegistry.CreateWorker(workerType, workerId, new Vector3(0, 0, 0));
-
-                if (forceDynamicWorkerId)
-                {
-                    worker.UseDynamicId = true;
-                }
 
                 Workers.Add(worker);
 

--- a/workers/unity/Assets/Playground/Scripts/Bootstrap.cs
+++ b/workers/unity/Assets/Playground/Scripts/Bootstrap.cs
@@ -64,11 +64,19 @@ namespace Playground
                 var workerId =
                     CommandLineUtility.GetCommandLineValue(commandLineArgs, RuntimeConfigNames.WorkerId,
                         string.Empty);
+                var useUniqueConnectionId = CommandLineUtility.GetCommandLineValue(commandLineArgs,
+                    RuntimeConfigNames.UseUniqueConnectionId,
+                    "false") == "true";
 
                 // because the launcher does not pass in the worker type as an argument
                 var worker = workerType.Equals(string.Empty)
                     ? WorkerRegistry.CreateWorker<UnityClient>($"{workerType}-{Guid.NewGuid()}", new Vector3(0, 0, 0))
                     : WorkerRegistry.CreateWorker(workerType, workerId, new Vector3(0, 0, 0));
+
+                if (useUniqueConnectionId)
+                {
+                    worker.RequiresUniqueWorkerIdPerConnection = true;
+                }
 
                 Workers.Add(worker);
 

--- a/workers/unity/Assets/Playground/Scripts/Bootstrap.cs
+++ b/workers/unity/Assets/Playground/Scripts/Bootstrap.cs
@@ -64,8 +64,8 @@ namespace Playground
                 var workerId =
                     CommandLineUtility.GetCommandLineValue(commandLineArgs, RuntimeConfigNames.WorkerId,
                         string.Empty);
-                var useDynamicWorkerId = CommandLineUtility.GetCommandLineValue(commandLineArgs,
-                    RuntimeConfigNames.UseDynamicWorkerId,
+                var forceDynamicWorkerId = CommandLineUtility.GetCommandLineValue(commandLineArgs,
+                    RuntimeConfigNames.ForceDynamicWorkerId,
                     false);
 
                 // because the launcher does not pass in the worker type as an argument
@@ -73,7 +73,7 @@ namespace Playground
                     ? WorkerRegistry.CreateWorker<UnityClient>($"{workerType}-{Guid.NewGuid()}", new Vector3(0, 0, 0))
                     : WorkerRegistry.CreateWorker(workerType, workerId, new Vector3(0, 0, 0));
 
-                if (useDynamicWorkerId)
+                if (forceDynamicWorkerId)
                 {
                     worker.UseDynamicId = true;
                 }

--- a/workers/unity/Assets/Playground/Scripts/Bootstrap.cs
+++ b/workers/unity/Assets/Playground/Scripts/Bootstrap.cs
@@ -64,8 +64,8 @@ namespace Playground
                 var workerId =
                     CommandLineUtility.GetCommandLineValue(commandLineArgs, RuntimeConfigNames.WorkerId,
                         string.Empty);
-                var useUniqueConnectionId = CommandLineUtility.GetCommandLineValue(commandLineArgs,
-                    RuntimeConfigNames.UseUniqueConnectionId,
+                var useDynamicWorkerId = CommandLineUtility.GetCommandLineValue(commandLineArgs,
+                    RuntimeConfigNames.UseDynamicWorkerId,
                     "false") == "true";
 
                 // because the launcher does not pass in the worker type as an argument
@@ -73,9 +73,9 @@ namespace Playground
                     ? WorkerRegistry.CreateWorker<UnityClient>($"{workerType}-{Guid.NewGuid()}", new Vector3(0, 0, 0))
                     : WorkerRegistry.CreateWorker(workerType, workerId, new Vector3(0, 0, 0));
 
-                if (useUniqueConnectionId)
+                if (useDynamicWorkerId)
                 {
-                    worker.RequiresUniqueWorkerIdPerConnection = true;
+                    worker.AllowDynamicId = true;
                 }
 
                 Workers.Add(worker);

--- a/workers/unity/Assets/Playground/Scripts/Workers/UnityClient.cs
+++ b/workers/unity/Assets/Playground/Scripts/Workers/UnityClient.cs
@@ -16,6 +16,8 @@ namespace Playground
         public UnityClient(string workerId, Vector3 origin) : base(workerId, origin, new ForwardingDispatcher())
         {
             forwardingDispatcher = (ForwardingDispatcher) View.LogDispatcher;
+
+            RequiresUniqueWorkerIdPerConnection = true;
         }
 
         public override void Connect(ConnectionConfig config)

--- a/workers/unity/Assets/Playground/Scripts/Workers/UnityClient.cs
+++ b/workers/unity/Assets/Playground/Scripts/Workers/UnityClient.cs
@@ -16,8 +16,7 @@ namespace Playground
         public UnityClient(string workerId, Vector3 origin) : base(workerId, origin, new ForwardingDispatcher())
         {
             forwardingDispatcher = (ForwardingDispatcher) View.LogDispatcher;
-
-            AllowDynamicId = true;
+            UseDynamicId = true;
         }
 
         public override void Connect(ConnectionConfig config)

--- a/workers/unity/Assets/Playground/Scripts/Workers/UnityClient.cs
+++ b/workers/unity/Assets/Playground/Scripts/Workers/UnityClient.cs
@@ -17,7 +17,7 @@ namespace Playground
         {
             forwardingDispatcher = (ForwardingDispatcher) View.LogDispatcher;
 
-            RequiresUniqueWorkerIdPerConnection = true;
+            AllowDynamicId = true;
         }
 
         public override void Connect(ConnectionConfig config)

--- a/workers/unity/Assets/Playground/Scripts/Workers/UnityGameLogic.cs
+++ b/workers/unity/Assets/Playground/Scripts/Workers/UnityGameLogic.cs
@@ -17,6 +17,10 @@ namespace Playground
         {
             PlayerLifecycleConfig.CreatePlayerEntityTemplate = PlayerTemplate.CreatePlayerEntityTemplate;
             forwardingDispatcher = (ForwardingDispatcher) View.LogDispatcher;
+
+#if UNITY_EDITOR
+            RequiresUniqueWorkerIdPerConnection = true;
+#endif
         }
 
         public override void Connect(ConnectionConfig config)

--- a/workers/unity/Assets/Playground/Scripts/Workers/UnityGameLogic.cs
+++ b/workers/unity/Assets/Playground/Scripts/Workers/UnityGameLogic.cs
@@ -19,7 +19,7 @@ namespace Playground
             forwardingDispatcher = (ForwardingDispatcher) View.LogDispatcher;
 
 #if UNITY_EDITOR
-            RequiresUniqueWorkerIdPerConnection = true;
+            AllowDynamicId = true;
 #endif
         }
 

--- a/workers/unity/Assets/Playground/Scripts/Workers/UnityGameLogic.cs
+++ b/workers/unity/Assets/Playground/Scripts/Workers/UnityGameLogic.cs
@@ -18,9 +18,7 @@ namespace Playground
             PlayerLifecycleConfig.CreatePlayerEntityTemplate = PlayerTemplate.CreatePlayerEntityTemplate;
             forwardingDispatcher = (ForwardingDispatcher) View.LogDispatcher;
 
-#if UNITY_EDITOR
-            AllowDynamicId = true;
-#endif
+            UseDynamicId = Application.isEditor;
         }
 
         public override void Connect(ConnectionConfig config)

--- a/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs
@@ -23,5 +23,6 @@ namespace Improbable.Gdk.Core
         public const string ReceptionistPort = "receptionistPort";
         public const string WorkerId = "workerId";
         public const string WorkerType = "workerType";
+        public const string UseUniqueConnectionId = "useUniqueConnectionId";
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs
@@ -23,6 +23,6 @@ namespace Improbable.Gdk.Core
         public const string ReceptionistPort = "receptionistPort";
         public const string WorkerId = "workerId";
         public const string WorkerType = "workerType";
-        public const string UseUniqueConnectionId = "useUniqueConnectionId";
+        public const string UseDynamicWorkerId = "useDynamicWorkerId";
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs
@@ -23,6 +23,5 @@ namespace Improbable.Gdk.Core
         public const string ReceptionistPort = "receptionistPort";
         public const string WorkerId = "workerId";
         public const string WorkerType = "workerType";
-        public const string ForceDynamicWorkerId = "forceDynamicWorkerId";
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs
@@ -23,6 +23,6 @@ namespace Improbable.Gdk.Core
         public const string ReceptionistPort = "receptionistPort";
         public const string WorkerId = "workerId";
         public const string WorkerType = "workerType";
-        public const string UseDynamicWorkerId = "useDynamicWorkerId";
+        public const string ForceDynamicWorkerId = "forceDynamicWorkerId";
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.core/Tests/Editmode/Worker/WorkerBaseTests.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Tests/Editmode/Worker/WorkerBaseTests.cs
@@ -8,33 +8,52 @@ namespace Improbable.Gdk.Core.EditmodeTests
     public class WorkerBaseTests
     {
         [Test]
-        public void WorkerBase_should_throw_exception_when_WorkerId_is_null_or_empty()
+        public void WorkerId_should_be_dynamically_generated_when_parameter_is_null_or_empty()
         {
-            // Empty check
-            var empty_exception = Assert.Throws<System.ArgumentException>(() =>
+            using (var workerWithEmptyWorkerIdParameter = new UnityTestWorker("", Vector3.zero))
             {
-                var worker = new UnityTestWorker("", new Vector3());
-                worker.Dispose();
-            });
-            Assert.IsTrue(empty_exception.Message.Contains("WorkerId"));
+                Assert.IsNotNull(workerWithEmptyWorkerIdParameter.WorkerId,
+                    "The worker should have an ID generated for it if an empty string is passed into the constructor parameter, but it did not.");
+                Assert.IsTrue(workerWithEmptyWorkerIdParameter.WorkerId.StartsWith("UnityTestWorker-"),
+                    "The generated worker ID should start with the worker type, but it did not.");
+            }
 
-            // Null check
-            var null_exception = Assert.Throws<System.ArgumentException>(() =>
+            using (var workerWithNullWorkerIdParameter = new UnityTestWorker(null, Vector3.zero))
             {
-                var worker = new UnityTestWorker(null, new Vector3());
-                worker.Dispose();
-            });
-            Assert.IsTrue(null_exception.Message.Contains("WorkerId"));
+                Assert.IsNotNull(workerWithNullWorkerIdParameter.WorkerId,
+                    "The worker should have an ID generated for it if null is passed into the constructor parameter, but it did not.");
+                Assert.IsTrue(workerWithNullWorkerIdParameter.WorkerId.StartsWith("UnityTestWorker-"),
+                    "The generated worker ID should start with the worker type, but it did not.");
+            }
+        }
+
+        [Test]
+        public void WorkerId_should_be_unique_when_dynamically_generated()
+        {
+            using (var workerWithEmptyWorkerIdParameter = new UnityTestWorker("", Vector3.zero))
+            {
+                using (var workerWithNullWorkerIdParameter = new UnityTestWorker(null, Vector3.zero))
+                {
+                    Assert.AreNotEqual(
+                        workerWithEmptyWorkerIdParameter.WorkerId,
+                        workerWithNullWorkerIdParameter.WorkerId,
+                        "Auto-generated worker IDs should be unique.");
+                }
+            }
         }
 
         [Test]
         public void WorkerBase_should_accept_an_arbitrary_WorkerId()
         {
-            Assert.DoesNotThrow(() =>
+            using (WorkerBase worker = new UnityTestWorker("worker-id", Vector3.zero))
             {
-                var worker = new UnityTestWorker("worker-id", new Vector3());
-                worker.Dispose();
-            });
+                Assert.AreEqual("worker-id", worker.WorkerId);
+            }
+
+            using (WorkerBase worker = new UnityTestWorker("another-worker-id", Vector3.zero))
+            {
+                Assert.AreEqual("another-worker-id", worker.WorkerId);
+            }
         }
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerBase.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerBase.cs
@@ -49,11 +49,25 @@ namespace Improbable.Gdk.Core
             World.Dispose();
         }
 
+        public bool RequiresUniqueWorkerIdPerConnection = false;
+
         public virtual void Connect(ConnectionConfig config)
         {
             if (config is ReceptionistConfig)
             {
-                Connection = ConnectionUtility.ConnectToSpatial((ReceptionistConfig) config, GetWorkerType, WorkerId);
+                string workerIdForConnection;
+
+                if (RequiresUniqueWorkerIdPerConnection)
+                {
+                    workerIdForConnection = $"{WorkerId}-{Guid.NewGuid()}";
+                }
+                else
+                {
+                    workerIdForConnection = WorkerId;
+                }
+
+                Connection = ConnectionUtility.ConnectToSpatial((ReceptionistConfig) config, GetWorkerType,
+                    workerIdForConnection);
             }
             else if (config is LocatorConfig)
             {

--- a/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerBase.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerBase.cs
@@ -21,7 +21,7 @@ namespace Improbable.Gdk.Core
 
         public EntityGameObjectLinker EntityGameObjectLinker { get; private set; }
 
-        public bool AllowDynamicId = false;
+        public bool UseDynamicId = false;
 
         protected WorkerBase(string workerId, Vector3 origin) : this(workerId, origin, new LoggingDispatcher())
         {
@@ -55,9 +55,7 @@ namespace Improbable.Gdk.Core
         {
             if (config is ReceptionistConfig)
             {
-                string workerIdForConnection;
-
-                if (AllowDynamicId)
+                if (UseDynamicId)
                 {
                     WorkerId = $"{GetWorkerType}-{Guid.NewGuid()}";
                 }

--- a/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerBase.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerBase.cs
@@ -21,7 +21,7 @@ namespace Improbable.Gdk.Core
 
         public EntityGameObjectLinker EntityGameObjectLinker { get; private set; }
 
-        public bool UseDynamicId = false;
+        public bool UseDynamicId { get; protected set; }
 
         protected WorkerBase(string workerId, Vector3 origin) : this(workerId, origin, new LoggingDispatcher())
         {
@@ -31,10 +31,15 @@ namespace Improbable.Gdk.Core
         {
             if (string.IsNullOrEmpty(workerId))
             {
-                throw new ArgumentException("WorkerId is null or empty.", nameof(workerId));
+                WorkerId = GenerateDynamicWorkerId();
+
+                UseDynamicId = true;
+            }
+            else
+            {
+                WorkerId = workerId;
             }
 
-            WorkerId = workerId;
             World = new World(WorkerId);
             WorkerRegistry.SetWorkerForWorld(this);
 
@@ -57,7 +62,7 @@ namespace Improbable.Gdk.Core
             {
                 if (UseDynamicId)
                 {
-                    WorkerId = $"{GetWorkerType}-{Guid.NewGuid()}";
+                    WorkerId = GenerateDynamicWorkerId();
                 }
 
                 Connection = ConnectionUtility.ConnectToSpatial((ReceptionistConfig) config, GetWorkerType,
@@ -80,6 +85,11 @@ namespace Improbable.Gdk.Core
             };
 
             View.Connect();
+        }
+
+        private string GenerateDynamicWorkerId()
+        {
+            return $"{GetWorkerType}-{Guid.NewGuid()}";
         }
 
         public virtual void RegisterSystems()

--- a/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerBase.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerBase.cs
@@ -21,6 +21,8 @@ namespace Improbable.Gdk.Core
 
         public EntityGameObjectLinker EntityGameObjectLinker { get; private set; }
 
+        public bool AllowDynamicId = false;
+
         protected WorkerBase(string workerId, Vector3 origin) : this(workerId, origin, new LoggingDispatcher())
         {
         }
@@ -49,25 +51,19 @@ namespace Improbable.Gdk.Core
             World.Dispose();
         }
 
-        public bool RequiresUniqueWorkerIdPerConnection = false;
-
         public virtual void Connect(ConnectionConfig config)
         {
             if (config is ReceptionistConfig)
             {
                 string workerIdForConnection;
 
-                if (RequiresUniqueWorkerIdPerConnection)
+                if (AllowDynamicId)
                 {
-                    workerIdForConnection = $"{WorkerId}-{Guid.NewGuid()}";
-                }
-                else
-                {
-                    workerIdForConnection = WorkerId;
+                    WorkerId = $"{GetWorkerType}-{Guid.NewGuid()}";
                 }
 
                 Connection = ConnectionUtility.ConnectToSpatial((ReceptionistConfig) config, GetWorkerType,
-                    workerIdForConnection);
+                    WorkerId);
             }
             else if (config is LocatorConfig)
             {

--- a/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerRegistry.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerRegistry.cs
@@ -65,7 +65,7 @@ namespace Improbable.Gdk.Core
             Func<string, Vector3, WorkerBase> createWorker;
             if (!WorkerTypeToInitializationFunction.TryGetValue(workerType, out createWorker))
             {
-                throw new ArgumentException("No worker found for worker type '{0}'", workerType);
+                throw new ArgumentException(string.Format("No worker found for worker type '{0}'", workerType), nameof(workerType));
             }
 
             return createWorker(workerId, origin);

--- a/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerRegistry.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerRegistry.cs
@@ -65,7 +65,7 @@ namespace Improbable.Gdk.Core
             Func<string, Vector3, WorkerBase> createWorker;
             if (!WorkerTypeToInitializationFunction.TryGetValue(workerType, out createWorker))
             {
-                throw new ArgumentException(string.Format("No worker found for worker type '{0}'", workerType), nameof(workerType));
+                throw new ArgumentException($"No worker found for worker type '{workerType}'", nameof(workerType));
             }
 
             return createWorker(workerId, origin);

--- a/workers/unity/spatialos.UnityClient.worker.json
+++ b/workers/unity/spatialos.UnityClient.worker.json
@@ -46,7 +46,7 @@
           "+projectName",
           "${IMPROBABLE_PROJECT_NAME}",
           "-logfile",
-          "external-default-unityclient.log"
+          "../../logs/external-default-unityclient.log"
         ]
       }
     }

--- a/workers/unity/spatialos.UnityGameLogic.worker.json
+++ b/workers/unity/spatialos.UnityGameLogic.worker.json
@@ -39,7 +39,7 @@
         "arguments": [
           "+workerType",
           "UnityGameLogic",
-          "+useUniqueConnectionId",
+          "+useDynamicWorkerId",
           "true",
           "+workerId",
           "UnityGameLogic",

--- a/workers/unity/spatialos.UnityGameLogic.worker.json
+++ b/workers/unity/spatialos.UnityGameLogic.worker.json
@@ -31,6 +31,28 @@
       "checkoutAllInitially": true
     }
   },
+  "external": {
+    "default": {
+      "run_type": "EXECUTABLE",
+      "windows": {
+        "command": "build/worker/UnityGameLogic@Windows/UnityGameLogic@Windows.exe",
+        "arguments": [
+          "+workerType",
+          "UnityGameLogic",
+          "+useUniqueConnectionId",
+          "true",
+          "+workerId",
+          "UnityGameLogic",
+          "+infraServicesUrl",
+          "http://127.0.0.1:21000",
+          "+projectName",
+          "${IMPROBABLE_PROJECT_NAME}",
+          "-logfile",
+          "../../logs/external-default-unitygamelogic.log"
+        ]
+      }
+    }
+  },
   "managed": {
     "windows": {
       "artifact_name": "UnityGameLogic@Windows.zip",

--- a/workers/unity/spatialos.UnityGameLogic.worker.json
+++ b/workers/unity/spatialos.UnityGameLogic.worker.json
@@ -39,7 +39,7 @@
         "arguments": [
           "+workerType",
           "UnityGameLogic",
-          "+useDynamicWorkerId",
+          "+forceDynamicWorkerId",
           "true",
           "+workerId",
           "UnityGameLogic",

--- a/workers/unity/spatialos.UnityGameLogic.worker.json
+++ b/workers/unity/spatialos.UnityGameLogic.worker.json
@@ -39,10 +39,6 @@
         "arguments": [
           "+workerType",
           "UnityGameLogic",
-          "+forceDynamicWorkerId",
-          "true",
-          "+workerId",
-          "UnityGameLogic",
           "+infraServicesUrl",
           "http://127.0.0.1:21000",
           "+projectName",


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Comes with some driveby fixes and features:
- Can launch UnityGameLogic
- Fixed ArgumentException for bad worker type in config params
- Added unique connection ID param to be passed into UnityGameLogic worker during startup (because we cannot have the cloud deployment be affected)
- Moved launch log files to logs folder

#### Tests
Tested locally using:
```
spatial local worker launch UnityGameLogic default
spatial local worker launch UnityClient default
```

#### Documentation
Needs to be added when documentation for launch arguments are considered (will create a ticket if it doesn't exist)

#### Primary reviewers
@jessicafalk @zeroZshadow 