### PR TITLE
UTY-709 Add interfaces to be used by MonoBehaviours

### DIFF
--- a/workers/unity/Packages/com.improbable.gdk.core/Components/ISpatialComponentUpdate.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Components/ISpatialComponentUpdate.cs
@@ -6,8 +6,8 @@ namespace Improbable.Gdk.Core
     {
     }
 
-    public interface ISpatialComponentUpdate<TComponent> : ISpatialComponentUpdate
-        where TComponent : ISpatialComponentData, IComponentData
+    public interface ISpatialComponentUpdate<TSpatialComponentData> : ISpatialComponentUpdate
+        where TSpatialComponentData : ISpatialComponentData
     {
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.core/Components/ISpatialComponentUpdate.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Components/ISpatialComponentUpdate.cs
@@ -1,6 +1,13 @@
+using Unity.Entities;
+
 namespace Improbable.Gdk.Core
 {
     public interface ISpatialComponentUpdate
+    {
+    }
+
+    public interface ISpatialComponentUpdate<TComponent> : ISpatialComponentUpdate
+        where TComponent : ISpatialComponentData, IComponentData
     {
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/Delegates.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/Delegates.cs
@@ -1,7 +1,4 @@
-﻿using System.Collections.Generic;
-using Improbable.Worker;
-using Unity.Entities;
-using Entity = Improbable.Worker.Entity;
+﻿using Improbable.Worker;
 
 namespace Improbable.Gdk.Core.MonoBehaviours
 {

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/Delegates.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/Delegates.cs
@@ -1,0 +1,13 @@
+﻿using System.Collections.Generic;
+using Improbable.Worker;
+using Unity.Entities;
+using Entity = Improbable.Worker.Entity;
+
+namespace Improbable.Gdk.Core.MonoBehaviours
+{
+    // TODO reviewers: shall we put these delegates into their own class/namespace?
+    public delegate void AuthorityChangedDelegate(Authority newAuthority);
+
+    public delegate void ComponentUpdateDelegate<in TComponentUpdate>(TComponentUpdate updateData)
+        where TComponentUpdate : ISpatialComponentUpdate;
+}

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/Delegates.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/Delegates.cs
@@ -1,10 +1,13 @@
 ﻿using Improbable.Worker;
+using Unity.Entities;
 
 namespace Improbable.Gdk.Core
 {
-    // TODO reviewers: shall we put these delegates into their own class/namespace?
-    public delegate void AuthorityChangedDelegate(Authority newAuthority);
+    public static class GameObjectDelegates
+    {
+        public delegate void AuthorityChanged(Authority newAuthority);
 
-    public delegate void ComponentUpdateDelegate<TComponentUpdate>(TComponentUpdate updateData)
-        where TComponentUpdate : ISpatialComponentUpdate;
+        public delegate void ComponentUpdated<TComponent>(ISpatialComponentUpdate<TComponent> updateData)
+            where TComponent : ISpatialComponentData, IComponentData;
+    }
 }

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/Delegates.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/Delegates.cs
@@ -1,10 +1,10 @@
 ﻿using Improbable.Worker;
 
-namespace Improbable.Gdk.Core.MonoBehaviours
+namespace Improbable.Gdk.Core
 {
     // TODO reviewers: shall we put these delegates into their own class/namespace?
     public delegate void AuthorityChangedDelegate(Authority newAuthority);
 
-    public delegate void ComponentUpdateDelegate<in TComponentUpdate>(TComponentUpdate updateData)
+    public delegate void ComponentUpdateDelegate<TComponentUpdate>(TComponentUpdate updateData)
         where TComponentUpdate : ISpatialComponentUpdate;
 }

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/Delegates.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/Delegates.cs
@@ -7,7 +7,7 @@ namespace Improbable.Gdk.Core
     {
         public delegate void AuthorityChanged(Authority newAuthority);
 
-        public delegate void ComponentUpdated<TComponent>(ISpatialComponentUpdate<TComponent> updateData)
-            where TComponent : ISpatialComponentData, IComponentData;
+        public delegate void ComponentUpdated<TSpatialComponentData>(ISpatialComponentUpdate<TSpatialComponentData> updateData)
+            where TSpatialComponentData : ISpatialComponentData;
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/Delegates.cs.meta
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/Delegates.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5077c8bc17423ea4fa29042325cf22d5
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/IReader.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/IReader.cs
@@ -1,0 +1,21 @@
+﻿using Improbable.Worker;
+using Unity.Entities;
+
+namespace Improbable.Gdk.Core.MonoBehaviours
+{
+    /// <summary>
+    /// The Reader interface is used by MonoBehaviours to query information about a SpatialOS component and register
+    /// callbacks for updates, events and commands for component instances.
+    /// </summary>
+    /// <typeparam name="TComponent">The data type for the SpatialOS component.</typeparam>
+    /// <typeparam name="TComponentUpdate">The data type for the SpatialOS component's update.</typeparam>
+    public interface IReader<TComponent, out TComponentUpdate>
+        where TComponent : ISpatialComponentData, IComponentData
+        where TComponentUpdate : ISpatialComponentUpdate<TComponent>
+    {
+        Authority Authority { get; }
+
+        event AuthorityChangedDelegate AuthorityChanged;
+        event ComponentUpdateDelegate<TComponentUpdate> ComponentUpdated;
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/IReader.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/IReader.cs
@@ -8,14 +8,12 @@ namespace Improbable.Gdk.Core.MonoBehaviours
     ///     callbacks for updates, events and commands for component instances.
     /// </summary>
     /// <typeparam name="TComponent">The data type for the SpatialOS component.</typeparam>
-    /// <typeparam name="TComponentUpdate">The data type for the SpatialOS component's update.</typeparam>
-    public interface IReader<TComponent, TComponentUpdate>
+    public interface IReader<TComponent>
         where TComponent : ISpatialComponentData, IComponentData
-        where TComponentUpdate : ISpatialComponentUpdate<TComponent>
     {
         Authority Authority { get; }
 
-        event AuthorityChangedDelegate AuthorityChanged;
-        event ComponentUpdateDelegate<TComponentUpdate> ComponentUpdated;
+        event GameObjectDelegates.AuthorityChanged AuthorityChanged;
+        event GameObjectDelegates.ComponentUpdated<TComponent> ComponentUpdated;
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/IReader.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/IReader.cs
@@ -9,7 +9,7 @@ namespace Improbable.Gdk.Core.MonoBehaviours
     /// </summary>
     /// <typeparam name="TComponent">The data type for the SpatialOS component.</typeparam>
     /// <typeparam name="TComponentUpdate">The data type for the SpatialOS component's update.</typeparam>
-    public interface IReader<TComponent, out TComponentUpdate>
+    public interface IReader<TComponent, TComponentUpdate>
         where TComponent : ISpatialComponentData, IComponentData
         where TComponentUpdate : ISpatialComponentUpdate<TComponent>
     {

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/IReader.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/IReader.cs
@@ -7,13 +7,14 @@ namespace Improbable.Gdk.Core.MonoBehaviours
     ///     The Reader interface is used by MonoBehaviours to query information about a SpatialOS component and register
     ///     callbacks for updates, events and commands for component instances.
     /// </summary>
-    /// <typeparam name="TComponent">The data type for the SpatialOS component.</typeparam>
-    public interface IReader<TComponent>
-        where TComponent : ISpatialComponentData, IComponentData
+    /// <typeparam name="TSpatialComponentData">The data type for the SpatialOS component.</typeparam>
+    public interface IReader<TSpatialComponentData>
+        where TSpatialComponentData : ISpatialComponentData
     {
         Authority Authority { get; }
+        TSpatialComponentData Data { get; }
 
         event GameObjectDelegates.AuthorityChanged AuthorityChanged;
-        event GameObjectDelegates.ComponentUpdated<TComponent> ComponentUpdated;
+        event GameObjectDelegates.ComponentUpdated<TSpatialComponentData> ComponentUpdated;
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/IReader.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/IReader.cs
@@ -4,8 +4,8 @@ using Unity.Entities;
 namespace Improbable.Gdk.Core.MonoBehaviours
 {
     /// <summary>
-    /// The Reader interface is used by MonoBehaviours to query information about a SpatialOS component and register
-    /// callbacks for updates, events and commands for component instances.
+    ///     The Reader interface is used by MonoBehaviours to query information about a SpatialOS component and register
+    ///     callbacks for updates, events and commands for component instances.
     /// </summary>
     /// <typeparam name="TComponent">The data type for the SpatialOS component.</typeparam>
     /// <typeparam name="TComponentUpdate">The data type for the SpatialOS component's update.</typeparam>

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/IReader.cs.meta
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/IReader.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 27a83eef72873aa4eb63828e24a16136
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/IReaderInternal.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/IReaderInternal.cs
@@ -1,12 +1,10 @@
-﻿using System.Runtime.CompilerServices;
-using Improbable.Worker;
-using Unity.Entities;
+﻿using Improbable.Worker;
 
 namespace Improbable.Gdk.Core.MonoBehaviours
 {
     /// <summary>
-    /// The interface that is used to signal a reader that a message has been received from the SpatialOS Dispatcher
-    /// about the component that the reader is connected to.
+    ///     The interface that is used to signal a reader that a message has been received from the SpatialOS Dispatcher
+    ///     about the component that the reader is connected to.
     /// </summary>
     internal interface IReaderInternal
     {

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/IReaderInternal.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/IReaderInternal.cs
@@ -1,0 +1,18 @@
+﻿using System.Runtime.CompilerServices;
+using Improbable.Worker;
+using Unity.Entities;
+
+namespace Improbable.Gdk.Core.MonoBehaviours
+{
+    /// <summary>
+    /// The interface that is used to signal a reader that a message has been received from the SpatialOS Dispatcher
+    /// about the component that the reader is connected to.
+    /// </summary>
+    internal interface IReaderInternal
+    {
+        void OnAuthorityChange(Authority authority);
+        void OnComponentUpdate();
+        void OnEvent(int eventIndex);
+        void OnCommandRequest(int commandIndex);
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/IReaderInternal.cs.meta
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/IReaderInternal.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fadc52badd6b4ae40a55ec851d04debf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Introducing the public and internal versions of the Reader interfaces.

Also preparing tagging for component updates to highlight that they are for a particular component. This will aid with type hinting for the rest of MonoBehaviour implementation.

To follow in following PRs:
- events
- commands

#### Tests
Tests to come in a following PR about UTY-709

#### Documentation
Inline documentation for interfaces