### PR TITLE
UTY-277: Add the ability to fail a command.

### DIFF
--- a/code_generator/GdkCodeGenerator/Templates/UnityCommandPayloadGenerator.tt
+++ b/code_generator/GdkCodeGenerator/Templates/UnityCommandPayloadGenerator.tt
@@ -47,6 +47,12 @@ namespace <#= qualifiedNamespace #>
                     Translation.<#= commandDetails.CommandName #>Responses.Add(
                         new OutgoingResponse(RequestId, response));
                 }
+                
+                public void Send<#= commandDetails.CommandName #>Failure(string message)
+                {
+                    Translation.<#= commandDetails.CommandName #>Failure.Add(
+                        new CommandFailure(RequestId, message));
+                }
             }
 
             internal struct OutgoingRequest : IOutgoingCommandRequest

--- a/code_generator/GdkCodeGenerator/Templates/UnityComponentConversionGenerator.tt
+++ b/code_generator/GdkCodeGenerator/Templates/UnityComponentConversionGenerator.tt
@@ -56,6 +56,7 @@ namespace <#= qualifiedNamespace #>
 <# foreach(var commandDetails in commandDetailsList) { #>
             internal List<<#= commandDetails.CommandName #>.OutgoingRequest> <#= commandDetails.CommandName #>Requests = new List<<#= commandDetails.CommandName #>.OutgoingRequest>();
             internal List<<#= commandDetails.CommandName #>.OutgoingResponse> <#= commandDetails.CommandName #>Responses = new List<<#= commandDetails.CommandName #>.OutgoingResponse>();
+            internal List<CommandFailure> <#= commandDetails.CommandName #>Failure = new List<CommandFailure>();
             private static readonly ComponentPool<CommandRequests<<#= commandDetails.CommandName #>.Request>> <#= commandDetails.CommandName #>RequestPool =
                 new ComponentPool<CommandRequests<<#= commandDetails.CommandName #>.Request>>(
                     () => new CommandRequests<<#= commandDetails.CommandName #>.Request>(),
@@ -429,6 +430,12 @@ namespace <#= qualifiedNamespace #>
                 connection.SendCommandResponse(requestId, response);
             }
 
+            private void Send<#= commandDetails.CommandName #>Failure(Connection connection, CommandFailure failure) {
+                var requestId = new RequestId<IncomingCommandRequest<<#= componentDetails.FullyQualifiedSpatialTypeName #>.Commands.<#= commandDetails.CommandName #>>>(
+                    failure.RequestId);
+
+                connection.SendCommandFailure(requestId, failure.Message);
+            }
 <# } #>
             public override void SendCommands(Connection connection)
             {
@@ -445,6 +452,11 @@ namespace <#= qualifiedNamespace #>
                 }
                 <#= commandDetails.CommandName #>Responses.Clear();
 
+                foreach (var failure in <#= commandDetails.CommandName #>Failure)
+                {
+                    Send<#= commandDetails.CommandName #>Failure(connection, failure);
+                }
+                <#= commandDetails.CommandName #>Failure.Clear();
 <# } #>
             }
 

--- a/workers/unity/Packages/com.improbable.gdk.core/Components/WorldCommandsTranslation.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Components/WorldCommandsTranslation.cs
@@ -109,6 +109,18 @@ namespace Improbable.Gdk.Core
         }
     }
 
+    public struct CommandFailure
+    {
+        public uint RequestId { get; }
+        public string Message { get; }
+
+        public CommandFailure(uint requestId, string message)
+        {
+            RequestId = requestId;
+            Message = message;
+        }
+    }
+
     public struct WorldCommandSender : IComponentData
     {
         private long EntityId { get; }


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
When a worker receives a command request it has 3 options - send a response, ignore it, or deliberately fail it. Currently we do not have an api for deliberately failing commands. Most likely this should be added as an api on the command request component along side the response method.

Example generated code:
```csharp
public partial class Launcher
{
    public class Translation : ComponentTranslation, IDispatcherCallbacks<global::Playground.Launcher>
    {

        internal List<LaunchEntity.OutgoingRequest> LaunchEntityRequests = new List<LaunchEntity.OutgoingRequest>();
        internal List<LaunchEntity.OutgoingResponse> LaunchEntityResponses = new List<LaunchEntity.OutgoingResponse>();
        internal List<CommandFailure> LaunchEntityFailure = new List<CommandFailure>();

        private void SendLaunchEntityFailure(Connection connection, CommandFailure failure) {
            var requestId = new RequestId<IncomingCommandRequest<global::Playground.Launcher.Commands.LaunchEntity>>(
                failure.RequestId);

            connection.SendCommandFailure(requestId, failure.Message);
        }
        
        public override void SendCommands(Connection connection)
        {
            ...
            
            foreach (var failure in LaunchEntityFailure)
            {
                SendLaunchEntityFailure(connection, failure);
            }
            LaunchEntityFailure.Clear();
        }
    }
}
```

#### Tests
Tried failing commands.

#### Documentation
Will add in a separate PR.

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.