### PR TITLE
UTY-276: Add the ability to ack authority loss.

### DIFF
--- a/code_generator/GdkCodeGenerator/Templates/UnityComponentConversionGenerator.tt
+++ b/code_generator/GdkCodeGenerator/Templates/UnityComponentConversionGenerator.tt
@@ -31,12 +31,10 @@ namespace <#= qualifiedNamespace #>
             private static readonly ComponentType targetComponentType = typeof(<#= componentDetails.TypeName #>);
 
             public override ComponentType[] ReplicationComponentTypes => replicationComponentTypes;
-            private static readonly ComponentType[] replicationComponentTypes = { typeof(<#= componentDetails.TypeName #>), typeof(Authoritative<<#= componentDetails.TypeName #>>), 
-                typeof(SpatialEntityId) };
+            private static readonly ComponentType[] replicationComponentTypes = { typeof(<#= componentDetails.TypeName #>), typeof(Authoritative<<#= componentDetails.TypeName #>>), typeof(SpatialEntityId) };
                 
             public override ComponentType[] AuthorityLossComponentTypes => authorityLossComponentTypes;
-            private static readonly ComponentType[] authorityLossComponentTypes = { typeof(AuthorityLossImminent<<#= componentDetails.TypeName #>>),
-                typeof(SpatialEntityId) };
+            private static readonly ComponentType[] authorityLossComponentTypes = { typeof(AuthorityLossImminent<<#= componentDetails.TypeName #>>), typeof(SpatialEntityId) };
 
             public override ComponentType[] CleanUpComponentTypes => cleanUpComponentTypes;
             private static readonly ComponentType[] cleanUpComponentTypes = 

--- a/code_generator/GdkCodeGenerator/Templates/UnityComponentConversionGenerator.tt
+++ b/code_generator/GdkCodeGenerator/Templates/UnityComponentConversionGenerator.tt
@@ -443,7 +443,7 @@ namespace <#= qualifiedNamespace #>
             }
 <# } #>
 
-            private void SendAuthorityLossImminentAcknowledgement(Connection connection)
+            public override void SendAuthorityLossImminentAcknowledgement(Connection connection)
             {
                 var componentDataArray = AuthorityLossComponentGroup.GetComponentDataArray<AuthorityLossImminent<<#= componentDetails.TypeName #>>>();
                 var spatialEntityIdData = AuthorityLossComponentGroup.GetComponentDataArray<SpatialEntityId>();
@@ -481,8 +481,6 @@ namespace <#= qualifiedNamespace #>
                 }
                 <#= commandDetails.CommandName #>Failure.Clear();
 <# } #>
-
-                SendAuthorityLossImminentAcknowledgement(connection);
             }
 
             public static <#= componentDetails.ComponentName #>.Translation GetTranslation(uint internalHandleToTranslation)

--- a/code_generator/GdkCodeGenerator/Templates/UnityComponentConversionGenerator.tt
+++ b/code_generator/GdkCodeGenerator/Templates/UnityComponentConversionGenerator.tt
@@ -31,7 +31,12 @@ namespace <#= qualifiedNamespace #>
             private static readonly ComponentType targetComponentType = typeof(<#= componentDetails.TypeName #>);
 
             public override ComponentType[] ReplicationComponentTypes => replicationComponentTypes;
-            private static readonly ComponentType[] replicationComponentTypes = { typeof(<#= componentDetails.TypeName #>), typeof(Authoritative<<#= componentDetails.TypeName #>>), typeof(SpatialEntityId)};
+            private static readonly ComponentType[] replicationComponentTypes = { typeof(<#= componentDetails.TypeName #>), typeof(Authoritative<<#= componentDetails.TypeName #>>), 
+                typeof(SpatialEntityId) };
+                
+            public override ComponentType[] AuthorityLossComponentTypes => authorityLossComponentTypes;
+            private static readonly ComponentType[] authorityLossComponentTypes = { typeof(AuthorityLossImminent<<#= componentDetails.TypeName #>>),
+                typeof(SpatialEntityId) };
 
             public override ComponentType[] CleanUpComponentTypes => cleanUpComponentTypes;
             private static readonly ComponentType[] cleanUpComponentTypes = 
@@ -437,6 +442,24 @@ namespace <#= qualifiedNamespace #>
                 connection.SendCommandFailure(requestId, failure.Message);
             }
 <# } #>
+
+            private void SendAuthorityLossImminentAcknowledgement(Connection connection)
+            {
+                var componentDataArray = AuthorityLossComponentGroup.GetComponentDataArray<AuthorityLossImminent<<#= componentDetails.TypeName #>>>();
+                var spatialEntityIdData = AuthorityLossComponentGroup.GetComponentDataArray<SpatialEntityId>();
+
+                for (int i = 0; i < componentDataArray.Length; i++)
+                {
+                    var component = componentDataArray[i];
+                    if (componentDataArray[i].AuthorityLossAcknowledged && !component.AuthorityLossAcknowledgmentSent)
+                    {
+                        connection.SendAuthorityLossImminentAcknowledgement<<#= componentDetails.FullyQualifiedSpatialTypeName #>>(new global::Improbable.EntityId(spatialEntityIdData[i].EntityId));
+                        component.AuthorityLossAcknowledgmentSent = true;
+                        componentDataArray[i] = component;
+                    }
+                }
+            }
+                
             public override void SendCommands(Connection connection)
             {
 <# foreach (var commandDetails in commandDetailsList) { #>
@@ -458,6 +481,8 @@ namespace <#= qualifiedNamespace #>
                 }
                 <#= commandDetails.CommandName #>Failure.Clear();
 <# } #>
+
+                SendAuthorityLossImminentAcknowledgement(connection);
             }
 
             public static <#= componentDetails.ComponentName #>.Translation GetTranslation(uint internalHandleToTranslation)

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveBlittableSingularTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveBlittableSingularTranslation.cs
@@ -379,7 +379,7 @@ namespace Generated.Improbable.Gdk.Tests
             }
 
 
-            private void SendAuthorityLossImminentAcknowledgement(Connection connection)
+            public override void SendAuthorityLossImminentAcknowledgement(Connection connection)
             {
                 var componentDataArray = AuthorityLossComponentGroup.GetComponentDataArray<AuthorityLossImminent<SpatialOSExhaustiveBlittableSingular>>();
                 var spatialEntityIdData = AuthorityLossComponentGroup.GetComponentDataArray<SpatialEntityId>();
@@ -398,8 +398,6 @@ namespace Generated.Improbable.Gdk.Tests
                 
             public override void SendCommands(Connection connection)
             {
-
-                SendAuthorityLossImminentAcknowledgement(connection);
             }
 
             public static ExhaustiveBlittableSingular.Translation GetTranslation(uint internalHandleToTranslation)

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveBlittableSingularTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveBlittableSingularTranslation.cs
@@ -24,7 +24,12 @@ namespace Generated.Improbable.Gdk.Tests
             private static readonly ComponentType targetComponentType = typeof(SpatialOSExhaustiveBlittableSingular);
 
             public override ComponentType[] ReplicationComponentTypes => replicationComponentTypes;
-            private static readonly ComponentType[] replicationComponentTypes = { typeof(SpatialOSExhaustiveBlittableSingular), typeof(Authoritative<SpatialOSExhaustiveBlittableSingular>), typeof(SpatialEntityId)};
+            private static readonly ComponentType[] replicationComponentTypes = { typeof(SpatialOSExhaustiveBlittableSingular), typeof(Authoritative<SpatialOSExhaustiveBlittableSingular>), 
+                typeof(SpatialEntityId) };
+                
+            public override ComponentType[] AuthorityLossComponentTypes => authorityLossComponentTypes;
+            private static readonly ComponentType[] authorityLossComponentTypes = { typeof(AuthorityLossImminent<SpatialOSExhaustiveBlittableSingular>),
+                typeof(SpatialEntityId) };
 
             public override ComponentType[] CleanUpComponentTypes => cleanUpComponentTypes;
             private static readonly ComponentType[] cleanUpComponentTypes = 
@@ -373,8 +378,28 @@ namespace Generated.Improbable.Gdk.Tests
                 
             }
 
+
+            private void SendAuthorityLossImminentAcknowledgement(Connection connection)
+            {
+                var componentDataArray = AuthorityLossComponentGroup.GetComponentDataArray<AuthorityLossImminent<SpatialOSExhaustiveBlittableSingular>>();
+                var spatialEntityIdData = AuthorityLossComponentGroup.GetComponentDataArray<SpatialEntityId>();
+
+                for (int i = 0; i < componentDataArray.Length; i++)
+                {
+                    var component = componentDataArray[i];
+                    if (componentDataArray[i].AuthorityLossAcknowledged && !component.AuthorityLossAcknowledgmentSent)
+                    {
+                        connection.SendAuthorityLossImminentAcknowledgement<global::Improbable.Gdk.Tests.ExhaustiveBlittableSingular>(new global::Improbable.EntityId(spatialEntityIdData[i].EntityId));
+                        component.AuthorityLossAcknowledgmentSent = true;
+                        componentDataArray[i] = component;
+                    }
+                }
+            }
+                
             public override void SendCommands(Connection connection)
             {
+
+                SendAuthorityLossImminentAcknowledgement(connection);
             }
 
             public static ExhaustiveBlittableSingular.Translation GetTranslation(uint internalHandleToTranslation)

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKeyTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKeyTranslation.cs
@@ -24,7 +24,12 @@ namespace Generated.Improbable.Gdk.Tests
             private static readonly ComponentType targetComponentType = typeof(SpatialOSExhaustiveMapKey);
 
             public override ComponentType[] ReplicationComponentTypes => replicationComponentTypes;
-            private static readonly ComponentType[] replicationComponentTypes = { typeof(SpatialOSExhaustiveMapKey), typeof(Authoritative<SpatialOSExhaustiveMapKey>), typeof(SpatialEntityId)};
+            private static readonly ComponentType[] replicationComponentTypes = { typeof(SpatialOSExhaustiveMapKey), typeof(Authoritative<SpatialOSExhaustiveMapKey>), 
+                typeof(SpatialEntityId) };
+                
+            public override ComponentType[] AuthorityLossComponentTypes => authorityLossComponentTypes;
+            private static readonly ComponentType[] authorityLossComponentTypes = { typeof(AuthorityLossImminent<SpatialOSExhaustiveMapKey>),
+                typeof(SpatialEntityId) };
 
             public override ComponentType[] CleanUpComponentTypes => cleanUpComponentTypes;
             private static readonly ComponentType[] cleanUpComponentTypes = 
@@ -373,8 +378,28 @@ namespace Generated.Improbable.Gdk.Tests
                 
             }
 
+
+            private void SendAuthorityLossImminentAcknowledgement(Connection connection)
+            {
+                var componentDataArray = AuthorityLossComponentGroup.GetComponentDataArray<AuthorityLossImminent<SpatialOSExhaustiveMapKey>>();
+                var spatialEntityIdData = AuthorityLossComponentGroup.GetComponentDataArray<SpatialEntityId>();
+
+                for (int i = 0; i < componentDataArray.Length; i++)
+                {
+                    var component = componentDataArray[i];
+                    if (componentDataArray[i].AuthorityLossAcknowledged && !component.AuthorityLossAcknowledgmentSent)
+                    {
+                        connection.SendAuthorityLossImminentAcknowledgement<global::Improbable.Gdk.Tests.ExhaustiveMapKey>(new global::Improbable.EntityId(spatialEntityIdData[i].EntityId));
+                        component.AuthorityLossAcknowledgmentSent = true;
+                        componentDataArray[i] = component;
+                    }
+                }
+            }
+                
             public override void SendCommands(Connection connection)
             {
+
+                SendAuthorityLossImminentAcknowledgement(connection);
             }
 
             public static ExhaustiveMapKey.Translation GetTranslation(uint internalHandleToTranslation)

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKeyTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKeyTranslation.cs
@@ -379,7 +379,7 @@ namespace Generated.Improbable.Gdk.Tests
             }
 
 
-            private void SendAuthorityLossImminentAcknowledgement(Connection connection)
+            public override void SendAuthorityLossImminentAcknowledgement(Connection connection)
             {
                 var componentDataArray = AuthorityLossComponentGroup.GetComponentDataArray<AuthorityLossImminent<SpatialOSExhaustiveMapKey>>();
                 var spatialEntityIdData = AuthorityLossComponentGroup.GetComponentDataArray<SpatialEntityId>();
@@ -398,8 +398,6 @@ namespace Generated.Improbable.Gdk.Tests
                 
             public override void SendCommands(Connection connection)
             {
-
-                SendAuthorityLossImminentAcknowledgement(connection);
             }
 
             public static ExhaustiveMapKey.Translation GetTranslation(uint internalHandleToTranslation)

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValueTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValueTranslation.cs
@@ -24,7 +24,12 @@ namespace Generated.Improbable.Gdk.Tests
             private static readonly ComponentType targetComponentType = typeof(SpatialOSExhaustiveMapValue);
 
             public override ComponentType[] ReplicationComponentTypes => replicationComponentTypes;
-            private static readonly ComponentType[] replicationComponentTypes = { typeof(SpatialOSExhaustiveMapValue), typeof(Authoritative<SpatialOSExhaustiveMapValue>), typeof(SpatialEntityId)};
+            private static readonly ComponentType[] replicationComponentTypes = { typeof(SpatialOSExhaustiveMapValue), typeof(Authoritative<SpatialOSExhaustiveMapValue>), 
+                typeof(SpatialEntityId) };
+                
+            public override ComponentType[] AuthorityLossComponentTypes => authorityLossComponentTypes;
+            private static readonly ComponentType[] authorityLossComponentTypes = { typeof(AuthorityLossImminent<SpatialOSExhaustiveMapValue>),
+                typeof(SpatialEntityId) };
 
             public override ComponentType[] CleanUpComponentTypes => cleanUpComponentTypes;
             private static readonly ComponentType[] cleanUpComponentTypes = 
@@ -373,8 +378,28 @@ namespace Generated.Improbable.Gdk.Tests
                 
             }
 
+
+            private void SendAuthorityLossImminentAcknowledgement(Connection connection)
+            {
+                var componentDataArray = AuthorityLossComponentGroup.GetComponentDataArray<AuthorityLossImminent<SpatialOSExhaustiveMapValue>>();
+                var spatialEntityIdData = AuthorityLossComponentGroup.GetComponentDataArray<SpatialEntityId>();
+
+                for (int i = 0; i < componentDataArray.Length; i++)
+                {
+                    var component = componentDataArray[i];
+                    if (componentDataArray[i].AuthorityLossAcknowledged && !component.AuthorityLossAcknowledgmentSent)
+                    {
+                        connection.SendAuthorityLossImminentAcknowledgement<global::Improbable.Gdk.Tests.ExhaustiveMapValue>(new global::Improbable.EntityId(spatialEntityIdData[i].EntityId));
+                        component.AuthorityLossAcknowledgmentSent = true;
+                        componentDataArray[i] = component;
+                    }
+                }
+            }
+                
             public override void SendCommands(Connection connection)
             {
+
+                SendAuthorityLossImminentAcknowledgement(connection);
             }
 
             public static ExhaustiveMapValue.Translation GetTranslation(uint internalHandleToTranslation)

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValueTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValueTranslation.cs
@@ -379,7 +379,7 @@ namespace Generated.Improbable.Gdk.Tests
             }
 
 
-            private void SendAuthorityLossImminentAcknowledgement(Connection connection)
+            public override void SendAuthorityLossImminentAcknowledgement(Connection connection)
             {
                 var componentDataArray = AuthorityLossComponentGroup.GetComponentDataArray<AuthorityLossImminent<SpatialOSExhaustiveMapValue>>();
                 var spatialEntityIdData = AuthorityLossComponentGroup.GetComponentDataArray<SpatialEntityId>();
@@ -398,8 +398,6 @@ namespace Generated.Improbable.Gdk.Tests
                 
             public override void SendCommands(Connection connection)
             {
-
-                SendAuthorityLossImminentAcknowledgement(connection);
             }
 
             public static ExhaustiveMapValue.Translation GetTranslation(uint internalHandleToTranslation)

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptionalTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptionalTranslation.cs
@@ -368,7 +368,7 @@ namespace Generated.Improbable.Gdk.Tests
             }
 
 
-            private void SendAuthorityLossImminentAcknowledgement(Connection connection)
+            public override void SendAuthorityLossImminentAcknowledgement(Connection connection)
             {
                 var componentDataArray = AuthorityLossComponentGroup.GetComponentDataArray<AuthorityLossImminent<SpatialOSExhaustiveOptional>>();
                 var spatialEntityIdData = AuthorityLossComponentGroup.GetComponentDataArray<SpatialEntityId>();
@@ -387,8 +387,6 @@ namespace Generated.Improbable.Gdk.Tests
                 
             public override void SendCommands(Connection connection)
             {
-
-                SendAuthorityLossImminentAcknowledgement(connection);
             }
 
             public static ExhaustiveOptional.Translation GetTranslation(uint internalHandleToTranslation)

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptionalTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptionalTranslation.cs
@@ -24,7 +24,12 @@ namespace Generated.Improbable.Gdk.Tests
             private static readonly ComponentType targetComponentType = typeof(SpatialOSExhaustiveOptional);
 
             public override ComponentType[] ReplicationComponentTypes => replicationComponentTypes;
-            private static readonly ComponentType[] replicationComponentTypes = { typeof(SpatialOSExhaustiveOptional), typeof(Authoritative<SpatialOSExhaustiveOptional>), typeof(SpatialEntityId)};
+            private static readonly ComponentType[] replicationComponentTypes = { typeof(SpatialOSExhaustiveOptional), typeof(Authoritative<SpatialOSExhaustiveOptional>), 
+                typeof(SpatialEntityId) };
+                
+            public override ComponentType[] AuthorityLossComponentTypes => authorityLossComponentTypes;
+            private static readonly ComponentType[] authorityLossComponentTypes = { typeof(AuthorityLossImminent<SpatialOSExhaustiveOptional>),
+                typeof(SpatialEntityId) };
 
             public override ComponentType[] CleanUpComponentTypes => cleanUpComponentTypes;
             private static readonly ComponentType[] cleanUpComponentTypes = 
@@ -362,8 +367,28 @@ namespace Generated.Improbable.Gdk.Tests
                 
             }
 
+
+            private void SendAuthorityLossImminentAcknowledgement(Connection connection)
+            {
+                var componentDataArray = AuthorityLossComponentGroup.GetComponentDataArray<AuthorityLossImminent<SpatialOSExhaustiveOptional>>();
+                var spatialEntityIdData = AuthorityLossComponentGroup.GetComponentDataArray<SpatialEntityId>();
+
+                for (int i = 0; i < componentDataArray.Length; i++)
+                {
+                    var component = componentDataArray[i];
+                    if (componentDataArray[i].AuthorityLossAcknowledged && !component.AuthorityLossAcknowledgmentSent)
+                    {
+                        connection.SendAuthorityLossImminentAcknowledgement<global::Improbable.Gdk.Tests.ExhaustiveOptional>(new global::Improbable.EntityId(spatialEntityIdData[i].EntityId));
+                        component.AuthorityLossAcknowledgmentSent = true;
+                        componentDataArray[i] = component;
+                    }
+                }
+            }
+                
             public override void SendCommands(Connection connection)
             {
+
+                SendAuthorityLossImminentAcknowledgement(connection);
             }
 
             public static ExhaustiveOptional.Translation GetTranslation(uint internalHandleToTranslation)

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeatedTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeatedTranslation.cs
@@ -24,7 +24,12 @@ namespace Generated.Improbable.Gdk.Tests
             private static readonly ComponentType targetComponentType = typeof(SpatialOSExhaustiveRepeated);
 
             public override ComponentType[] ReplicationComponentTypes => replicationComponentTypes;
-            private static readonly ComponentType[] replicationComponentTypes = { typeof(SpatialOSExhaustiveRepeated), typeof(Authoritative<SpatialOSExhaustiveRepeated>), typeof(SpatialEntityId)};
+            private static readonly ComponentType[] replicationComponentTypes = { typeof(SpatialOSExhaustiveRepeated), typeof(Authoritative<SpatialOSExhaustiveRepeated>), 
+                typeof(SpatialEntityId) };
+                
+            public override ComponentType[] AuthorityLossComponentTypes => authorityLossComponentTypes;
+            private static readonly ComponentType[] authorityLossComponentTypes = { typeof(AuthorityLossImminent<SpatialOSExhaustiveRepeated>),
+                typeof(SpatialEntityId) };
 
             public override ComponentType[] CleanUpComponentTypes => cleanUpComponentTypes;
             private static readonly ComponentType[] cleanUpComponentTypes = 
@@ -373,8 +378,28 @@ namespace Generated.Improbable.Gdk.Tests
                 
             }
 
+
+            private void SendAuthorityLossImminentAcknowledgement(Connection connection)
+            {
+                var componentDataArray = AuthorityLossComponentGroup.GetComponentDataArray<AuthorityLossImminent<SpatialOSExhaustiveRepeated>>();
+                var spatialEntityIdData = AuthorityLossComponentGroup.GetComponentDataArray<SpatialEntityId>();
+
+                for (int i = 0; i < componentDataArray.Length; i++)
+                {
+                    var component = componentDataArray[i];
+                    if (componentDataArray[i].AuthorityLossAcknowledged && !component.AuthorityLossAcknowledgmentSent)
+                    {
+                        connection.SendAuthorityLossImminentAcknowledgement<global::Improbable.Gdk.Tests.ExhaustiveRepeated>(new global::Improbable.EntityId(spatialEntityIdData[i].EntityId));
+                        component.AuthorityLossAcknowledgmentSent = true;
+                        componentDataArray[i] = component;
+                    }
+                }
+            }
+                
             public override void SendCommands(Connection connection)
             {
+
+                SendAuthorityLossImminentAcknowledgement(connection);
             }
 
             public static ExhaustiveRepeated.Translation GetTranslation(uint internalHandleToTranslation)

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeatedTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeatedTranslation.cs
@@ -379,7 +379,7 @@ namespace Generated.Improbable.Gdk.Tests
             }
 
 
-            private void SendAuthorityLossImminentAcknowledgement(Connection connection)
+            public override void SendAuthorityLossImminentAcknowledgement(Connection connection)
             {
                 var componentDataArray = AuthorityLossComponentGroup.GetComponentDataArray<AuthorityLossImminent<SpatialOSExhaustiveRepeated>>();
                 var spatialEntityIdData = AuthorityLossComponentGroup.GetComponentDataArray<SpatialEntityId>();
@@ -398,8 +398,6 @@ namespace Generated.Improbable.Gdk.Tests
                 
             public override void SendCommands(Connection connection)
             {
-
-                SendAuthorityLossImminentAcknowledgement(connection);
             }
 
             public static ExhaustiveRepeated.Translation GetTranslation(uint internalHandleToTranslation)

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingularTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingularTranslation.cs
@@ -390,7 +390,7 @@ namespace Generated.Improbable.Gdk.Tests
             }
 
 
-            private void SendAuthorityLossImminentAcknowledgement(Connection connection)
+            public override void SendAuthorityLossImminentAcknowledgement(Connection connection)
             {
                 var componentDataArray = AuthorityLossComponentGroup.GetComponentDataArray<AuthorityLossImminent<SpatialOSExhaustiveSingular>>();
                 var spatialEntityIdData = AuthorityLossComponentGroup.GetComponentDataArray<SpatialEntityId>();
@@ -409,8 +409,6 @@ namespace Generated.Improbable.Gdk.Tests
                 
             public override void SendCommands(Connection connection)
             {
-
-                SendAuthorityLossImminentAcknowledgement(connection);
             }
 
             public static ExhaustiveSingular.Translation GetTranslation(uint internalHandleToTranslation)

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingularTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingularTranslation.cs
@@ -24,7 +24,12 @@ namespace Generated.Improbable.Gdk.Tests
             private static readonly ComponentType targetComponentType = typeof(SpatialOSExhaustiveSingular);
 
             public override ComponentType[] ReplicationComponentTypes => replicationComponentTypes;
-            private static readonly ComponentType[] replicationComponentTypes = { typeof(SpatialOSExhaustiveSingular), typeof(Authoritative<SpatialOSExhaustiveSingular>), typeof(SpatialEntityId)};
+            private static readonly ComponentType[] replicationComponentTypes = { typeof(SpatialOSExhaustiveSingular), typeof(Authoritative<SpatialOSExhaustiveSingular>), 
+                typeof(SpatialEntityId) };
+                
+            public override ComponentType[] AuthorityLossComponentTypes => authorityLossComponentTypes;
+            private static readonly ComponentType[] authorityLossComponentTypes = { typeof(AuthorityLossImminent<SpatialOSExhaustiveSingular>),
+                typeof(SpatialEntityId) };
 
             public override ComponentType[] CleanUpComponentTypes => cleanUpComponentTypes;
             private static readonly ComponentType[] cleanUpComponentTypes = 
@@ -384,8 +389,28 @@ namespace Generated.Improbable.Gdk.Tests
                 
             }
 
+
+            private void SendAuthorityLossImminentAcknowledgement(Connection connection)
+            {
+                var componentDataArray = AuthorityLossComponentGroup.GetComponentDataArray<AuthorityLossImminent<SpatialOSExhaustiveSingular>>();
+                var spatialEntityIdData = AuthorityLossComponentGroup.GetComponentDataArray<SpatialEntityId>();
+
+                for (int i = 0; i < componentDataArray.Length; i++)
+                {
+                    var component = componentDataArray[i];
+                    if (componentDataArray[i].AuthorityLossAcknowledged && !component.AuthorityLossAcknowledgmentSent)
+                    {
+                        connection.SendAuthorityLossImminentAcknowledgement<global::Improbable.Gdk.Tests.ExhaustiveSingular>(new global::Improbable.EntityId(spatialEntityIdData[i].EntityId));
+                        component.AuthorityLossAcknowledgmentSent = true;
+                        componentDataArray[i] = component;
+                    }
+                }
+            }
+                
             public override void SendCommands(Connection connection)
             {
+
+                SendAuthorityLossImminentAcknowledgement(connection);
             }
 
             public static ExhaustiveSingular.Translation GetTranslation(uint internalHandleToTranslation)

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/NestedComponentTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/NestedComponentTranslation.cs
@@ -225,7 +225,7 @@ namespace Generated.Improbable.Gdk.Tests
             }
 
 
-            private void SendAuthorityLossImminentAcknowledgement(Connection connection)
+            public override void SendAuthorityLossImminentAcknowledgement(Connection connection)
             {
                 var componentDataArray = AuthorityLossComponentGroup.GetComponentDataArray<AuthorityLossImminent<SpatialOSNestedComponent>>();
                 var spatialEntityIdData = AuthorityLossComponentGroup.GetComponentDataArray<SpatialEntityId>();
@@ -244,8 +244,6 @@ namespace Generated.Improbable.Gdk.Tests
                 
             public override void SendCommands(Connection connection)
             {
-
-                SendAuthorityLossImminentAcknowledgement(connection);
             }
 
             public static NestedComponent.Translation GetTranslation(uint internalHandleToTranslation)

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/NestedComponentTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/NestedComponentTranslation.cs
@@ -24,7 +24,12 @@ namespace Generated.Improbable.Gdk.Tests
             private static readonly ComponentType targetComponentType = typeof(SpatialOSNestedComponent);
 
             public override ComponentType[] ReplicationComponentTypes => replicationComponentTypes;
-            private static readonly ComponentType[] replicationComponentTypes = { typeof(SpatialOSNestedComponent), typeof(Authoritative<SpatialOSNestedComponent>), typeof(SpatialEntityId)};
+            private static readonly ComponentType[] replicationComponentTypes = { typeof(SpatialOSNestedComponent), typeof(Authoritative<SpatialOSNestedComponent>), 
+                typeof(SpatialEntityId) };
+                
+            public override ComponentType[] AuthorityLossComponentTypes => authorityLossComponentTypes;
+            private static readonly ComponentType[] authorityLossComponentTypes = { typeof(AuthorityLossImminent<SpatialOSNestedComponent>),
+                typeof(SpatialEntityId) };
 
             public override ComponentType[] CleanUpComponentTypes => cleanUpComponentTypes;
             private static readonly ComponentType[] cleanUpComponentTypes = 
@@ -219,8 +224,28 @@ namespace Generated.Improbable.Gdk.Tests
                 
             }
 
+
+            private void SendAuthorityLossImminentAcknowledgement(Connection connection)
+            {
+                var componentDataArray = AuthorityLossComponentGroup.GetComponentDataArray<AuthorityLossImminent<SpatialOSNestedComponent>>();
+                var spatialEntityIdData = AuthorityLossComponentGroup.GetComponentDataArray<SpatialEntityId>();
+
+                for (int i = 0; i < componentDataArray.Length; i++)
+                {
+                    var component = componentDataArray[i];
+                    if (componentDataArray[i].AuthorityLossAcknowledged && !component.AuthorityLossAcknowledgmentSent)
+                    {
+                        connection.SendAuthorityLossImminentAcknowledgement<global::Improbable.Gdk.Tests.NestedComponent>(new global::Improbable.EntityId(spatialEntityIdData[i].EntityId));
+                        component.AuthorityLossAcknowledgmentSent = true;
+                        componentDataArray[i] = component;
+                    }
+                }
+            }
+                
             public override void SendCommands(Connection connection)
             {
+
+                SendAuthorityLossImminentAcknowledgement(connection);
             }
 
             public static NestedComponent.Translation GetTranslation(uint internalHandleToTranslation)

--- a/workers/unity/Packages/com.improbable.gdk.core/Components/AuthorityComponents.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Components/AuthorityComponents.cs
@@ -12,5 +12,7 @@ namespace Improbable.Gdk.Core
 
     public struct AuthorityLossImminent<T> : IComponentData
     {
+        public BlittableBool AuthorityLossAcknowledged;
+        public BlittableBool AuthorityLossAcknowledgmentSent;
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.core/Components/ComponentTranslation.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Components/ComponentTranslation.cs
@@ -56,6 +56,9 @@ namespace Improbable.Gdk.Core.Components
         public ComponentGroup ReplicationComponentGroup { get; set; }
         public abstract void ExecuteReplication(Connection connection);
 
+        public abstract ComponentType[] AuthorityLossComponentTypes { get; }
+        public ComponentGroup AuthorityLossComponentGroup { get; set; }
+
         public abstract ComponentType[] CleanUpComponentTypes { get; }
         public List<ComponentGroup> CleanUpComponentGroups { get; set; }
         public abstract void CleanUpComponents(ref EntityCommandBuffer entityCommandBuffer);

--- a/workers/unity/Packages/com.improbable.gdk.core/Components/ComponentTranslation.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Components/ComponentTranslation.cs
@@ -64,6 +64,7 @@ namespace Improbable.Gdk.Core.Components
         public abstract void CleanUpComponents(ref EntityCommandBuffer entityCommandBuffer);
 
         public abstract void AddCommandRequestSender(Entity entity, long entityId);
+        public abstract void SendAuthorityLossImminentAcknowledgement(Connection connection);
         public abstract void SendCommands(Connection connection);
 
         protected void RemoveComponents<T>(ref EntityCommandBuffer entityCommandBuffer, int groupIndex)

--- a/workers/unity/Packages/com.improbable.gdk.core/Components/WorldCommandsTranslation.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Components/WorldCommandsTranslation.cs
@@ -197,6 +197,9 @@ namespace Improbable.Gdk.Core
         public override ComponentType[] ReplicationComponentTypes => replicationComponentTypes;
         private static readonly ComponentType[] replicationComponentTypes = { };
 
+        public override ComponentType[] AuthorityLossComponentTypes => authorityLossComponentTypes;
+        private static readonly ComponentType[] authorityLossComponentTypes = { };
+
         public override ComponentType[] CleanUpComponentTypes => cleanUpComponentTypes;
 
         private static readonly ComponentType[] cleanUpComponentTypes =

--- a/workers/unity/Packages/com.improbable.gdk.core/Components/WorldCommandsTranslation.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Components/WorldCommandsTranslation.cs
@@ -264,6 +264,10 @@ namespace Improbable.Gdk.Core
             view.AddComponent(entity, new WorldCommandSender(EntityId, translationHandle));
         }
 
+        public override void SendAuthorityLossImminentAcknowledgement(Connection connection)
+        {
+        }
+
         public override void ExecuteReplication(Connection connection)
         {
         }

--- a/workers/unity/Packages/com.improbable.gdk.core/MutableView/MutableView.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/MutableView/MutableView.cs
@@ -245,7 +245,11 @@ namespace Improbable.Gdk.Core
                         return;
                     }
 
