### PR TITLE
Extract SetComponentObject into an extension method

### DIFF
--- a/workers/unity/Packages/com.improbable.gdk.core/MutableView/MutableView.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/MutableView/MutableView.cs
@@ -24,14 +24,6 @@ namespace Improbable.Gdk.Core
 
         private readonly EntityManager entityManager;
 
-        private readonly Action<Entity, ComponentType, object> setComponentObjectAction;
-
-        // Reflection magic to get the internal method "SetComponentObject" on the specific EntityManager instance. This is required to add Components to Entities at runtime
-        private static readonly MethodInfo setComponentObjectMethodInfo =
-            typeof(EntityManager).GetMethod("SetComponentObject", BindingFlags.Instance | BindingFlags.NonPublic, null,
-                new Type[] { typeof(Entity), typeof(ComponentType), typeof(object) },
-                new ParameterModifier[] { });
-
         private readonly Dictionary<long, Entity> entityMapping;
 
         public MutableView(World world, ILogDispatcher logDispatcher)
@@ -40,8 +32,6 @@ namespace Improbable.Gdk.Core
             entityMapping = new Dictionary<long, Entity>();
             LogDispatcher = logDispatcher;
 
-            setComponentObjectAction = (Action<Entity, ComponentType, object>) Delegate.CreateDelegate(
-                typeof(Action<Entity, ComponentType, object>), entityManager, setComponentObjectMethodInfo);
 
             FindTranslationUnits();
 
@@ -121,7 +111,7 @@ namespace Improbable.Gdk.Core
                 entityManager.AddComponent(entity, typeof(T));
             }
 
-            setComponentObjectAction(entity, typeof(T), component);
+            entityManager.SetComponentObject(entity, component);
         }
 
         public void SetComponentData<T>(Entity entity, T componentData) where T : struct, IComponentData
@@ -143,7 +133,7 @@ namespace Improbable.Gdk.Core
                 entityManager.AddComponent(entity, componentType);
             }
 
-            setComponentObjectAction(entity, componentType, component);
+            entityManager.SetComponentObject(entity, componentType, component);
         }
 
         public void SetComponentObject<T>(long entityId, T component) where T : Component
@@ -163,7 +153,7 @@ namespace Improbable.Gdk.Core
                 entityManager.AddComponent(entity, typeof(T));
             }
 
-            setComponentObjectAction(entity, typeof(T), component);
+            entityManager.SetComponentObject(entity, typeof(T), component);
         }
 
         public void AddComponentsUpdated<T>(Entity entity, T update, ComponentPool<ComponentsUpdated<T>> pool)

--- a/workers/unity/Packages/com.improbable.gdk.core/Utility/EntityManagerExtensions.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Utility/EntityManagerExtensions.cs
@@ -1,17 +1,12 @@
 ﻿using System;
-using System.Diagnostics;
 using System.Reflection;
 using Unity.Entities;
