### PR TITLE
UTY-622 Enable alternative with no flag

### DIFF
--- a/workers/unity/Assets/Playground/Scripts/Bootstrap.cs
+++ b/workers/unity/Assets/Playground/Scripts/Bootstrap.cs
@@ -64,19 +64,13 @@ namespace Playground
                 var workerId =
                     CommandLineUtility.GetCommandLineValue(commandLineArgs, RuntimeConfigNames.WorkerId,
                         string.Empty);
-                var forceDynamicWorkerId = CommandLineUtility.GetCommandLineValue(commandLineArgs,
-                    RuntimeConfigNames.ForceDynamicWorkerId,
-                    false);
 
                 // because the launcher does not pass in the worker type as an argument
                 var worker = workerType.Equals(string.Empty)
-                    ? WorkerRegistry.CreateWorker<UnityClient>($"{workerType}-{Guid.NewGuid()}", new Vector3(0, 0, 0))
+                    ? WorkerRegistry.CreateWorker<UnityClient>(
+                        workerId: null, // The worker id for the UnityClient will be auto-generated.
+                        origin: new Vector3(0, 0, 0))
                     : WorkerRegistry.CreateWorker(workerType, workerId, new Vector3(0, 0, 0));
-
-                if (forceDynamicWorkerId)
-                {
-                    worker.UseDynamicId = true;
-                }
 
                 Workers.Add(worker);
 

--- a/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Config/RuntimeConfig.cs
@@ -23,6 +23,5 @@ namespace Improbable.Gdk.Core
         public const string ReceptionistPort = "receptionistPort";
         public const string WorkerId = "workerId";
         public const string WorkerType = "workerType";
-        public const string ForceDynamicWorkerId = "forceDynamicWorkerId";
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.core/Tests/Editmode/Worker/WorkerBaseTests.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Tests/Editmode/Worker/WorkerBaseTests.cs
@@ -8,33 +8,52 @@ namespace Improbable.Gdk.Core.EditmodeTests
     public class WorkerBaseTests
     {
         [Test]
-        public void WorkerBase_should_throw_exception_when_WorkerId_is_null_or_empty()
+        public void WorkerId_should_be_dynamically_generated_when_parameter_is_null_or_empty()
         {
-            // Empty check
-            var empty_exception = Assert.Throws<System.ArgumentException>(() =>
+            using (var workerWithEmptyWorkerIdParameter = new UnityTestWorker("", Vector3.zero))
             {
-                var worker = new UnityTestWorker("", new Vector3());
-                worker.Dispose();
-            });
-            Assert.IsTrue(empty_exception.Message.Contains("WorkerId"));
+                Assert.IsNotNull(workerWithEmptyWorkerIdParameter.WorkerId,
+                    "The worker should have an ID generated for it if an empty string is passed into the constructor parameter, but it did not.");
+                Assert.IsTrue(workerWithEmptyWorkerIdParameter.WorkerId.StartsWith("UnityTestWorker-"),
+                    "The generated worker ID should start with the worker type, but it did not.");
+            }
 
-            // Null check
-            var null_exception = Assert.Throws<System.ArgumentException>(() =>
+            using (var workerWithNullWorkerIdParameter = new UnityTestWorker(null, Vector3.zero))
             {
-                var worker = new UnityTestWorker(null, new Vector3());
-                worker.Dispose();
-            });
-            Assert.IsTrue(null_exception.Message.Contains("WorkerId"));
+                Assert.IsNotNull(workerWithNullWorkerIdParameter.WorkerId,
+                    "The worker should have an ID generated for it if null is passed into the constructor parameter, but it did not.");
+                Assert.IsTrue(workerWithNullWorkerIdParameter.WorkerId.StartsWith("UnityTestWorker-"),
+                    "The generated worker ID should start with the worker type, but it did not.");
+            }
+        }
+
+        [Test]
+        public void WorkerId_should_be_unique_when_dynamically_generated()
+        {
+            using (var workerWithEmptyWorkerIdParameter = new UnityTestWorker("", Vector3.zero))
+            {
+                using (var workerWithNullWorkerIdParameter = new UnityTestWorker(null, Vector3.zero))
+                {
+                    Assert.AreNotEqual(
+                        workerWithEmptyWorkerIdParameter.WorkerId,
+                        workerWithNullWorkerIdParameter.WorkerId,
+                        "Auto-generated worker IDs should be unique.");
+                }
+            }
         }
 
         [Test]
         public void WorkerBase_should_accept_an_arbitrary_WorkerId()
         {
-            Assert.DoesNotThrow(() =>
+            using (WorkerBase worker = new UnityTestWorker("worker-id", Vector3.zero))
             {
-                var worker = new UnityTestWorker("worker-id", new Vector3());
-                worker.Dispose();
-            });
+                Assert.AreEqual("worker-id", worker.WorkerId);
+            }
+
+            using (WorkerBase worker = new UnityTestWorker("another-worker-id", Vector3.zero))
+            {
+                Assert.AreEqual("another-worker-id", worker.WorkerId);
+            }
         }
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerBase.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerBase.cs
@@ -21,7 +21,7 @@ namespace Improbable.Gdk.Core
 
         public EntityGameObjectLinker EntityGameObjectLinker { get; private set; }
 
-        public bool UseDynamicId = false;
+        public bool UseDynamicId { get; protected set; }
 
         protected WorkerBase(string workerId, Vector3 origin) : this(workerId, origin, new LoggingDispatcher())
         {
@@ -31,10 +31,15 @@ namespace Improbable.Gdk.Core
         {
             if (string.IsNullOrEmpty(workerId))
             {
-                throw new ArgumentException("WorkerId is null or empty.", nameof(workerId));
+                WorkerId = GenerateDynamicWorkerId();
+
+                UseDynamicId = true;
+            }
+            else
+            {
+                WorkerId = workerId;
             }
 
-            WorkerId = workerId;
             World = new World(WorkerId);
             WorkerRegistry.SetWorkerForWorld(this);
 
@@ -57,7 +62,7 @@ namespace Improbable.Gdk.Core
             {
                 if (UseDynamicId)
                 {
-                    WorkerId = $"{GetWorkerType}-{Guid.NewGuid()}";
+                    WorkerId = GenerateDynamicWorkerId();
                 }
 
                 Connection = ConnectionUtility.ConnectToSpatial((ReceptionistConfig) config, GetWorkerType,
@@ -80,6 +85,11 @@ namespace Improbable.Gdk.Core
             };
 
             View.Connect();
+        }
+
+        private string GenerateDynamicWorkerId()
+        {
+            return $"{GetWorkerType}-{Guid.NewGuid()}";
         }
 
         public virtual void RegisterSystems()

--- a/workers/unity/spatialos.UnityGameLogic.worker.json
+++ b/workers/unity/spatialos.UnityGameLogic.worker.json
@@ -39,10 +39,6 @@
         "arguments": [
           "+workerType",
           "UnityGameLogic",
-          "+forceDynamicWorkerId",
-          "true",
-          "+workerId",
-          "UnityGameLogic",
           "+infraServicesUrl",
           "http://127.0.0.1:21000",
           "+projectName",


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Attempt to resolve issues raised by @zeroZshadow within #123 by removing the flag passed into the launch parameters, and force unique ids if no worker id is specified

#### Tests
Adjusted WorkerBaseTests to handle the parameter changes
- [x] Local Test runs
- [x] CI
- [x] Local Deployment
- [ ] Cloud Deployment

#### Documentation
Internal changes

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
@zeroZshadow @jessicafalk 