-                    AddComponent(entity, new AuthorityLossImminent<T>());
+                    AddComponent(entity, new AuthorityLossImminent<T>
+                    {
+                        AuthorityLossAcknowledged = false,
+                        AuthorityLossAcknowledgmentSent = false
+                    });
                     break;
                 case Authority.NotAuthoritative:
                     if (!HasComponent<Authoritative<T>>(entity))

--- a/workers/unity/Packages/com.improbable.gdk.core/Systems/SpatialOSSendSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Systems/SpatialOSSendSystem.cs
@@ -32,6 +32,9 @@ namespace Improbable.Gdk.Core
                 var replicationComponentGroup = GetComponentGroup(componentTranslator.ReplicationComponentTypes);
                 componentTranslator.ReplicationComponentGroup = replicationComponentGroup;
 
+                var authorityLossComponentGroup = GetComponentGroup(componentTranslator.AuthorityLossComponentTypes);
+                componentTranslator.AuthorityLossComponentGroup = authorityLossComponentGroup;
+
                 registeredReplicators.Add(componentIndex);
                 commandSenders.Add(componentIndex);
             }

--- a/workers/unity/Packages/com.improbable.gdk.core/Systems/SpatialOSSendSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Systems/SpatialOSSendSystem.cs
@@ -68,6 +68,7 @@ namespace Improbable.Gdk.Core
             foreach (var componentTypeIndex in commandSenders)
             {
                 view.TranslationUnits[componentTypeIndex].SendCommands(connection);
+                view.TranslationUnits[componentTypeIndex].SendAuthorityLossImminentAcknowledgement(connection);
             }
         }
     }


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Currently it is only possible to send authority loss imminent ack only using the C# SDK, added the functionality in the GDK as well.

Example generated code:
```csharp
private void SendAuthorityLossImminentAcknowledgement(Connection connection)
{
    var componentDataArray = AuthorityLossComponentGroup.GetComponentDataArray<AuthorityLossImminent<SpatialOSTransform>>();
    var spatialEntityIdData = AuthorityLossComponentGroup.GetComponentDataArray<SpatialEntityId>();

    for (int i = 0; i < componentDataArray.Length; i++)
    {
        var component = componentDataArray[i];
        if (componentDataArray[i].AuthorityLossAcknowledged && !component.AuthorityLossAcknowledgmentSent)
        {
            connection.SendAuthorityLossImminentAcknowledgement<global::Improbable.Transform.Transform>(new global::Improbable.EntityId(spatialEntityIdData[i].EntityId));
            component.AuthorityLossAcknowledgmentSent = true;
            componentDataArray[i] = component;
        }
    }
}
```

#### Tests
Added AuthorityLossImminent component to entities to see whether sending works.

#### Documentation
Will add in a separate PR.

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.