-#if UNITY_EDITOR
-using UnityEditor;
-
-#endif
 
 namespace Improbable.Gdk.Core
 {
 #if UNITY_EDITOR
     // Attempt to validate the method as soon as possible when in the editor.
-    [InitializeOnLoad]
+    [UnityEditor.InitializeOnLoad]
 #endif
     internal static class EntityManagerExtensions
     {

--- a/workers/unity/Packages/com.improbable.gdk.core/Utility/EntityManagerExtensions.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Utility/EntityManagerExtensions.cs
@@ -1,13 +1,18 @@
 ﻿using System;
 using System.Diagnostics;
-using System.Linq;
 using System.Reflection;
 using Unity.Entities;
+#if UNITY_EDITOR
 using UnityEditor;
+
+#endif
 
 namespace Improbable.Gdk.Core
 {
+#if UNITY_EDITOR
+    // Attempt to validate the method as soon as possible when in the editor.
     [InitializeOnLoad]
+#endif
     internal static class EntityManagerExtensions
     {
         private delegate void SetComponentObjectDelegate(EntityManager entityManager,

--- a/workers/unity/Packages/com.improbable.gdk.core/Utility/EntityManagerExtensions.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Utility/EntityManagerExtensions.cs
@@ -28,43 +28,21 @@ namespace Improbable.Gdk.Core
                     new Type[] { typeof(Entity), typeof(ComponentType), typeof(object) },
                     new ParameterModifier[] { });
 
-            ValidateParameters(setComponentObjectMethodInfo);
+            if (setComponentObjectMethodInfo == null)
+            {
+                throw new MissingMethodException(
+                    "Could not find the EntityManager.SetComponentObject(Entity, ComponentType, object) method.\n" +
+                    "Please ensure you are using a compatible version of the Unity.Entities package.");
+            }
 
             SetComponentObjectAction =
                 (SetComponentObjectDelegate) Delegate.CreateDelegate(typeof(SetComponentObjectDelegate),
                     setComponentObjectMethodInfo);
         }
 
-        [Conditional("UNITY_EDITOR")]
-        [Conditional("DEVELOPMENT_BUILD")]
-        private static void ValidateParameters(MethodInfo setComponentObjectMethodInfo)
-        {
-            const string errorMessage =
-                "Could not find the EntityManager.SetComponentObject(Entity, ComponentType, object) method.\n" +
-                "Please ensure you are using a compatible version of the Unity.Entities package.";
-
-            if (setComponentObjectMethodInfo == null)
-            {
-                throw new MissingMethodException(errorMessage);
-            }
-
-            var parameters = setComponentObjectMethodInfo.GetParameters();
-
-            if (parameters.Length == 3 &&
-                parameters[0].ParameterType == typeof(Entity) &&
-                parameters[1].ParameterType == typeof(ComponentType) &&
-                parameters[2].ParameterType == typeof(object))
-            {
-                // All good!
-                return;
-            }
-
-            throw new MissingMethodException(errorMessage);
-        }
-
         public static void SetComponentObject<T>(this EntityManager entityManager, Entity entity, T component)
         {
-            SetComponentObjectAction(entityManager, entity, typeof(T), component);
+            SetComponentObjectAction(entityManager, entity, ComponentType.Create<T>(), component);
         }
 
         public static void SetComponentObject(this EntityManager entityManager, Entity entity,

--- a/workers/unity/Packages/com.improbable.gdk.core/Utility/EntityManagerExtensions.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Utility/EntityManagerExtensions.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using Unity.Entities;
+using UnityEditor;
+
+namespace Improbable.Gdk.Core
+{
+    [InitializeOnLoad]
+    internal static class EntityManagerExtensions
+    {
+        private delegate void SetComponentObjectDelegate(EntityManager entityManager,
+            Entity entity, ComponentType componentType, object componentObject);
+
+        private static readonly SetComponentObjectDelegate SetComponentObjectAction;
+
+        static EntityManagerExtensions()
+        {
+            var setComponentObjectMethodInfo =
+                typeof(EntityManager).GetMethod("SetComponentObject", BindingFlags.Instance | BindingFlags.NonPublic,
+                    null,
+                    new Type[] { typeof(Entity), typeof(ComponentType), typeof(object) },
+                    new ParameterModifier[] { });
+
+            ValidateParameters(setComponentObjectMethodInfo);
+
+            SetComponentObjectAction =
+                (SetComponentObjectDelegate) Delegate.CreateDelegate(typeof(SetComponentObjectDelegate),
+                    setComponentObjectMethodInfo);
+        }
+
+        [Conditional("UNITY_EDITOR")]
+        [Conditional("DEVELOPMENT_BUILD")]
+        private static void ValidateParameters(MethodInfo setComponentObjectMethodInfo)
+        {
+            const string errorMessage =
+                "Could not find the EntityManager.SetComponentObject(Entity, ComponentType, object) method.\n" +
+                "Please ensure you are using a compatible version of the Unity.Entities package.";
+
+            if (setComponentObjectMethodInfo == null)
+            {
+                throw new MissingMethodException(errorMessage);
+            }
+
+            var parameters = setComponentObjectMethodInfo.GetParameters();
+
+            if (parameters.Length == 3 &&
+                parameters[0].ParameterType == typeof(Entity) &&
+                parameters[1].ParameterType == typeof(ComponentType) &&
+                parameters[2].ParameterType == typeof(object))
+            {
+                // All good!
+                return;
+            }
+
+            throw new MissingMethodException(errorMessage);
+        }
+
+        public static void SetComponentObject<T>(this EntityManager entityManager, Entity entity, T component)
+        {
+            SetComponentObjectAction(entityManager, entity, typeof(T), component);
+        }
+
+        public static void SetComponentObject(this EntityManager entityManager, Entity entity,
+            ComponentType componentType, object component)
+        {
+            SetComponentObjectAction(entityManager, entity, componentType, component);
+        }
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.core/Utility/EntityManagerExtensions.cs.meta
+++ b/workers/unity/Packages/com.improbable.gdk.core/Utility/EntityManagerExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b9693e823603bed42b03c6d251e646a9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
This makes it consistent with `GetComponentObject` extension method too.

Also adds some exceptions to help resolve problems if things change

#### Tests
Tested with local deployments and in editor

#### Documentation
Internal only

#### Primary reviewers
@zeroZshadow @jamiebrynes7 