### PR TITLE
Allow exception messages to be passed into Unity's logger properly

### DIFF
--- a/docs/content/logging.md
+++ b/docs/content/logging.md
@@ -37,9 +37,9 @@ worker.View.LogDispatcher.HandleLog(LogType.Error, new LogEvent(
     .WithField("CustomKey", "CustomValue"));
 ```
 
-For exception messages, please pass in the exception to the `LogEvent` class using the `WithException` method.
+For `LogType.Exception`, add the exception to the `LogEvent` class using the `WithException(Exception)` method.
 
-You can additionally add a context object to be passed into the Unity console using the `WithContext` method. 
+You can add a context object to be passed into the Unity console using the `WithContext(UnityEngine.Object)` method. 
 
 ### Creating and using your own dispatcher
 

--- a/docs/content/logging.md
+++ b/docs/content/logging.md
@@ -37,6 +37,10 @@ worker.View.LogDispatcher.HandleLog(LogType.Error, new LogEvent(
     .WithField("CustomKey", "CustomValue"));
 ```
 
+For exception messages, please pass in the exception to the `LogEvent` class using the `WithException` method.
+
+You can additionally add a context object to be passed into the Unity console using the `WithContext` method. 
+
 ### Creating and using your own dispatcher
 
 To create your own dispatcher, make a new class which implements `ILogDispatcher`:

--- a/docs/content/logging.md
+++ b/docs/content/logging.md
@@ -37,9 +37,11 @@ worker.View.LogDispatcher.HandleLog(LogType.Error, new LogEvent(
     .WithField("CustomKey", "CustomValue"));
 ```
 
-For `LogType.Exception`, add the exception to the `LogEvent` class using the `WithException(Exception)` method.
-
-You can add a context object to be passed into the Unity console using the `WithContext(UnityEngine.Object)` method. 
+The `LogEvent` class allows construction of enhanced log messages.
+* Use the `WithField` method to set additional information to be displayed with the log message.
+* Use the `WithContext(UnityEngine.Object)` method to add a context object to be passed into the Unity console.
+ 
+**Note**: For `LogType.Exception`, add a relevant exception to the `LogEvent` class using the `WithException(Exception)` method. The `WithException` method will be ignored for other `LogType` values.
 
 ### Creating and using your own dispatcher
 

--- a/workers/unity/Packages/com.improbable.gdk.core/Logging/ForwardingDispatcher.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Logging/ForwardingDispatcher.cs
@@ -14,6 +14,8 @@ namespace Improbable.Gdk.Core
 
         private readonly LogLevel minimumLogLevel;
 
+        private bool inHandleLog;
+
         private static readonly Dictionary<LogType, LogLevel> LogTypeMapping = new Dictionary<LogType, LogLevel>
         {
             { LogType.Exception, LogLevel.Error },
@@ -29,8 +31,15 @@ namespace Improbable.Gdk.Core
             Application.logMessageReceived += LogCallback;
         }
 
+        // This method catches exceptions coming from the engine, or third party code.
         private void LogCallback(string message, string stackTrace, LogType type)
         {
+            if (inHandleLog)
+            {
+                // HandleLog will do its own message sending.
+                return;
+            }
+
             // This is required to avoid duplicate forwarding caused by HandleLog also logging to console
             if (type == LogType.Exception)
             {
@@ -45,32 +54,48 @@ namespace Improbable.Gdk.Core
 
         public void HandleLog(LogType type, LogEvent logEvent)
         {
-            if (type == LogType.Exception)
+            inHandleLog = true;
+            try
             {
-                // For exception types, Unity expects an exception object to be passed.
-                // Otherwise, it will not be displayed.
-                Exception exception = logEvent.Exception ?? new Exception(logEvent.ToString());
+                if (type == LogType.Exception)
+                {
+                    // For exception types, Unity expects an exception object to be passed.
+                    // Otherwise, it will not be displayed.
+                    Exception exception = logEvent.Exception ?? new Exception(logEvent.ToString());
 
-                Debug.unityLogger.LogException(exception, logEvent.Context);
+                    Debug.unityLogger.LogException(exception, logEvent.Context);
+                }
+                else
+                {
+                    Debug.unityLogger.Log(
+                        logType: type,
+                        message: logEvent,
+                        context: logEvent.Context);
+                }
+
+                LogLevel logLevel = LogTypeMapping[type];
+
+                if (connection == null || logLevel < minimumLogLevel)
+                {
+                    return;
+                }
+
+                var message = logEvent.ToString();
+
+                if (type == LogType.Exception && logEvent.Exception != null)
+                {
+                    // Append the stack trace of the exception to the message.
+                    message += $"\n{logEvent.Exception.StackTrace}";
+                }
+
+                var entityId = LoggingUtils.ExtractEntityId(logEvent.Data);
+
+                connection.SendLogMessage(logLevel, LoggingUtils.ExtractLoggerName(logEvent.Data), message, entityId);
             }
-            else
+            finally
             {
-                Debug.unityLogger.Log(
-                    logType: type,
-                    message: logEvent,
-                    context: logEvent.Context);
+                inHandleLog = false;
             }
-
-            LogLevel logLevel = LogTypeMapping[type];
-
-            if (connection == null || logLevel < minimumLogLevel)
-            {
-                return;
-            }
-
-            var message = logEvent.ToString();
-            var entityId = LoggingUtils.ExtractEntityId(logEvent.Data);
-            connection.SendLogMessage(logLevel, LoggingUtils.ExtractLoggerName(logEvent.Data), message, entityId);
         }
 
         public void Dispose()

--- a/workers/unity/Packages/com.improbable.gdk.core/Logging/ForwardingDispatcher.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Logging/ForwardingDispatcher.cs
@@ -45,7 +45,22 @@ namespace Improbable.Gdk.Core
 
         public void HandleLog(LogType type, LogEvent logEvent)
         {
-            Debug.unityLogger.Log(type, logEvent);
+            if (type == LogType.Exception)
+            {
+                // For exception types, Unity expects an exception object to be passed.
+                // Otherwise, it will not be displayed.
+                Exception exception = logEvent.Exception ?? new Exception(logEvent.ToString());
+
+                Debug.unityLogger.LogException(exception, logEvent.Context);
+            }
+            else
+            {
+                Debug.unityLogger.Log(
+                    logType: type,
+                    message: logEvent,
+                    context: logEvent.Context);
+            }
+
             LogLevel logLevel = LogTypeMapping[type];
 
             if (connection == null || logLevel < minimumLogLevel)

--- a/workers/unity/Packages/com.improbable.gdk.core/Logging/LogEvent.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Logging/LogEvent.cs
@@ -8,9 +8,8 @@ namespace Improbable.Gdk.Core
     {
         public string Message;
         public Dictionary<string, object> Data;
-
-        public Exception Exception;
         public UnityEngine.Object Context;
+        public Exception Exception;
 
         public LogEvent(string message)
         {
@@ -20,12 +19,23 @@ namespace Improbable.Gdk.Core
             Context = null;
         }
 
+        /// <summary>
+        /// Sets additional information to be displayed with the log message.
+        /// </summary>
+        /// <param name="key">The key.</param>
+        /// <param name="value">The value.</param>
+        /// <returns></returns>
         public LogEvent WithField(string key, object value)
         {
             Data.Add(key, value);
             return this;
         }
 
+        /// <summary>
+        /// Adds a context object to be passed as the second parameter into <see cref="UnityEngine.Debug.Log(object, UnityEngine.Object)"/>
+        /// </summary>
+        /// <param name="context">The context object</param>
+        /// <returns>itself</returns>
         public LogEvent WithContext(UnityEngine.Object context)
         {
             Context = context;
@@ -47,8 +57,8 @@ namespace Improbable.Gdk.Core
             if (Data.Count > 0)
             {
                 builder.AppendLine();
-                
-                builder.AppendLine("Log event context:");
+
+                builder.AppendLine("Log event data:");
 
                 foreach (var entry in Data)
                 {

--- a/workers/unity/Packages/com.improbable.gdk.core/Logging/LogEvent.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Logging/LogEvent.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Text;
 
@@ -8,10 +9,15 @@ namespace Improbable.Gdk.Core
         public string Message;
         public Dictionary<string, object> Data;
 
+        public Exception Exception;
+        public UnityEngine.Object Context;
+
         public LogEvent(string message)
         {
             Message = message;
             Data = new Dictionary<string, object>();
+            Exception = null;
+            Context = null;
         }
 
         public LogEvent WithField(string key, object value)
@@ -20,14 +26,28 @@ namespace Improbable.Gdk.Core
             return this;
         }
 
+        public LogEvent WithContext(UnityEngine.Object context)
+        {
+            Context = context;
+            return this;
+        }
+
+        public LogEvent WithException(Exception exception)
+        {
+            Exception = exception;
+            return this;
+        }
+
         public override string ToString()
         {
             var builder = new StringBuilder();
 
-            builder.AppendLine(Message);
+            builder.Append(Message);
 
             if (Data.Count > 0)
             {
+                builder.AppendLine();
+                
                 builder.AppendLine("Log event context:");
 
                 foreach (var entry in Data)

--- a/workers/unity/Packages/com.improbable.gdk.core/Logging/LoggingDispatcher.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Logging/LoggingDispatcher.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 
 namespace Improbable.Gdk.Core
@@ -9,7 +10,21 @@ namespace Improbable.Gdk.Core
     {
         public void HandleLog(LogType type, LogEvent logEvent)
         {
-            Debug.unityLogger.Log(type, logEvent);
+            if (type == LogType.Exception)
+            {
+                // For exception types, Unity expects an exception object to be passed.
+                // Otherwise, it will not be displayed.
+                Exception exception = logEvent.Exception ?? new Exception(logEvent.ToString());
+
+                Debug.unityLogger.LogException(exception, logEvent.Context);
+            }
+            else
+            {
+                Debug.unityLogger.Log(
+                    logType: type,
+                    message: logEvent,
+                    context: logEvent.Context);
+            }
         }
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.core/Tests/Editmode/Logging.meta
+++ b/workers/unity/Packages/com.improbable.gdk.core/Tests/Editmode/Logging.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fcd00a854aa76884f9b757a0de56875d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/com.improbable.gdk.core/Tests/Editmode/Logging/LoggingTests.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Tests/Editmode/Logging/LoggingTests.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace Improbable.Gdk.Core.EditmodeTests.Logging
+{
+    [TestFixture]
+    public class LoggingDispatcherTests
+    {
+        private LoggingDispatcher logDispatcher;
+
+        [SetUp]
+        public void SetUp()
+        {
+            logDispatcher = new LoggingDispatcher();
+        }
+
+        [Test]
+        [TestCase(LogType.Error)]
+        [TestCase(LogType.Assert)]
+        [TestCase(LogType.Warning)]
+        [TestCase(LogType.Log)]
+        public void ForwardsCorrectMessageTypes(LogType logType)
+        {
+            LogAssert.Expect(logType, $"Message with type: {logType}");
+            logDispatcher.HandleLog(logType, new LogEvent($"Message with type: {logType}"));
+        }
+
+        [Test]
+        public void ForwardsExceptionTypes()
+        {
+            LogAssert.Expect(LogType.Exception, "Exception: Test Exception");
+            logDispatcher.HandleLog(LogType.Exception, new LogEvent()
+                .WithException(new Exception("Test Exception")));
+        }
+
+        [Test]
+        public void CreatesExceptionIfNotSpecified()
+        {
+            LogAssert.Expect(LogType.Exception, "Exception: Test Exception");
+            logDispatcher.HandleLog(LogType.Exception, new LogEvent("Test Exception"));
+        }
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.core/Tests/Editmode/Logging/LoggingTests.cs.meta
+++ b/workers/unity/Packages/com.improbable.gdk.core/Tests/Editmode/Logging/LoggingTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 05d4de0a356ae8447847f4fb094c51aa
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
While writing exceptions for UTY-709 I discovered that they were not showing in the Unity console.

This PR
- allows exception messages to be passed into Unity's logger properly
- and adds logging tests
- also removes redundant newlines from logs

#### Tests
New tests added to test all log types
#### Documentation
Added docs for new methods
#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
@martinzlocha @JonasImprobable 