### PR TITLE
[Experimental][CSharp Core SDK] Blittable list and map

### DIFF
--- a/workers/unity/Packages/com.improbable.gdk.core/Collections.meta
+++ b/workers/unity/Packages/com.improbable.gdk.core/Collections.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 26b5c378c21ab2747bac1c71cbcc2ade
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/com.improbable.gdk.core/Collections/BlittableList.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Collections/BlittableList.cs
@@ -1,0 +1,91 @@
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Improbable.Gdk.Core.Collections
+{
+    public struct BlittableList<TValue> : IList<TValue>
+    {
+        private readonly uint handle;
+
+        internal List<TValue> Internal => CollectionProvider<List<TValue>, TValue>.Get(handle);
+
+        internal BlittableList(uint handle)
+        {
+            this.handle = handle;
+        }
+
+        public static implicit operator List<TValue>(BlittableList<TValue> bl)
+        {
+            return bl.Internal;
+        }
+
+        #region IList<T>
+
+        public TValue this[int index]
+        {
+            get => Internal[index];
+            set => Internal[index] = value;
+        }
+
+        public int Count => Internal.Count;
+
+        public bool IsReadOnly => ((ICollection<TValue>) Internal).IsReadOnly;
+
+        public void Add(TValue item)
+        {
+            Internal.Add(item);
+        }
+
+        public void Insert(int index, TValue item)
+        {
+            Internal.Insert(index, item);
+        }
+
+        public void Clear()
+        {
+            Internal.Clear();
+        }
+
+        public bool Contains(TValue item)
+        {
+            return Internal.Contains(item);
+        }
+
+        public void CopyTo(TValue[] array, int arrayIndex)
+        {
+            Internal.CopyTo(array, arrayIndex);
+        }
+
+        public int IndexOf(TValue item)
+        {
+            return Internal.IndexOf(item);
+        }
+
+        public bool Remove(TValue item)
+        {
+            return Internal.Remove(item);
+        }
+
+        public void RemoveAt(int index)
+        {
+            Internal.RemoveAt(index);
+        }
+
+        public List<TValue>.Enumerator GetEnumerator()
+        {
+            return Internal.GetEnumerator();
+        }
+
+        IEnumerator<TValue> IEnumerable<TValue>.GetEnumerator()
+        {
+            return ((IEnumerable<TValue>) Internal).GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return ((IEnumerable) Internal).GetEnumerator();
+        }
+
+        #endregion
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.core/Collections/BlittableList.cs.meta
+++ b/workers/unity/Packages/com.improbable.gdk.core/Collections/BlittableList.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fbae09ff434822b46961bc512da9717b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/com.improbable.gdk.core/Collections/BlittableMap.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Collections/BlittableMap.cs
@@ -1,0 +1,101 @@
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Improbable.Gdk.Core.Collections
+{
+    public struct BlittableMap<TKey, TValue> : IDictionary<TKey, TValue>
+    {
+        private readonly uint handle;
+
+        internal Dictionary<TKey, TValue> Internal =>
+            CollectionProvider<Dictionary<TKey, TValue>, KeyValuePair<TKey, TValue>>.Get(handle);
+
+        internal BlittableMap(uint handle)
+        {
+            this.handle = handle;
+        }
+
+        #region IDictionary
+
+        public void Clear()
+        {
+            Internal.Clear();
+        }
+
+        public int Count => Internal.Count;
+
+        public void Add(TKey key, TValue value)
+        {
+            Internal.Add(key, value);
+        }
+
+        public bool ContainsKey(TKey key)
+        {
+            return Internal.ContainsKey(key);
+        }
+
+        public bool Remove(TKey key)
+        {
+            return Internal.Remove(key);
+        }
+
+        public bool TryGetValue(TKey key, out TValue value)
+        {
+            return Internal.TryGetValue(key, out value);
+        }
+
+        public TValue this[TKey key]
+        {
+            get => Internal[key];
+            set => Internal[key] = value;
+        }
+
+        public static implicit operator Dictionary<TKey, TValue>(BlittableMap<TKey, TValue> bl)
+        {
+            return bl.Internal;
+        }
+
+        public ICollection<TKey> Keys => Internal.Keys;
+        public ICollection<TValue> Values => Internal.Values;
+
+        public Dictionary<TKey, TValue>.Enumerator GetEnumerator()
+        {
+            return Internal.GetEnumerator();
+        }
+
+        IEnumerator<KeyValuePair<TKey, TValue>> IEnumerable<KeyValuePair<TKey, TValue>>.GetEnumerator()
+        {
+            return ((IEnumerable<KeyValuePair<TKey, TValue>>) Internal).GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return ((IEnumerable) Internal).GetEnumerator();
+        }
+
+        void ICollection<KeyValuePair<TKey, TValue>>.Add(KeyValuePair<TKey, TValue> item)
+        {
+            ((ICollection<KeyValuePair<TKey, TValue>>) Internal).Add(item);
+        }
+
+        bool ICollection<KeyValuePair<TKey, TValue>>.Contains(KeyValuePair<TKey, TValue> item)
+        {
+            return ((ICollection<KeyValuePair<TKey, TValue>>) Internal).Contains(item);
+        }
+
+        void ICollection<KeyValuePair<TKey, TValue>>.CopyTo(KeyValuePair<TKey, TValue>[] array, int arrayIndex)
+        {
+            ((ICollection<KeyValuePair<TKey, TValue>>) Internal).CopyTo(array, arrayIndex);
+        }
+
+        bool ICollection<KeyValuePair<TKey, TValue>>.Remove(KeyValuePair<TKey, TValue> item)
+        {
+            return ((ICollection<KeyValuePair<TKey, TValue>>) Internal).Remove(item);
+        }
+
+        bool ICollection<KeyValuePair<TKey, TValue>>.IsReadOnly =>
+            ((ICollection<KeyValuePair<TKey, TValue>>) Internal).IsReadOnly;
+
+        #endregion
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.core/Collections/BlittableMap.cs.meta
+++ b/workers/unity/Packages/com.improbable.gdk.core/Collections/BlittableMap.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 3324211b880141fdb36e89a4e8a17c51
+timeCreated: 1531321956

--- a/workers/unity/Packages/com.improbable.gdk.core/Collections/BlittableString.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Collections/BlittableString.cs
@@ -1,0 +1,24 @@
+namespace Improbable.Gdk.Core.Collections
+{
+    public struct BlittableString
+    {
+        private readonly uint handle;
+
+        internal string Internal => StringProvider.Get(handle);
+
+        internal BlittableString(uint handle)
+        {
+            this.handle = handle;
+        }
+
+        public void Set(string value)
+        {
+            StringProvider.Set(handle, value);
+        }
+
+        public static implicit operator string(BlittableString bl)
+        {
+            return bl.Internal;
+        }
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.core/Collections/BlittableString.cs.meta
+++ b/workers/unity/Packages/com.improbable.gdk.core/Collections/BlittableString.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 61641277fb69412db2e139737360ae62
+timeCreated: 1532013956

--- a/workers/unity/Packages/com.improbable.gdk.core/Collections/CollectionProvider.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Collections/CollectionProvider.cs
@@ -3,27 +3,27 @@ using System.Collections.Generic;
 
 namespace Improbable.Gdk.Core.Collections
 {
-    internal static class CollectionProvider<TProvider, TValue> where TProvider : class, ICollection<TValue>, new()
+    internal static class CollectionProvider<TCollection, TValue> where TCollection : class, ICollection<TValue>, new()
     {
-        private static readonly Dictionary<uint, TProvider> Storage = new Dictionary<uint, TProvider>();
+        private static readonly Dictionary<uint, TCollection> Storage = new Dictionary<uint, TCollection>();
 
-        internal static void AllocateHandle(uint handle, TProvider initialValue = default(TProvider))
+        internal static void AllocateHandle(uint handle, TCollection initialValue = default(TCollection))
         {
             if (Storage.ContainsKey(handle))
             {
                 throw new InvalidOperationException(
-                    $"CollectionProvider<{typeof(TProvider)}> already contains handle `{handle}`");
+                    $"CollectionProvider<{typeof(TCollection)}> already contains handle `{handle}`");
             }
 
-            Storage.Add(handle, initialValue ?? new TProvider());
+            Storage.Add(handle, initialValue ?? new TCollection());
         }
 
-        internal static TProvider Get(uint handle)
+        internal static TCollection Get(uint handle)
         {
             if (!Storage.TryGetValue(handle, out var item))
             {
                 throw new ArgumentException(
-                    $"CollectionProvider<{typeof(TProvider)}> does not contain handle `{handle}`");
+                    $"CollectionProvider<{typeof(TCollection)}> does not contain handle `{handle}`");
             }
 
             return item;
@@ -34,7 +34,7 @@ namespace Improbable.Gdk.Core.Collections
             if (!Storage.TryGetValue(handle, out var item))
             {
                 throw new ArgumentException(
-                    $"CollectionProvider<{typeof(TProvider)}> does not contain handle `{handle}`");
+                    $"CollectionProvider<{typeof(TCollection)}> does not contain handle `{handle}`");
             }
 
             item.Clear();

--- a/workers/unity/Packages/com.improbable.gdk.core/Collections/CollectionProvider.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Collections/CollectionProvider.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+
+namespace Improbable.Gdk.Core.Collections
+{
+    internal static class CollectionProvider<TProvider, TValue> where TProvider : ICollection<TValue>, new()
+    {
+        private static readonly Dictionary<uint, TProvider> Storage = new Dictionary<uint, TProvider>();
+
+        internal static void AllocateHandle(uint handle)
+        {
+            if (Storage.ContainsKey(handle))
+            {
+                throw new InvalidOperationException(
+                    $"CollectionProvider<{typeof(TProvider)}> already contains handle `{handle}`");
+            }
+
+            var item = new TProvider();
+            Storage.Add(handle, item);
+        }
+
+        internal static TProvider Get(uint handle)
+        {
+            if (!Storage.TryGetValue(handle, out var item))
+            {
+                throw new ArgumentException(
+                    $"CollectionProvider<{typeof(TProvider)}> does not contain handle `{handle}`");
+            }
+
+            return item;
+        }
+
+        internal static void FreeHandle(uint handle)
+        {
+            if (!Storage.TryGetValue(handle, out var item))
+            {
+                throw new ArgumentException(
+                    $"CollectionProvider<{typeof(TProvider)}> does not contain handle `{handle}`");
+            }
+
+            item.Clear();
+            Storage.Remove(handle);
+        }
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.core/Collections/CollectionProvider.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Collections/CollectionProvider.cs
@@ -3,11 +3,11 @@ using System.Collections.Generic;
 
 namespace Improbable.Gdk.Core.Collections
 {
-    internal static class CollectionProvider<TProvider, TValue> where TProvider : ICollection<TValue>, new()
+    internal static class CollectionProvider<TProvider, TValue> where TProvider : class, ICollection<TValue>, new()
     {
         private static readonly Dictionary<uint, TProvider> Storage = new Dictionary<uint, TProvider>();
 
-        internal static void AllocateHandle(uint handle)
+        internal static void AllocateHandle(uint handle, TProvider initialValue = default(TProvider))
         {
             if (Storage.ContainsKey(handle))
             {
@@ -15,8 +15,7 @@ namespace Improbable.Gdk.Core.Collections
                     $"CollectionProvider<{typeof(TProvider)}> already contains handle `{handle}`");
             }
 
-            var item = new TProvider();
-            Storage.Add(handle, item);
+            Storage.Add(handle, initialValue ?? new TProvider());
         }
 
         internal static TProvider Get(uint handle)

--- a/workers/unity/Packages/com.improbable.gdk.core/Collections/CollectionProvider.cs.meta
+++ b/workers/unity/Packages/com.improbable.gdk.core/Collections/CollectionProvider.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: d422d5a2dc14486c8e334c894de6bd61
+timeCreated: 1531998756

--- a/workers/unity/Packages/com.improbable.gdk.core/Collections/HandleProvider.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Collections/HandleProvider.cs
@@ -16,10 +16,10 @@ namespace Improbable.Gdk.Core.Collections
             return handle;
         }
 
-        public static uint AllocateMapHandle<TValue, TKey>()
+        public static uint AllocateMapHandle<TValue, TKey>(Dictionary<TKey, TValue> data = null)
         {
             var handle = GetHandle();
-            CollectionProvider<Dictionary<TKey, TValue>, KeyValuePair<TKey, TValue>>.AllocateHandle(handle);
+            CollectionProvider<Dictionary<TKey, TValue>, KeyValuePair<TKey, TValue>>.AllocateHandle(handle, data);
             FreeActions.Add(handle,
                 CollectionProvider<Dictionary<TKey, TValue>, KeyValuePair<TKey, TValue>>.FreeHandle);
             return handle;

--- a/workers/unity/Packages/com.improbable.gdk.core/Collections/HandleProvider.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Collections/HandleProvider.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+
+namespace Improbable.Gdk.Core.Collections
+{
+    internal static class HandleProvider
+    {
+        private static uint nextHandle = 0;
+        private static readonly Dictionary<uint, Action<uint>> FreeActions = new Dictionary<uint, Action<uint>>();
+
+        public static uint AllocateListHandle<TValue>()
+        {
+            var handle = GetHandle();
+            CollectionProvider<List<TValue>, TValue>.AllocateHandle(handle);
+            FreeActions.Add(handle, CollectionProvider<List<TValue>, TValue>.FreeHandle);
+            return handle;
+        }
+
+        public static uint AllocateMapHandle<TValue, TKey>()
+        {
+            var handle = GetHandle();
+            CollectionProvider<Dictionary<TKey, TValue>, KeyValuePair<TKey, TValue>>.AllocateHandle(handle);
+            FreeActions.Add(handle,
+                CollectionProvider<Dictionary<TKey, TValue>, KeyValuePair<TKey, TValue>>.FreeHandle);
+            return handle;
+        }
+
+        public static uint AllocateStringHandle()
+        {
+            var handle = GetHandle();
+            StringProvider.AllocateHandle(handle);
+            FreeActions.Add(handle, StringProvider.FreeHandle);
+            return handle;
+        }
+
+        public static void FreeHandle(uint handle)
+        {
+            FreeActions[handle](handle);
+            FreeActions.Remove(handle);
+        }
+
+        private static uint GetHandle()
+        {
+            // Check for duplicates in case of wraparound
+            while (FreeActions.ContainsKey(++nextHandle))
+            {
+            }
+
+            return nextHandle;
+        }
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.core/Collections/HandleProvider.cs.meta
+++ b/workers/unity/Packages/com.improbable.gdk.core/Collections/HandleProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 827d3fb73fc832a409513b2e83a7b056
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/com.improbable.gdk.core/Collections/StringProvider.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Collections/StringProvider.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+
+namespace Improbable.Gdk.Core.Collections
+{
+    internal static class StringProvider
+    {
+        private static readonly Dictionary<uint, string> Storage = new Dictionary<uint, string>();
+
+        internal static void AllocateHandle(uint handle)
+        {
+            if (Storage.ContainsKey(handle))
+            {
+                throw new InvalidOperationException($"StringProvider already contains handle `{handle}`");
+            }
+
+            var item = string.Empty;
+            Storage.Add(handle, item);
+        }
+
+        internal static string Get(uint handle)
+        {
+            if (!Storage.TryGetValue(handle, out var item))
+            {
+                throw new ArgumentException($"StringProvider does not contain handle `{handle}`");
+            }
+
+            return item;
+        }
+
+        internal static void Set(uint handle, string value)
+        {
+            if (!Storage.ContainsKey(handle))
+            {
+                throw new ArgumentException($"StringProvider does not contain handle `{handle}`");
+            }
+
+            Storage[handle] = value;
+        }
+
+        internal static void FreeHandle(uint handle)
+        {
+            if (!Storage.TryGetValue(handle, out var item))
+            {
+                throw new ArgumentException($"StringProvider does not contain handle `{handle}`");
+            }
+
+            Storage.Remove(handle);
+        }
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.core/Collections/StringProvider.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Collections/StringProvider.cs
@@ -7,15 +7,14 @@ namespace Improbable.Gdk.Core.Collections
     {
         private static readonly Dictionary<uint, string> Storage = new Dictionary<uint, string>();
 
-        internal static void AllocateHandle(uint handle)
+        internal static void AllocateHandle(uint handle, string initialValue = default(string))
         {
             if (Storage.ContainsKey(handle))
             {
                 throw new InvalidOperationException($"StringProvider already contains handle `{handle}`");
             }
 
-            var item = string.Empty;
-            Storage.Add(handle, item);
+            Storage.Add(handle, initialValue);
         }
 
         internal static string Get(uint handle)

--- a/workers/unity/Packages/com.improbable.gdk.core/Collections/StringProvider.cs.meta
+++ b/workers/unity/Packages/com.improbable.gdk.core/Collections/StringProvider.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 554b2ebe03c7494c9365f5d63fe69cc8
+timeCreated: 1532014132


### PR DESCRIPTION
#### Description
Add Wrappers for List, Dictionary, and string to use in codegen for schema list,map, and strings.
This is a quick version to allow @jamiebrynes7 to make all components blittable.

This still needs to be discussed and improved upon later.
IList and IDictionary was implemented just for ease of use now.
Will need to be re-considered.

#### Primary reviewers
@jamiebrynes7 