### PR TITLE
C# 7 refactor + Logging

### DIFF
--- a/code_generator/GdkCodeGenerator/Templates/UnityComponentConversionGenerator.tt
+++ b/code_generator/GdkCodeGenerator/Templates/UnityComponentConversionGenerator.tt
@@ -17,6 +17,7 @@ using Unity.Entities;
 using Improbable.Worker;
 using Improbable.Gdk.Core;
 using Improbable.Gdk.Core.Components;
+using ILogger = Improbable.Gdk.Core.ILogger;
 using <#= spatialNamespace #>;
 
 namespace <#= qualifiedNamespace #>
@@ -89,7 +90,7 @@ namespace <#= qualifiedNamespace #>
                     (component) => component.Buffer.Clear());
 <# } #>
 
-            public Translation(MutableView view) : base(view)
+            public Translation(MutableView view, ILogger logger) : base(view, logger)
             {
             }
 
@@ -115,13 +116,11 @@ namespace <#= qualifiedNamespace #>
 
             public void OnAddComponent(AddComponentOp<<#= componentDetails.FullyQualifiedSpatialTypeName #>> op)
             {
-                Unity.Entities.Entity entity;
-                if (!view.TryGetEntity(op.EntityId.Id, out entity))
+                if (!view.TryGetEntity(op.EntityId.Id, out var entity))
                 {
-                    LogDispatcher.HandleLog(LogType.Error, new LogEvent("Entity not found during OnAddComponent.")
-                        .WithField(LoggingUtils.LoggerName, LoggerName)
+                    Logger.Log(LogType.Error, new LogEvent("Entity not found during OnAddComponent.")
                         .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                        .WithField(MutableView.Component, "<#= componentDetails.TypeName #>"));
+                        .WithField(LoggingUtils.Component, "<#= componentDetails.TypeName #>"));
                     return;
                 }
 <# if(fieldDetailsList.Count > 0) { #>
@@ -151,23 +150,20 @@ namespace <#= qualifiedNamespace #>
                 }
                 else
                 {
-                    LogDispatcher.HandleLog(LogType.Error, new LogEvent(
+                    Logger.Log(LogType.Error, new LogEvent(
                             "Received ComponentAdded but have already received one for this entity.")
-                        .WithField(LoggingUtils.LoggerName, LoggerName)
                         .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                        .WithField(MutableView.Component, "<#= componentDetails.TypeName #>"));
+                        .WithField(LoggingUtils.Component, "<#= componentDetails.TypeName #>"));
                 }
             }
 
             public void OnComponentUpdate(ComponentUpdateOp<<#= componentDetails.FullyQualifiedSpatialTypeName #>> op)
             {
-                Unity.Entities.Entity entity;
-                if (!view.TryGetEntity(op.EntityId.Id, out entity))
+                if (!view.TryGetEntity(op.EntityId.Id, out var entity))
                 {
-                    LogDispatcher.HandleLog(LogType.Error, new LogEvent("Entity not found during OnComponentUpdate.")
-                        .WithField(LoggingUtils.LoggerName, LoggerName)
+                    Logger.Log(LogType.Error, new LogEvent("Entity not found during OnComponentUpdate.")
                         .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                        .WithField(MutableView.Component, "<#= componentDetails.TypeName #>"));
+                        .WithField(LoggingUtils.Component, "<#= componentDetails.TypeName #>"));
                     return;
                 }
 
@@ -232,13 +228,11 @@ namespace <#= qualifiedNamespace #>
 
             public void OnRemoveComponent(RemoveComponentOp op)
             {
-                Unity.Entities.Entity entity;
-                if (!view.TryGetEntity(op.EntityId.Id, out entity))
+                if (!view.TryGetEntity(op.EntityId.Id, out var entity))
                 {
-                    LogDispatcher.HandleLog(LogType.Error, new LogEvent("Entity not found during OnRemoveComponent.")
-                        .WithField(LoggingUtils.LoggerName, LoggerName)
+                    Logger.Log(LogType.Error, new LogEvent("Entity not found during OnRemoveComponent.")
                         .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                        .WithField(MutableView.Component, "<#= componentDetails.TypeName #>"));
+                        .WithField(LoggingUtils.Component, "<#= componentDetails.TypeName #>"));
                     return;
                 }
 
@@ -254,11 +248,10 @@ namespace <#= qualifiedNamespace #>
                 }
                 else
                 {
-                    LogDispatcher.HandleLog(LogType.Error, new LogEvent(
+                    Logger.Log(LogType.Error, new LogEvent(
                             "Received ComponentRemoved but have already received one for this entity.")
-                        .WithField(LoggingUtils.LoggerName, LoggerName)
                         .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                        .WithField(MutableView.Component, "<#= componentDetails.TypeName #>"));
+                        .WithField(LoggingUtils.Component, "<#= componentDetails.TypeName #>"));
                 }
             }
 
@@ -300,35 +293,37 @@ namespace <#= qualifiedNamespace #>
                     var hasPendingEvents = false;
 <# foreach(var eventDetails in eventDetailsList) { #>
                     var <#= eventDetails.CamelCaseTypeName #>Events = EntityIdTo<#= eventDetails.EventName #>Events[entityId];
-                    hasPendingEvents |= <#= eventDetails.CamelCaseTypeName #>Events.Count() > 0;
+                    hasPendingEvents |= <#= eventDetails.CamelCaseTypeName #>Events.Count > 0;
 <# } #>
 
-                    if (componentData.DirtyBit || hasPendingEvents)
+                    if (!componentData.DirtyBit && !hasPendingEvents)
                     {
-                        var update = new <#= componentDetails.FullyQualifiedSpatialTypeName #>.Update();
-<# foreach (var fieldDetails in fieldDetailsList) { #>
-                        update.Set<#= fieldDetails.PascalCaseName #>(<#= UnityTypeMappings.GetSpatialTypeMethod(fieldDetails.RawFieldDefinition, "componentData." + fieldDetails.PascalCaseName, enumSet) #>);
-<# } #>
-<# foreach(var eventDetails in eventDetailsList) { #>
-                        foreach (var nativeEvent in <#= eventDetails.CamelCaseTypeName #>Events)
-                        {
-                            var spatialEvent = <#= eventDetails.FullyQualifiedPayloadTypeName #>.ToSpatial(nativeEvent);
-                            update.<#= eventDetails.CamelCaseTypeName #>.Add(spatialEvent);
-                        }
-<# } #>
-                        SendComponentUpdate(connection, entityId, update);
-
-                        componentData.DirtyBit = false;
-<# if (componentDetails.IsBlittable) { #>
-                        componentDataArray[i] = componentData;
-<# } else { #>
-                        view.SetComponentObject(entityId, componentData);
-<# } #>
-
-<# foreach(var eventDetails in eventDetailsList) { #>
-                        <#= eventDetails.CamelCaseTypeName #>Events.Clear();
-<# } #>
+                        continue;
                     }
+
+                    var update = new <#= componentDetails.FullyQualifiedSpatialTypeName #>.Update();
+<# foreach (var fieldDetails in fieldDetailsList) { #>
+                    update.Set<#= fieldDetails.PascalCaseName #>(<#= UnityTypeMappings.GetSpatialTypeMethod(fieldDetails.RawFieldDefinition, "componentData." + fieldDetails.PascalCaseName, enumSet) #>);
+<# } #>
+<# foreach(var eventDetails in eventDetailsList) { #>
+                    foreach (var nativeEvent in <#= eventDetails.CamelCaseTypeName #>Events)
+                    {
+                        var spatialEvent = <#= eventDetails.FullyQualifiedPayloadTypeName #>.ToSpatial(nativeEvent);
+                        update.<#= eventDetails.CamelCaseTypeName #>.Add(spatialEvent);
+                    }
+<# } #>
+                    SendComponentUpdate(connection, entityId, update);
+
+                    componentData.DirtyBit = false;
+<# if (componentDetails.IsBlittable) { #>
+                    componentDataArray[i] = componentData;
+<# } else { #>
+                    view.SetComponentObject(entityId, componentData);
+<# } #>
+
+<# foreach(var eventDetails in eventDetailsList) { #>
+                    <#= eventDetails.CamelCaseTypeName #>Events.Clear();
+<# } #>
                 }
             }
 
@@ -358,13 +353,11 @@ namespace <#= qualifiedNamespace #>
 <# foreach (var commandDetails in commandDetailsList) { #>
             public void OnCommandRequest<#= commandDetails.CommandName #>(CommandRequestOp<<#= componentDetails.FullyQualifiedSpatialTypeName #>.Commands.<#= commandDetails.CommandName #>> op)
             {
-                Unity.Entities.Entity entity;
-                if (!view.TryGetEntity(op.EntityId.Id, out entity))
+                if (!view.TryGetEntity(op.EntityId.Id, out var entity))
                 {
-                    LogDispatcher.HandleLog(LogType.Error, new LogEvent("Entity not found during OnCommandRequest.")
-                        .WithField(LoggingUtils.LoggerName, LoggerName)
+                    Logger.Log(LogType.Error, new LogEvent("Entity not found during OnCommandRequest.")
                         .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                        .WithField(MutableView.Component, "<#= componentDetails.TypeName #>"));
+                        .WithField(LoggingUtils.Component, "<#= componentDetails.TypeName #>"));
                     return;
                 }
 
@@ -378,13 +371,11 @@ namespace <#= qualifiedNamespace #>
             public void OnCommandResponse<#= commandDetails.CommandName #>(CommandResponseOp<<#= componentDetails.FullyQualifiedSpatialTypeName #>.Commands.<#= commandDetails.CommandName #>> op)
             {
                 var requestId = op.RequestId.Id;
-                RequestContext requestContext;
-                if (!RequestIdToRequestContext.TryGetValue(requestId, out requestContext))
+                if (!RequestIdToRequestContext.TryGetValue(requestId, out var requestContext))
                 {
-                    LogDispatcher.HandleLog(LogType.Error, new LogEvent("Entity not found during OnCommandResponse.")
-                        .WithField(LoggingUtils.LoggerName, LoggerName)
+                    Logger.Log(LogType.Error, new LogEvent("Entity not found during OnCommandResponse.")
                         .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                        .WithField(MutableView.Component, "<#= componentDetails.TypeName #>"));
+                        .WithField(LoggingUtils.Component, "<#= componentDetails.TypeName #>"));
                     return;
                 }
 

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveBlittableSingularTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveBlittableSingularTranslation.cs
@@ -10,6 +10,7 @@ using Unity.Entities;
 using Improbable.Worker;
 using Improbable.Gdk.Core;
 using Improbable.Gdk.Core.Components;
+using ILogger = Improbable.Gdk.Core.ILogger;
 using Improbable.Gdk.Tests;
 
 namespace Generated.Improbable.Gdk.Tests
@@ -46,7 +47,7 @@ namespace Generated.Improbable.Gdk.Tests
                     () => new ComponentsUpdated<SpatialOSExhaustiveBlittableSingular.Update>(),
                     (component) => component.Buffer.Clear());
 
-            public Translation(MutableView view) : base(view)
+            public Translation(MutableView view, ILogger logger) : base(view, logger)
             {
             }
 
@@ -65,13 +66,11 @@ namespace Generated.Improbable.Gdk.Tests
 
             public void OnAddComponent(AddComponentOp<global::Improbable.Gdk.Tests.ExhaustiveBlittableSingular> op)
             {
-                Unity.Entities.Entity entity;
-                if (!view.TryGetEntity(op.EntityId.Id, out entity))
+                if (!view.TryGetEntity(op.EntityId.Id, out var entity))
                 {
-                    LogDispatcher.HandleLog(LogType.Error, new LogEvent("Entity not found during OnAddComponent.")
-                        .WithField(LoggingUtils.LoggerName, LoggerName)
+                    Logger.Log(LogType.Error, new LogEvent("Entity not found during OnAddComponent.")
                         .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                        .WithField(MutableView.Component, "SpatialOSExhaustiveBlittableSingular"));
+                        .WithField(LoggingUtils.Component, "SpatialOSExhaustiveBlittableSingular"));
                     return;
                 }
                 var data = op.Data.Get().Value;
@@ -107,23 +106,20 @@ namespace Generated.Improbable.Gdk.Tests
                 }
                 else
                 {
-                    LogDispatcher.HandleLog(LogType.Error, new LogEvent(
+                    Logger.Log(LogType.Error, new LogEvent(
                             "Received ComponentAdded but have already received one for this entity.")
-                        .WithField(LoggingUtils.LoggerName, LoggerName)
                         .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                        .WithField(MutableView.Component, "SpatialOSExhaustiveBlittableSingular"));
+                        .WithField(LoggingUtils.Component, "SpatialOSExhaustiveBlittableSingular"));
                 }
             }
 
             public void OnComponentUpdate(ComponentUpdateOp<global::Improbable.Gdk.Tests.ExhaustiveBlittableSingular> op)
             {
-                Unity.Entities.Entity entity;
-                if (!view.TryGetEntity(op.EntityId.Id, out entity))
+                if (!view.TryGetEntity(op.EntityId.Id, out var entity))
                 {
-                    LogDispatcher.HandleLog(LogType.Error, new LogEvent("Entity not found during OnComponentUpdate.")
-                        .WithField(LoggingUtils.LoggerName, LoggerName)
+                    Logger.Log(LogType.Error, new LogEvent("Entity not found during OnComponentUpdate.")
                         .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                        .WithField(MutableView.Component, "SpatialOSExhaustiveBlittableSingular"));
+                        .WithField(LoggingUtils.Component, "SpatialOSExhaustiveBlittableSingular"));
                     return;
                 }
 
@@ -284,13 +280,11 @@ namespace Generated.Improbable.Gdk.Tests
 
             public void OnRemoveComponent(RemoveComponentOp op)
             {
-                Unity.Entities.Entity entity;
-                if (!view.TryGetEntity(op.EntityId.Id, out entity))
+                if (!view.TryGetEntity(op.EntityId.Id, out var entity))
                 {
-                    LogDispatcher.HandleLog(LogType.Error, new LogEvent("Entity not found during OnRemoveComponent.")
-                        .WithField(LoggingUtils.LoggerName, LoggerName)
+                    Logger.Log(LogType.Error, new LogEvent("Entity not found during OnRemoveComponent.")
                         .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                        .WithField(MutableView.Component, "SpatialOSExhaustiveBlittableSingular"));
+                        .WithField(LoggingUtils.Component, "SpatialOSExhaustiveBlittableSingular"));
                     return;
                 }
 
@@ -306,11 +300,10 @@ namespace Generated.Improbable.Gdk.Tests
                 }
                 else
                 {
-                    LogDispatcher.HandleLog(LogType.Error, new LogEvent(
+                    Logger.Log(LogType.Error, new LogEvent(
                             "Received ComponentRemoved but have already received one for this entity.")
-                        .WithField(LoggingUtils.LoggerName, LoggerName)
                         .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                        .WithField(MutableView.Component, "SpatialOSExhaustiveBlittableSingular"));
+                        .WithField(LoggingUtils.Component, "SpatialOSExhaustiveBlittableSingular"));
                 }
             }
 
@@ -331,30 +324,32 @@ namespace Generated.Improbable.Gdk.Tests
                     var entityId = spatialEntityIdData[i].EntityId;
                     var hasPendingEvents = false;
 
-                    if (componentData.DirtyBit || hasPendingEvents)
+                    if (!componentData.DirtyBit && !hasPendingEvents)
                     {
-                        var update = new global::Improbable.Gdk.Tests.ExhaustiveBlittableSingular.Update();
-                        update.SetField1(componentData.Field1);
-                        update.SetField2(componentData.Field2);
-                        update.SetField4(componentData.Field4);
-                        update.SetField5(componentData.Field5);
-                        update.SetField6(componentData.Field6);
-                        update.SetField8(componentData.Field8);
-                        update.SetField9(componentData.Field9);
-                        update.SetField10(componentData.Field10);
-                        update.SetField11(componentData.Field11);
-                        update.SetField12(componentData.Field12);
-                        update.SetField13(componentData.Field13);
-                        update.SetField14(componentData.Field14);
-                        update.SetField15(componentData.Field15);
-                        update.SetField16(new global::Improbable.EntityId(componentData.Field16));
-                        update.SetField17(global::Generated.Improbable.Gdk.Tests.SomeType.ToSpatial(componentData.Field17));
-                        SendComponentUpdate(connection, entityId, update);
-
-                        componentData.DirtyBit = false;
-                        componentDataArray[i] = componentData;
-
+                        continue;
                     }
+
+                    var update = new global::Improbable.Gdk.Tests.ExhaustiveBlittableSingular.Update();
+                    update.SetField1(componentData.Field1);
+                    update.SetField2(componentData.Field2);
+                    update.SetField4(componentData.Field4);
+                    update.SetField5(componentData.Field5);
+                    update.SetField6(componentData.Field6);
+                    update.SetField8(componentData.Field8);
+                    update.SetField9(componentData.Field9);
+                    update.SetField10(componentData.Field10);
+                    update.SetField11(componentData.Field11);
+                    update.SetField12(componentData.Field12);
+                    update.SetField13(componentData.Field13);
+                    update.SetField14(componentData.Field14);
+                    update.SetField15(componentData.Field15);
+                    update.SetField16(new global::Improbable.EntityId(componentData.Field16));
+                    update.SetField17(global::Generated.Improbable.Gdk.Tests.SomeType.ToSpatial(componentData.Field17));
+                    SendComponentUpdate(connection, entityId, update);
+
+                    componentData.DirtyBit = false;
+                    componentDataArray[i] = componentData;
+
                 }
             }
 

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKeyTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKeyTranslation.cs
@@ -10,6 +10,7 @@ using Unity.Entities;
 using Improbable.Worker;
 using Improbable.Gdk.Core;
 using Improbable.Gdk.Core.Components;
+using ILogger = Improbable.Gdk.Core.ILogger;
 using Improbable.Gdk.Tests;
 
 namespace Generated.Improbable.Gdk.Tests
@@ -46,7 +47,7 @@ namespace Generated.Improbable.Gdk.Tests
                     () => new ComponentsUpdated<SpatialOSExhaustiveMapKey.Update>(),
                     (component) => component.Buffer.Clear());
 
-            public Translation(MutableView view) : base(view)
+            public Translation(MutableView view, ILogger logger) : base(view, logger)
             {
             }
 
@@ -65,13 +66,11 @@ namespace Generated.Improbable.Gdk.Tests
 
             public void OnAddComponent(AddComponentOp<global::Improbable.Gdk.Tests.ExhaustiveMapKey> op)
             {
-                Unity.Entities.Entity entity;
-                if (!view.TryGetEntity(op.EntityId.Id, out entity))
+                if (!view.TryGetEntity(op.EntityId.Id, out var entity))
                 {
-                    LogDispatcher.HandleLog(LogType.Error, new LogEvent("Entity not found during OnAddComponent.")
-                        .WithField(LoggingUtils.LoggerName, LoggerName)
+                    Logger.Log(LogType.Error, new LogEvent("Entity not found during OnAddComponent.")
                         .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                        .WithField(MutableView.Component, "SpatialOSExhaustiveMapKey"));
+                        .WithField(LoggingUtils.Component, "SpatialOSExhaustiveMapKey"));
                     return;
                 }
                 var data = op.Data.Get().Value;
@@ -107,23 +106,20 @@ namespace Generated.Improbable.Gdk.Tests
                 }
                 else
                 {
-                    LogDispatcher.HandleLog(LogType.Error, new LogEvent(
+                    Logger.Log(LogType.Error, new LogEvent(
                             "Received ComponentAdded but have already received one for this entity.")
-                        .WithField(LoggingUtils.LoggerName, LoggerName)
                         .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                        .WithField(MutableView.Component, "SpatialOSExhaustiveMapKey"));
+                        .WithField(LoggingUtils.Component, "SpatialOSExhaustiveMapKey"));
                 }
             }
 
             public void OnComponentUpdate(ComponentUpdateOp<global::Improbable.Gdk.Tests.ExhaustiveMapKey> op)
             {
-                Unity.Entities.Entity entity;
-                if (!view.TryGetEntity(op.EntityId.Id, out entity))
+                if (!view.TryGetEntity(op.EntityId.Id, out var entity))
                 {
-                    LogDispatcher.HandleLog(LogType.Error, new LogEvent("Entity not found during OnComponentUpdate.")
-                        .WithField(LoggingUtils.LoggerName, LoggerName)
+                    Logger.Log(LogType.Error, new LogEvent("Entity not found during OnComponentUpdate.")
                         .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                        .WithField(MutableView.Component, "SpatialOSExhaustiveMapKey"));
+                        .WithField(LoggingUtils.Component, "SpatialOSExhaustiveMapKey"));
                     return;
                 }
 
@@ -284,13 +280,11 @@ namespace Generated.Improbable.Gdk.Tests
 
             public void OnRemoveComponent(RemoveComponentOp op)
             {
-                Unity.Entities.Entity entity;
-                if (!view.TryGetEntity(op.EntityId.Id, out entity))
+                if (!view.TryGetEntity(op.EntityId.Id, out var entity))
                 {
-                    LogDispatcher.HandleLog(LogType.Error, new LogEvent("Entity not found during OnRemoveComponent.")
-                        .WithField(LoggingUtils.LoggerName, LoggerName)
+                    Logger.Log(LogType.Error, new LogEvent("Entity not found during OnRemoveComponent.")
                         .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                        .WithField(MutableView.Component, "SpatialOSExhaustiveMapKey"));
+                        .WithField(LoggingUtils.Component, "SpatialOSExhaustiveMapKey"));
                     return;
                 }
 
@@ -306,11 +300,10 @@ namespace Generated.Improbable.Gdk.Tests
                 }
                 else
                 {
-                    LogDispatcher.HandleLog(LogType.Error, new LogEvent(
+                    Logger.Log(LogType.Error, new LogEvent(
                             "Received ComponentRemoved but have already received one for this entity.")
-                        .WithField(LoggingUtils.LoggerName, LoggerName)
                         .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                        .WithField(MutableView.Component, "SpatialOSExhaustiveMapKey"));
+                        .WithField(LoggingUtils.Component, "SpatialOSExhaustiveMapKey"));
                 }
             }
 
@@ -331,30 +324,32 @@ namespace Generated.Improbable.Gdk.Tests
                     var entityId = spatialEntityIdData[i].EntityId;
                     var hasPendingEvents = false;
 
-                    if (componentData.DirtyBit || hasPendingEvents)
+                    if (!componentData.DirtyBit && !hasPendingEvents)
                     {
-                        var update = new global::Improbable.Gdk.Tests.ExhaustiveMapKey.Update();
-                        update.SetField2(new global::Improbable.Collections.Map<float,string>(componentData.Field2.ToDictionary(entry => entry.Key, entry => entry.Value)));
-                        update.SetField4(new global::Improbable.Collections.Map<int,string>(componentData.Field4.ToDictionary(entry => entry.Key, entry => entry.Value)));
-                        update.SetField5(new global::Improbable.Collections.Map<long,string>(componentData.Field5.ToDictionary(entry => entry.Key, entry => entry.Value)));
-                        update.SetField6(new global::Improbable.Collections.Map<double,string>(componentData.Field6.ToDictionary(entry => entry.Key, entry => entry.Value)));
-                        update.SetField7(new global::Improbable.Collections.Map<string,string>(componentData.Field7.ToDictionary(entry => entry.Key, entry => entry.Value)));
-                        update.SetField8(new global::Improbable.Collections.Map<uint,string>(componentData.Field8.ToDictionary(entry => entry.Key, entry => entry.Value)));
-                        update.SetField9(new global::Improbable.Collections.Map<ulong,string>(componentData.Field9.ToDictionary(entry => entry.Key, entry => entry.Value)));
-                        update.SetField10(new global::Improbable.Collections.Map<int,string>(componentData.Field10.ToDictionary(entry => entry.Key, entry => entry.Value)));
-                        update.SetField11(new global::Improbable.Collections.Map<long,string>(componentData.Field11.ToDictionary(entry => entry.Key, entry => entry.Value)));
-                        update.SetField12(new global::Improbable.Collections.Map<uint,string>(componentData.Field12.ToDictionary(entry => entry.Key, entry => entry.Value)));
-                        update.SetField13(new global::Improbable.Collections.Map<ulong,string>(componentData.Field13.ToDictionary(entry => entry.Key, entry => entry.Value)));
-                        update.SetField14(new global::Improbable.Collections.Map<int,string>(componentData.Field14.ToDictionary(entry => entry.Key, entry => entry.Value)));
-                        update.SetField15(new global::Improbable.Collections.Map<long,string>(componentData.Field15.ToDictionary(entry => entry.Key, entry => entry.Value)));
-                        update.SetField16(new global::Improbable.Collections.Map<global::Improbable.EntityId,string>(componentData.Field16.ToDictionary(entry => new global::Improbable.EntityId(entry.Key), entry => entry.Value)));
-                        update.SetField17(new global::Improbable.Collections.Map<global::Improbable.Gdk.Tests.SomeType,string>(componentData.Field17.ToDictionary(entry => global::Generated.Improbable.Gdk.Tests.SomeType.ToSpatial(entry.Key), entry => entry.Value)));
-                        SendComponentUpdate(connection, entityId, update);
-
-                        componentData.DirtyBit = false;
-                        view.SetComponentObject(entityId, componentData);
-
+                        continue;
                     }
+
+                    var update = new global::Improbable.Gdk.Tests.ExhaustiveMapKey.Update();
+                    update.SetField2(new global::Improbable.Collections.Map<float,string>(componentData.Field2.ToDictionary(entry => entry.Key, entry => entry.Value)));
+                    update.SetField4(new global::Improbable.Collections.Map<int,string>(componentData.Field4.ToDictionary(entry => entry.Key, entry => entry.Value)));
+                    update.SetField5(new global::Improbable.Collections.Map<long,string>(componentData.Field5.ToDictionary(entry => entry.Key, entry => entry.Value)));
+                    update.SetField6(new global::Improbable.Collections.Map<double,string>(componentData.Field6.ToDictionary(entry => entry.Key, entry => entry.Value)));
+                    update.SetField7(new global::Improbable.Collections.Map<string,string>(componentData.Field7.ToDictionary(entry => entry.Key, entry => entry.Value)));
+                    update.SetField8(new global::Improbable.Collections.Map<uint,string>(componentData.Field8.ToDictionary(entry => entry.Key, entry => entry.Value)));
+                    update.SetField9(new global::Improbable.Collections.Map<ulong,string>(componentData.Field9.ToDictionary(entry => entry.Key, entry => entry.Value)));
+                    update.SetField10(new global::Improbable.Collections.Map<int,string>(componentData.Field10.ToDictionary(entry => entry.Key, entry => entry.Value)));
+                    update.SetField11(new global::Improbable.Collections.Map<long,string>(componentData.Field11.ToDictionary(entry => entry.Key, entry => entry.Value)));
+                    update.SetField12(new global::Improbable.Collections.Map<uint,string>(componentData.Field12.ToDictionary(entry => entry.Key, entry => entry.Value)));
+                    update.SetField13(new global::Improbable.Collections.Map<ulong,string>(componentData.Field13.ToDictionary(entry => entry.Key, entry => entry.Value)));
+                    update.SetField14(new global::Improbable.Collections.Map<int,string>(componentData.Field14.ToDictionary(entry => entry.Key, entry => entry.Value)));
+                    update.SetField15(new global::Improbable.Collections.Map<long,string>(componentData.Field15.ToDictionary(entry => entry.Key, entry => entry.Value)));
+                    update.SetField16(new global::Improbable.Collections.Map<global::Improbable.EntityId,string>(componentData.Field16.ToDictionary(entry => new global::Improbable.EntityId(entry.Key), entry => entry.Value)));
+                    update.SetField17(new global::Improbable.Collections.Map<global::Improbable.Gdk.Tests.SomeType,string>(componentData.Field17.ToDictionary(entry => global::Generated.Improbable.Gdk.Tests.SomeType.ToSpatial(entry.Key), entry => entry.Value)));
+                    SendComponentUpdate(connection, entityId, update);
+
+                    componentData.DirtyBit = false;
+                    view.SetComponentObject(entityId, componentData);
+
                 }
             }
 

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValueTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValueTranslation.cs
@@ -10,6 +10,7 @@ using Unity.Entities;
 using Improbable.Worker;
 using Improbable.Gdk.Core;
 using Improbable.Gdk.Core.Components;
+using ILogger = Improbable.Gdk.Core.ILogger;
 using Improbable.Gdk.Tests;
 
 namespace Generated.Improbable.Gdk.Tests
@@ -46,7 +47,7 @@ namespace Generated.Improbable.Gdk.Tests
                     () => new ComponentsUpdated<SpatialOSExhaustiveMapValue.Update>(),
                     (component) => component.Buffer.Clear());
 
-            public Translation(MutableView view) : base(view)
+            public Translation(MutableView view, ILogger logger) : base(view, logger)
             {
             }
 
@@ -65,13 +66,11 @@ namespace Generated.Improbable.Gdk.Tests
 
             public void OnAddComponent(AddComponentOp<global::Improbable.Gdk.Tests.ExhaustiveMapValue> op)
             {
-                Unity.Entities.Entity entity;
-                if (!view.TryGetEntity(op.EntityId.Id, out entity))
+                if (!view.TryGetEntity(op.EntityId.Id, out var entity))
                 {
-                    LogDispatcher.HandleLog(LogType.Error, new LogEvent("Entity not found during OnAddComponent.")
-                        .WithField(LoggingUtils.LoggerName, LoggerName)
+                    Logger.Log(LogType.Error, new LogEvent("Entity not found during OnAddComponent.")
                         .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                        .WithField(MutableView.Component, "SpatialOSExhaustiveMapValue"));
+                        .WithField(LoggingUtils.Component, "SpatialOSExhaustiveMapValue"));
                     return;
                 }
                 var data = op.Data.Get().Value;
@@ -107,23 +106,20 @@ namespace Generated.Improbable.Gdk.Tests
                 }
                 else
                 {
-                    LogDispatcher.HandleLog(LogType.Error, new LogEvent(
+                    Logger.Log(LogType.Error, new LogEvent(
                             "Received ComponentAdded but have already received one for this entity.")
-                        .WithField(LoggingUtils.LoggerName, LoggerName)
                         .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                        .WithField(MutableView.Component, "SpatialOSExhaustiveMapValue"));
+                        .WithField(LoggingUtils.Component, "SpatialOSExhaustiveMapValue"));
                 }
             }
 
             public void OnComponentUpdate(ComponentUpdateOp<global::Improbable.Gdk.Tests.ExhaustiveMapValue> op)
             {
-                Unity.Entities.Entity entity;
-                if (!view.TryGetEntity(op.EntityId.Id, out entity))
+                if (!view.TryGetEntity(op.EntityId.Id, out var entity))
                 {
-                    LogDispatcher.HandleLog(LogType.Error, new LogEvent("Entity not found during OnComponentUpdate.")
-                        .WithField(LoggingUtils.LoggerName, LoggerName)
+                    Logger.Log(LogType.Error, new LogEvent("Entity not found during OnComponentUpdate.")
                         .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                        .WithField(MutableView.Component, "SpatialOSExhaustiveMapValue"));
+                        .WithField(LoggingUtils.Component, "SpatialOSExhaustiveMapValue"));
                     return;
                 }
 
@@ -284,13 +280,11 @@ namespace Generated.Improbable.Gdk.Tests
 
             public void OnRemoveComponent(RemoveComponentOp op)
             {
-                Unity.Entities.Entity entity;
-                if (!view.TryGetEntity(op.EntityId.Id, out entity))
+                if (!view.TryGetEntity(op.EntityId.Id, out var entity))
                 {
-                    LogDispatcher.HandleLog(LogType.Error, new LogEvent("Entity not found during OnRemoveComponent.")
-                        .WithField(LoggingUtils.LoggerName, LoggerName)
+                    Logger.Log(LogType.Error, new LogEvent("Entity not found during OnRemoveComponent.")
                         .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                        .WithField(MutableView.Component, "SpatialOSExhaustiveMapValue"));
+                        .WithField(LoggingUtils.Component, "SpatialOSExhaustiveMapValue"));
                     return;
                 }
 
@@ -306,11 +300,10 @@ namespace Generated.Improbable.Gdk.Tests
                 }
                 else
                 {
-                    LogDispatcher.HandleLog(LogType.Error, new LogEvent(
+                    Logger.Log(LogType.Error, new LogEvent(
                             "Received ComponentRemoved but have already received one for this entity.")
-                        .WithField(LoggingUtils.LoggerName, LoggerName)
                         .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                        .WithField(MutableView.Component, "SpatialOSExhaustiveMapValue"));
+                        .WithField(LoggingUtils.Component, "SpatialOSExhaustiveMapValue"));
                 }
             }
 
@@ -331,30 +324,32 @@ namespace Generated.Improbable.Gdk.Tests
                     var entityId = spatialEntityIdData[i].EntityId;
                     var hasPendingEvents = false;
 
-                    if (componentData.DirtyBit || hasPendingEvents)
+                    if (!componentData.DirtyBit && !hasPendingEvents)
                     {
-                        var update = new global::Improbable.Gdk.Tests.ExhaustiveMapValue.Update();
-                        update.SetField2(new global::Improbable.Collections.Map<string,float>(componentData.Field2.ToDictionary(entry => entry.Key, entry => entry.Value)));
-                        update.SetField4(new global::Improbable.Collections.Map<string,int>(componentData.Field4.ToDictionary(entry => entry.Key, entry => entry.Value)));
-                        update.SetField5(new global::Improbable.Collections.Map<string,long>(componentData.Field5.ToDictionary(entry => entry.Key, entry => entry.Value)));
-                        update.SetField6(new global::Improbable.Collections.Map<string,double>(componentData.Field6.ToDictionary(entry => entry.Key, entry => entry.Value)));
-                        update.SetField7(new global::Improbable.Collections.Map<string,string>(componentData.Field7.ToDictionary(entry => entry.Key, entry => entry.Value)));
-                        update.SetField8(new global::Improbable.Collections.Map<string,uint>(componentData.Field8.ToDictionary(entry => entry.Key, entry => entry.Value)));
-                        update.SetField9(new global::Improbable.Collections.Map<string,ulong>(componentData.Field9.ToDictionary(entry => entry.Key, entry => entry.Value)));
-                        update.SetField10(new global::Improbable.Collections.Map<string,int>(componentData.Field10.ToDictionary(entry => entry.Key, entry => entry.Value)));
-                        update.SetField11(new global::Improbable.Collections.Map<string,long>(componentData.Field11.ToDictionary(entry => entry.Key, entry => entry.Value)));
-                        update.SetField12(new global::Improbable.Collections.Map<string,uint>(componentData.Field12.ToDictionary(entry => entry.Key, entry => entry.Value)));
-                        update.SetField13(new global::Improbable.Collections.Map<string,ulong>(componentData.Field13.ToDictionary(entry => entry.Key, entry => entry.Value)));
-                        update.SetField14(new global::Improbable.Collections.Map<string,int>(componentData.Field14.ToDictionary(entry => entry.Key, entry => entry.Value)));
-                        update.SetField15(new global::Improbable.Collections.Map<string,long>(componentData.Field15.ToDictionary(entry => entry.Key, entry => entry.Value)));
-                        update.SetField16(new global::Improbable.Collections.Map<string,global::Improbable.EntityId>(componentData.Field16.ToDictionary(entry => entry.Key, entry => new global::Improbable.EntityId(entry.Value))));
-                        update.SetField17(new global::Improbable.Collections.Map<string,global::Improbable.Gdk.Tests.SomeType>(componentData.Field17.ToDictionary(entry => entry.Key, entry => global::Generated.Improbable.Gdk.Tests.SomeType.ToSpatial(entry.Value))));
-                        SendComponentUpdate(connection, entityId, update);
-
-                        componentData.DirtyBit = false;
-                        view.SetComponentObject(entityId, componentData);
-
+                        continue;
                     }
+
+                    var update = new global::Improbable.Gdk.Tests.ExhaustiveMapValue.Update();
+                    update.SetField2(new global::Improbable.Collections.Map<string,float>(componentData.Field2.ToDictionary(entry => entry.Key, entry => entry.Value)));
+                    update.SetField4(new global::Improbable.Collections.Map<string,int>(componentData.Field4.ToDictionary(entry => entry.Key, entry => entry.Value)));
+                    update.SetField5(new global::Improbable.Collections.Map<string,long>(componentData.Field5.ToDictionary(entry => entry.Key, entry => entry.Value)));
+                    update.SetField6(new global::Improbable.Collections.Map<string,double>(componentData.Field6.ToDictionary(entry => entry.Key, entry => entry.Value)));
+                    update.SetField7(new global::Improbable.Collections.Map<string,string>(componentData.Field7.ToDictionary(entry => entry.Key, entry => entry.Value)));
+                    update.SetField8(new global::Improbable.Collections.Map<string,uint>(componentData.Field8.ToDictionary(entry => entry.Key, entry => entry.Value)));
+                    update.SetField9(new global::Improbable.Collections.Map<string,ulong>(componentData.Field9.ToDictionary(entry => entry.Key, entry => entry.Value)));
+                    update.SetField10(new global::Improbable.Collections.Map<string,int>(componentData.Field10.ToDictionary(entry => entry.Key, entry => entry.Value)));
+                    update.SetField11(new global::Improbable.Collections.Map<string,long>(componentData.Field11.ToDictionary(entry => entry.Key, entry => entry.Value)));
+                    update.SetField12(new global::Improbable.Collections.Map<string,uint>(componentData.Field12.ToDictionary(entry => entry.Key, entry => entry.Value)));
+                    update.SetField13(new global::Improbable.Collections.Map<string,ulong>(componentData.Field13.ToDictionary(entry => entry.Key, entry => entry.Value)));
+                    update.SetField14(new global::Improbable.Collections.Map<string,int>(componentData.Field14.ToDictionary(entry => entry.Key, entry => entry.Value)));
+                    update.SetField15(new global::Improbable.Collections.Map<string,long>(componentData.Field15.ToDictionary(entry => entry.Key, entry => entry.Value)));
+                    update.SetField16(new global::Improbable.Collections.Map<string,global::Improbable.EntityId>(componentData.Field16.ToDictionary(entry => entry.Key, entry => new global::Improbable.EntityId(entry.Value))));
+                    update.SetField17(new global::Improbable.Collections.Map<string,global::Improbable.Gdk.Tests.SomeType>(componentData.Field17.ToDictionary(entry => entry.Key, entry => global::Generated.Improbable.Gdk.Tests.SomeType.ToSpatial(entry.Value))));
+                    SendComponentUpdate(connection, entityId, update);
+
+                    componentData.DirtyBit = false;
+                    view.SetComponentObject(entityId, componentData);
+
                 }
             }
 

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptionalTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptionalTranslation.cs
@@ -10,6 +10,7 @@ using Unity.Entities;
 using Improbable.Worker;
 using Improbable.Gdk.Core;
 using Improbable.Gdk.Core.Components;
+using ILogger = Improbable.Gdk.Core.ILogger;
 using Improbable.Gdk.Tests;
 
 namespace Generated.Improbable.Gdk.Tests
@@ -46,7 +47,7 @@ namespace Generated.Improbable.Gdk.Tests
                     () => new ComponentsUpdated<SpatialOSExhaustiveOptional.Update>(),
                     (component) => component.Buffer.Clear());
 
-            public Translation(MutableView view) : base(view)
+            public Translation(MutableView view, ILogger logger) : base(view, logger)
             {
             }
 
@@ -65,13 +66,11 @@ namespace Generated.Improbable.Gdk.Tests
 
             public void OnAddComponent(AddComponentOp<global::Improbable.Gdk.Tests.ExhaustiveOptional> op)
             {
-                Unity.Entities.Entity entity;
-                if (!view.TryGetEntity(op.EntityId.Id, out entity))
+                if (!view.TryGetEntity(op.EntityId.Id, out var entity))
                 {
-                    LogDispatcher.HandleLog(LogType.Error, new LogEvent("Entity not found during OnAddComponent.")
-                        .WithField(LoggingUtils.LoggerName, LoggerName)
+                    Logger.Log(LogType.Error, new LogEvent("Entity not found during OnAddComponent.")
                         .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                        .WithField(MutableView.Component, "SpatialOSExhaustiveOptional"));
+                        .WithField(LoggingUtils.Component, "SpatialOSExhaustiveOptional"));
                     return;
                 }
                 var data = op.Data.Get().Value;
@@ -106,23 +105,20 @@ namespace Generated.Improbable.Gdk.Tests
                 }
                 else
                 {
-                    LogDispatcher.HandleLog(LogType.Error, new LogEvent(
+                    Logger.Log(LogType.Error, new LogEvent(
                             "Received ComponentAdded but have already received one for this entity.")
-                        .WithField(LoggingUtils.LoggerName, LoggerName)
                         .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                        .WithField(MutableView.Component, "SpatialOSExhaustiveOptional"));
+                        .WithField(LoggingUtils.Component, "SpatialOSExhaustiveOptional"));
                 }
             }
 
             public void OnComponentUpdate(ComponentUpdateOp<global::Improbable.Gdk.Tests.ExhaustiveOptional> op)
             {
-                Unity.Entities.Entity entity;
-                if (!view.TryGetEntity(op.EntityId.Id, out entity))
+                if (!view.TryGetEntity(op.EntityId.Id, out var entity))
                 {
-                    LogDispatcher.HandleLog(LogType.Error, new LogEvent("Entity not found during OnComponentUpdate.")
-                        .WithField(LoggingUtils.LoggerName, LoggerName)
+                    Logger.Log(LogType.Error, new LogEvent("Entity not found during OnComponentUpdate.")
                         .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                        .WithField(MutableView.Component, "SpatialOSExhaustiveOptional"));
+                        .WithField(LoggingUtils.Component, "SpatialOSExhaustiveOptional"));
                     return;
                 }
 
@@ -274,13 +270,11 @@ namespace Generated.Improbable.Gdk.Tests
 
             public void OnRemoveComponent(RemoveComponentOp op)
             {
-                Unity.Entities.Entity entity;
-                if (!view.TryGetEntity(op.EntityId.Id, out entity))
+                if (!view.TryGetEntity(op.EntityId.Id, out var entity))
                 {
-                    LogDispatcher.HandleLog(LogType.Error, new LogEvent("Entity not found during OnRemoveComponent.")
-                        .WithField(LoggingUtils.LoggerName, LoggerName)
+                    Logger.Log(LogType.Error, new LogEvent("Entity not found during OnRemoveComponent.")
                         .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                        .WithField(MutableView.Component, "SpatialOSExhaustiveOptional"));
+                        .WithField(LoggingUtils.Component, "SpatialOSExhaustiveOptional"));
                     return;
                 }
 
@@ -296,11 +290,10 @@ namespace Generated.Improbable.Gdk.Tests
                 }
                 else
                 {
-                    LogDispatcher.HandleLog(LogType.Error, new LogEvent(
+                    Logger.Log(LogType.Error, new LogEvent(
                             "Received ComponentRemoved but have already received one for this entity.")
-                        .WithField(LoggingUtils.LoggerName, LoggerName)
                         .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                        .WithField(MutableView.Component, "SpatialOSExhaustiveOptional"));
+                        .WithField(LoggingUtils.Component, "SpatialOSExhaustiveOptional"));
                 }
             }
 
@@ -321,29 +314,31 @@ namespace Generated.Improbable.Gdk.Tests
                     var entityId = spatialEntityIdData[i].EntityId;
                     var hasPendingEvents = false;
 
-                    if (componentData.DirtyBit || hasPendingEvents)
+                    if (!componentData.DirtyBit && !hasPendingEvents)
                     {
-                        var update = new global::Improbable.Gdk.Tests.ExhaustiveOptional.Update();
-                        update.SetField2(componentData.Field2.HasValue ? new global::Improbable.Collections.Option<float>(componentData.Field2.Value) : new global::Improbable.Collections.Option<float>());
-                        update.SetField4(componentData.Field4.HasValue ? new global::Improbable.Collections.Option<int>(componentData.Field4.Value) : new global::Improbable.Collections.Option<int>());
-                        update.SetField5(componentData.Field5.HasValue ? new global::Improbable.Collections.Option<long>(componentData.Field5.Value) : new global::Improbable.Collections.Option<long>());
-                        update.SetField6(componentData.Field6.HasValue ? new global::Improbable.Collections.Option<double>(componentData.Field6.Value) : new global::Improbable.Collections.Option<double>());
-                        update.SetField8(componentData.Field8.HasValue ? new global::Improbable.Collections.Option<uint>(componentData.Field8.Value) : new global::Improbable.Collections.Option<uint>());
-                        update.SetField9(componentData.Field9.HasValue ? new global::Improbable.Collections.Option<ulong>(componentData.Field9.Value) : new global::Improbable.Collections.Option<ulong>());
-                        update.SetField10(componentData.Field10.HasValue ? new global::Improbable.Collections.Option<int>(componentData.Field10.Value) : new global::Improbable.Collections.Option<int>());
-                        update.SetField11(componentData.Field11.HasValue ? new global::Improbable.Collections.Option<long>(componentData.Field11.Value) : new global::Improbable.Collections.Option<long>());
-                        update.SetField12(componentData.Field12.HasValue ? new global::Improbable.Collections.Option<uint>(componentData.Field12.Value) : new global::Improbable.Collections.Option<uint>());
-                        update.SetField13(componentData.Field13.HasValue ? new global::Improbable.Collections.Option<ulong>(componentData.Field13.Value) : new global::Improbable.Collections.Option<ulong>());
-                        update.SetField14(componentData.Field14.HasValue ? new global::Improbable.Collections.Option<int>(componentData.Field14.Value) : new global::Improbable.Collections.Option<int>());
-                        update.SetField15(componentData.Field15.HasValue ? new global::Improbable.Collections.Option<long>(componentData.Field15.Value) : new global::Improbable.Collections.Option<long>());
-                        update.SetField16(componentData.Field16.HasValue ? new global::Improbable.Collections.Option<global::Improbable.EntityId>(new global::Improbable.EntityId(componentData.Field16.Value)) : new global::Improbable.Collections.Option<global::Improbable.EntityId>());
-                        update.SetField17(componentData.Field17.HasValue ? new global::Improbable.Collections.Option<global::Improbable.Gdk.Tests.SomeType>(global::Generated.Improbable.Gdk.Tests.SomeType.ToSpatial(componentData.Field17.Value)) : new global::Improbable.Collections.Option<global::Improbable.Gdk.Tests.SomeType>());
-                        SendComponentUpdate(connection, entityId, update);
-
-                        componentData.DirtyBit = false;
-                        view.SetComponentObject(entityId, componentData);
-
+                        continue;
                     }
+
+                    var update = new global::Improbable.Gdk.Tests.ExhaustiveOptional.Update();
+                    update.SetField2(componentData.Field2.HasValue ? new global::Improbable.Collections.Option<float>(componentData.Field2.Value) : new global::Improbable.Collections.Option<float>());
+                    update.SetField4(componentData.Field4.HasValue ? new global::Improbable.Collections.Option<int>(componentData.Field4.Value) : new global::Improbable.Collections.Option<int>());
+                    update.SetField5(componentData.Field5.HasValue ? new global::Improbable.Collections.Option<long>(componentData.Field5.Value) : new global::Improbable.Collections.Option<long>());
+                    update.SetField6(componentData.Field6.HasValue ? new global::Improbable.Collections.Option<double>(componentData.Field6.Value) : new global::Improbable.Collections.Option<double>());
+                    update.SetField8(componentData.Field8.HasValue ? new global::Improbable.Collections.Option<uint>(componentData.Field8.Value) : new global::Improbable.Collections.Option<uint>());
+                    update.SetField9(componentData.Field9.HasValue ? new global::Improbable.Collections.Option<ulong>(componentData.Field9.Value) : new global::Improbable.Collections.Option<ulong>());
+                    update.SetField10(componentData.Field10.HasValue ? new global::Improbable.Collections.Option<int>(componentData.Field10.Value) : new global::Improbable.Collections.Option<int>());
+                    update.SetField11(componentData.Field11.HasValue ? new global::Improbable.Collections.Option<long>(componentData.Field11.Value) : new global::Improbable.Collections.Option<long>());
+                    update.SetField12(componentData.Field12.HasValue ? new global::Improbable.Collections.Option<uint>(componentData.Field12.Value) : new global::Improbable.Collections.Option<uint>());
+                    update.SetField13(componentData.Field13.HasValue ? new global::Improbable.Collections.Option<ulong>(componentData.Field13.Value) : new global::Improbable.Collections.Option<ulong>());
+                    update.SetField14(componentData.Field14.HasValue ? new global::Improbable.Collections.Option<int>(componentData.Field14.Value) : new global::Improbable.Collections.Option<int>());
+                    update.SetField15(componentData.Field15.HasValue ? new global::Improbable.Collections.Option<long>(componentData.Field15.Value) : new global::Improbable.Collections.Option<long>());
+                    update.SetField16(componentData.Field16.HasValue ? new global::Improbable.Collections.Option<global::Improbable.EntityId>(new global::Improbable.EntityId(componentData.Field16.Value)) : new global::Improbable.Collections.Option<global::Improbable.EntityId>());
+                    update.SetField17(componentData.Field17.HasValue ? new global::Improbable.Collections.Option<global::Improbable.Gdk.Tests.SomeType>(global::Generated.Improbable.Gdk.Tests.SomeType.ToSpatial(componentData.Field17.Value)) : new global::Improbable.Collections.Option<global::Improbable.Gdk.Tests.SomeType>());
+                    SendComponentUpdate(connection, entityId, update);
+
+                    componentData.DirtyBit = false;
+                    view.SetComponentObject(entityId, componentData);
+
                 }
             }
 

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeatedTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeatedTranslation.cs
@@ -10,6 +10,7 @@ using Unity.Entities;
 using Improbable.Worker;
 using Improbable.Gdk.Core;
 using Improbable.Gdk.Core.Components;
+using ILogger = Improbable.Gdk.Core.ILogger;
 using Improbable.Gdk.Tests;
 
 namespace Generated.Improbable.Gdk.Tests
@@ -46,7 +47,7 @@ namespace Generated.Improbable.Gdk.Tests
                     () => new ComponentsUpdated<SpatialOSExhaustiveRepeated.Update>(),
                     (component) => component.Buffer.Clear());
 
-            public Translation(MutableView view) : base(view)
+            public Translation(MutableView view, ILogger logger) : base(view, logger)
             {
             }
 
@@ -65,13 +66,11 @@ namespace Generated.Improbable.Gdk.Tests
 
             public void OnAddComponent(AddComponentOp<global::Improbable.Gdk.Tests.ExhaustiveRepeated> op)
             {
-                Unity.Entities.Entity entity;
-                if (!view.TryGetEntity(op.EntityId.Id, out entity))
+                if (!view.TryGetEntity(op.EntityId.Id, out var entity))
                 {
-                    LogDispatcher.HandleLog(LogType.Error, new LogEvent("Entity not found during OnAddComponent.")
-                        .WithField(LoggingUtils.LoggerName, LoggerName)
+                    Logger.Log(LogType.Error, new LogEvent("Entity not found during OnAddComponent.")
                         .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                        .WithField(MutableView.Component, "SpatialOSExhaustiveRepeated"));
+                        .WithField(LoggingUtils.Component, "SpatialOSExhaustiveRepeated"));
                     return;
                 }
                 var data = op.Data.Get().Value;
@@ -107,23 +106,20 @@ namespace Generated.Improbable.Gdk.Tests
                 }
                 else
                 {
-                    LogDispatcher.HandleLog(LogType.Error, new LogEvent(
+                    Logger.Log(LogType.Error, new LogEvent(
                             "Received ComponentAdded but have already received one for this entity.")
-                        .WithField(LoggingUtils.LoggerName, LoggerName)
                         .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                        .WithField(MutableView.Component, "SpatialOSExhaustiveRepeated"));
+                        .WithField(LoggingUtils.Component, "SpatialOSExhaustiveRepeated"));
                 }
             }
 
             public void OnComponentUpdate(ComponentUpdateOp<global::Improbable.Gdk.Tests.ExhaustiveRepeated> op)
             {
-                Unity.Entities.Entity entity;
-                if (!view.TryGetEntity(op.EntityId.Id, out entity))
+                if (!view.TryGetEntity(op.EntityId.Id, out var entity))
                 {
-                    LogDispatcher.HandleLog(LogType.Error, new LogEvent("Entity not found during OnComponentUpdate.")
-                        .WithField(LoggingUtils.LoggerName, LoggerName)
+                    Logger.Log(LogType.Error, new LogEvent("Entity not found during OnComponentUpdate.")
                         .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                        .WithField(MutableView.Component, "SpatialOSExhaustiveRepeated"));
+                        .WithField(LoggingUtils.Component, "SpatialOSExhaustiveRepeated"));
                     return;
                 }
 
@@ -284,13 +280,11 @@ namespace Generated.Improbable.Gdk.Tests
 
             public void OnRemoveComponent(RemoveComponentOp op)
             {
-                Unity.Entities.Entity entity;
-                if (!view.TryGetEntity(op.EntityId.Id, out entity))
+                if (!view.TryGetEntity(op.EntityId.Id, out var entity))
                 {
-                    LogDispatcher.HandleLog(LogType.Error, new LogEvent("Entity not found during OnRemoveComponent.")
-                        .WithField(LoggingUtils.LoggerName, LoggerName)
+                    Logger.Log(LogType.Error, new LogEvent("Entity not found during OnRemoveComponent.")
                         .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                        .WithField(MutableView.Component, "SpatialOSExhaustiveRepeated"));
+                        .WithField(LoggingUtils.Component, "SpatialOSExhaustiveRepeated"));
                     return;
                 }
 
@@ -306,11 +300,10 @@ namespace Generated.Improbable.Gdk.Tests
                 }
                 else
                 {
-                    LogDispatcher.HandleLog(LogType.Error, new LogEvent(
+                    Logger.Log(LogType.Error, new LogEvent(
                             "Received ComponentRemoved but have already received one for this entity.")
-                        .WithField(LoggingUtils.LoggerName, LoggerName)
                         .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                        .WithField(MutableView.Component, "SpatialOSExhaustiveRepeated"));
+                        .WithField(LoggingUtils.Component, "SpatialOSExhaustiveRepeated"));
                 }
             }
 
@@ -331,30 +324,32 @@ namespace Generated.Improbable.Gdk.Tests
                     var entityId = spatialEntityIdData[i].EntityId;
                     var hasPendingEvents = false;
 
-                    if (componentData.DirtyBit || hasPendingEvents)
+                    if (!componentData.DirtyBit && !hasPendingEvents)
                     {
-                        var update = new global::Improbable.Gdk.Tests.ExhaustiveRepeated.Update();
-                        update.SetField2(new global::Improbable.Collections.List<float>(componentData.Field2));
-                        update.SetField4(new global::Improbable.Collections.List<int>(componentData.Field4));
-                        update.SetField5(new global::Improbable.Collections.List<long>(componentData.Field5));
-                        update.SetField6(new global::Improbable.Collections.List<double>(componentData.Field6));
-                        update.SetField7(new global::Improbable.Collections.List<string>(componentData.Field7));
-                        update.SetField8(new global::Improbable.Collections.List<uint>(componentData.Field8));
-                        update.SetField9(new global::Improbable.Collections.List<ulong>(componentData.Field9));
-                        update.SetField10(new global::Improbable.Collections.List<int>(componentData.Field10));
-                        update.SetField11(new global::Improbable.Collections.List<long>(componentData.Field11));
-                        update.SetField12(new global::Improbable.Collections.List<uint>(componentData.Field12));
-                        update.SetField13(new global::Improbable.Collections.List<ulong>(componentData.Field13));
-                        update.SetField14(new global::Improbable.Collections.List<int>(componentData.Field14));
-                        update.SetField15(new global::Improbable.Collections.List<long>(componentData.Field15));
-                        update.SetField16(new global::Improbable.Collections.List<global::Improbable.EntityId>(componentData.Field16.Select(nativeInternalObject => new global::Improbable.EntityId(nativeInternalObject))));
-                        update.SetField17(new global::Improbable.Collections.List<global::Improbable.Gdk.Tests.SomeType>(componentData.Field17.Select(nativeInternalObject => global::Generated.Improbable.Gdk.Tests.SomeType.ToSpatial(nativeInternalObject))));
-                        SendComponentUpdate(connection, entityId, update);
-
-                        componentData.DirtyBit = false;
-                        view.SetComponentObject(entityId, componentData);
-
+                        continue;
                     }
+
+                    var update = new global::Improbable.Gdk.Tests.ExhaustiveRepeated.Update();
+                    update.SetField2(new global::Improbable.Collections.List<float>(componentData.Field2));
+                    update.SetField4(new global::Improbable.Collections.List<int>(componentData.Field4));
+                    update.SetField5(new global::Improbable.Collections.List<long>(componentData.Field5));
+                    update.SetField6(new global::Improbable.Collections.List<double>(componentData.Field6));
+                    update.SetField7(new global::Improbable.Collections.List<string>(componentData.Field7));
+                    update.SetField8(new global::Improbable.Collections.List<uint>(componentData.Field8));
+                    update.SetField9(new global::Improbable.Collections.List<ulong>(componentData.Field9));
+                    update.SetField10(new global::Improbable.Collections.List<int>(componentData.Field10));
+                    update.SetField11(new global::Improbable.Collections.List<long>(componentData.Field11));
+                    update.SetField12(new global::Improbable.Collections.List<uint>(componentData.Field12));
+                    update.SetField13(new global::Improbable.Collections.List<ulong>(componentData.Field13));
+                    update.SetField14(new global::Improbable.Collections.List<int>(componentData.Field14));
+                    update.SetField15(new global::Improbable.Collections.List<long>(componentData.Field15));
+                    update.SetField16(new global::Improbable.Collections.List<global::Improbable.EntityId>(componentData.Field16.Select(nativeInternalObject => new global::Improbable.EntityId(nativeInternalObject))));
+                    update.SetField17(new global::Improbable.Collections.List<global::Improbable.Gdk.Tests.SomeType>(componentData.Field17.Select(nativeInternalObject => global::Generated.Improbable.Gdk.Tests.SomeType.ToSpatial(nativeInternalObject))));
+                    SendComponentUpdate(connection, entityId, update);
+
+                    componentData.DirtyBit = false;
+                    view.SetComponentObject(entityId, componentData);
+
                 }
             }
 

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingularTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingularTranslation.cs
@@ -10,6 +10,7 @@ using Unity.Entities;
 using Improbable.Worker;
 using Improbable.Gdk.Core;
 using Improbable.Gdk.Core.Components;
+using ILogger = Improbable.Gdk.Core.ILogger;
 using Improbable.Gdk.Tests;
 
 namespace Generated.Improbable.Gdk.Tests
@@ -46,7 +47,7 @@ namespace Generated.Improbable.Gdk.Tests
                     () => new ComponentsUpdated<SpatialOSExhaustiveSingular.Update>(),
                     (component) => component.Buffer.Clear());
 
-            public Translation(MutableView view) : base(view)
+            public Translation(MutableView view, ILogger logger) : base(view, logger)
             {
             }
 
@@ -65,13 +66,11 @@ namespace Generated.Improbable.Gdk.Tests
 
             public void OnAddComponent(AddComponentOp<global::Improbable.Gdk.Tests.ExhaustiveSingular> op)
             {
-                Unity.Entities.Entity entity;
-                if (!view.TryGetEntity(op.EntityId.Id, out entity))
+                if (!view.TryGetEntity(op.EntityId.Id, out var entity))
                 {
-                    LogDispatcher.HandleLog(LogType.Error, new LogEvent("Entity not found during OnAddComponent.")
-                        .WithField(LoggingUtils.LoggerName, LoggerName)
+                    Logger.Log(LogType.Error, new LogEvent("Entity not found during OnAddComponent.")
                         .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                        .WithField(MutableView.Component, "SpatialOSExhaustiveSingular"));
+                        .WithField(LoggingUtils.Component, "SpatialOSExhaustiveSingular"));
                     return;
                 }
                 var data = op.Data.Get().Value;
@@ -108,23 +107,20 @@ namespace Generated.Improbable.Gdk.Tests
                 }
                 else
                 {
-                    LogDispatcher.HandleLog(LogType.Error, new LogEvent(
+                    Logger.Log(LogType.Error, new LogEvent(
                             "Received ComponentAdded but have already received one for this entity.")
-                        .WithField(LoggingUtils.LoggerName, LoggerName)
                         .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                        .WithField(MutableView.Component, "SpatialOSExhaustiveSingular"));
+                        .WithField(LoggingUtils.Component, "SpatialOSExhaustiveSingular"));
                 }
             }
 
             public void OnComponentUpdate(ComponentUpdateOp<global::Improbable.Gdk.Tests.ExhaustiveSingular> op)
             {
-                Unity.Entities.Entity entity;
-                if (!view.TryGetEntity(op.EntityId.Id, out entity))
+                if (!view.TryGetEntity(op.EntityId.Id, out var entity))
                 {
-                    LogDispatcher.HandleLog(LogType.Error, new LogEvent("Entity not found during OnComponentUpdate.")
-                        .WithField(LoggingUtils.LoggerName, LoggerName)
+                    Logger.Log(LogType.Error, new LogEvent("Entity not found during OnComponentUpdate.")
                         .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                        .WithField(MutableView.Component, "SpatialOSExhaustiveSingular"));
+                        .WithField(LoggingUtils.Component, "SpatialOSExhaustiveSingular"));
                     return;
                 }
 
@@ -294,13 +290,11 @@ namespace Generated.Improbable.Gdk.Tests
 
             public void OnRemoveComponent(RemoveComponentOp op)
             {
-                Unity.Entities.Entity entity;
-                if (!view.TryGetEntity(op.EntityId.Id, out entity))
+                if (!view.TryGetEntity(op.EntityId.Id, out var entity))
                 {
-                    LogDispatcher.HandleLog(LogType.Error, new LogEvent("Entity not found during OnRemoveComponent.")
-                        .WithField(LoggingUtils.LoggerName, LoggerName)
+                    Logger.Log(LogType.Error, new LogEvent("Entity not found during OnRemoveComponent.")
                         .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                        .WithField(MutableView.Component, "SpatialOSExhaustiveSingular"));
+                        .WithField(LoggingUtils.Component, "SpatialOSExhaustiveSingular"));
                     return;
                 }
 
@@ -316,11 +310,10 @@ namespace Generated.Improbable.Gdk.Tests
                 }
                 else
                 {
-                    LogDispatcher.HandleLog(LogType.Error, new LogEvent(
+                    Logger.Log(LogType.Error, new LogEvent(
                             "Received ComponentRemoved but have already received one for this entity.")
-                        .WithField(LoggingUtils.LoggerName, LoggerName)
                         .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                        .WithField(MutableView.Component, "SpatialOSExhaustiveSingular"));
+                        .WithField(LoggingUtils.Component, "SpatialOSExhaustiveSingular"));
                 }
             }
 
@@ -341,31 +334,33 @@ namespace Generated.Improbable.Gdk.Tests
                     var entityId = spatialEntityIdData[i].EntityId;
                     var hasPendingEvents = false;
 
-                    if (componentData.DirtyBit || hasPendingEvents)
+                    if (!componentData.DirtyBit && !hasPendingEvents)
                     {
-                        var update = new global::Improbable.Gdk.Tests.ExhaustiveSingular.Update();
-                        update.SetField1(componentData.Field1);
-                        update.SetField2(componentData.Field2);
-                        update.SetField4(componentData.Field4);
-                        update.SetField5(componentData.Field5);
-                        update.SetField6(componentData.Field6);
-                        update.SetField7(componentData.Field7);
-                        update.SetField8(componentData.Field8);
-                        update.SetField9(componentData.Field9);
-                        update.SetField10(componentData.Field10);
-                        update.SetField11(componentData.Field11);
-                        update.SetField12(componentData.Field12);
-                        update.SetField13(componentData.Field13);
-                        update.SetField14(componentData.Field14);
-                        update.SetField15(componentData.Field15);
-                        update.SetField16(new global::Improbable.EntityId(componentData.Field16));
-                        update.SetField17(global::Generated.Improbable.Gdk.Tests.SomeType.ToSpatial(componentData.Field17));
-                        SendComponentUpdate(connection, entityId, update);
-
-                        componentData.DirtyBit = false;
-                        view.SetComponentObject(entityId, componentData);
-
+                        continue;
                     }
+
+                    var update = new global::Improbable.Gdk.Tests.ExhaustiveSingular.Update();
+                    update.SetField1(componentData.Field1);
+                    update.SetField2(componentData.Field2);
+                    update.SetField4(componentData.Field4);
+                    update.SetField5(componentData.Field5);
+                    update.SetField6(componentData.Field6);
+                    update.SetField7(componentData.Field7);
+                    update.SetField8(componentData.Field8);
+                    update.SetField9(componentData.Field9);
+                    update.SetField10(componentData.Field10);
+                    update.SetField11(componentData.Field11);
+                    update.SetField12(componentData.Field12);
+                    update.SetField13(componentData.Field13);
+                    update.SetField14(componentData.Field14);
+                    update.SetField15(componentData.Field15);
+                    update.SetField16(new global::Improbable.EntityId(componentData.Field16));
+                    update.SetField17(global::Generated.Improbable.Gdk.Tests.SomeType.ToSpatial(componentData.Field17));
+                    SendComponentUpdate(connection, entityId, update);
+
+                    componentData.DirtyBit = false;
+                    view.SetComponentObject(entityId, componentData);
+
                 }
             }
 

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/NestedComponentTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/NestedComponentTranslation.cs
@@ -10,6 +10,7 @@ using Unity.Entities;
 using Improbable.Worker;
 using Improbable.Gdk.Core;
 using Improbable.Gdk.Core.Components;
+using ILogger = Improbable.Gdk.Core.ILogger;
 using Improbable.Gdk.Tests;
 
 namespace Generated.Improbable.Gdk.Tests
@@ -46,7 +47,7 @@ namespace Generated.Improbable.Gdk.Tests
                     () => new ComponentsUpdated<SpatialOSNestedComponent.Update>(),
                     (component) => component.Buffer.Clear());
 
-            public Translation(MutableView view) : base(view)
+            public Translation(MutableView view, ILogger logger) : base(view, logger)
             {
             }
 
@@ -65,13 +66,11 @@ namespace Generated.Improbable.Gdk.Tests
 
             public void OnAddComponent(AddComponentOp<global::Improbable.Gdk.Tests.NestedComponent> op)
             {
-                Unity.Entities.Entity entity;
-                if (!view.TryGetEntity(op.EntityId.Id, out entity))
+                if (!view.TryGetEntity(op.EntityId.Id, out var entity))
                 {
-                    LogDispatcher.HandleLog(LogType.Error, new LogEvent("Entity not found during OnAddComponent.")
-                        .WithField(LoggingUtils.LoggerName, LoggerName)
+                    Logger.Log(LogType.Error, new LogEvent("Entity not found during OnAddComponent.")
                         .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                        .WithField(MutableView.Component, "SpatialOSNestedComponent"));
+                        .WithField(LoggingUtils.Component, "SpatialOSNestedComponent"));
                     return;
                 }
                 var data = op.Data.Get().Value;
@@ -93,23 +92,20 @@ namespace Generated.Improbable.Gdk.Tests
                 }
                 else
                 {
-                    LogDispatcher.HandleLog(LogType.Error, new LogEvent(
+                    Logger.Log(LogType.Error, new LogEvent(
                             "Received ComponentAdded but have already received one for this entity.")
-                        .WithField(LoggingUtils.LoggerName, LoggerName)
                         .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                        .WithField(MutableView.Component, "SpatialOSNestedComponent"));
+                        .WithField(LoggingUtils.Component, "SpatialOSNestedComponent"));
                 }
             }
 
             public void OnComponentUpdate(ComponentUpdateOp<global::Improbable.Gdk.Tests.NestedComponent> op)
             {
-                Unity.Entities.Entity entity;
-                if (!view.TryGetEntity(op.EntityId.Id, out entity))
+                if (!view.TryGetEntity(op.EntityId.Id, out var entity))
                 {
-                    LogDispatcher.HandleLog(LogType.Error, new LogEvent("Entity not found during OnComponentUpdate.")
-                        .WithField(LoggingUtils.LoggerName, LoggerName)
+                    Logger.Log(LogType.Error, new LogEvent("Entity not found during OnComponentUpdate.")
                         .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                        .WithField(MutableView.Component, "SpatialOSNestedComponent"));
+                        .WithField(LoggingUtils.Component, "SpatialOSNestedComponent"));
                     return;
                 }
 
@@ -144,13 +140,11 @@ namespace Generated.Improbable.Gdk.Tests
 
             public void OnRemoveComponent(RemoveComponentOp op)
             {
-                Unity.Entities.Entity entity;
-                if (!view.TryGetEntity(op.EntityId.Id, out entity))
+                if (!view.TryGetEntity(op.EntityId.Id, out var entity))
                 {
-                    LogDispatcher.HandleLog(LogType.Error, new LogEvent("Entity not found during OnRemoveComponent.")
-                        .WithField(LoggingUtils.LoggerName, LoggerName)
+                    Logger.Log(LogType.Error, new LogEvent("Entity not found during OnRemoveComponent.")
                         .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                        .WithField(MutableView.Component, "SpatialOSNestedComponent"));
+                        .WithField(LoggingUtils.Component, "SpatialOSNestedComponent"));
                     return;
                 }
 
@@ -166,11 +160,10 @@ namespace Generated.Improbable.Gdk.Tests
                 }
                 else
                 {
-                    LogDispatcher.HandleLog(LogType.Error, new LogEvent(
+                    Logger.Log(LogType.Error, new LogEvent(
                             "Received ComponentRemoved but have already received one for this entity.")
-                        .WithField(LoggingUtils.LoggerName, LoggerName)
                         .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                        .WithField(MutableView.Component, "SpatialOSNestedComponent"));
+                        .WithField(LoggingUtils.Component, "SpatialOSNestedComponent"));
                 }
             }
 
@@ -191,16 +184,18 @@ namespace Generated.Improbable.Gdk.Tests
                     var entityId = spatialEntityIdData[i].EntityId;
                     var hasPendingEvents = false;
 
-                    if (componentData.DirtyBit || hasPendingEvents)
+                    if (!componentData.DirtyBit && !hasPendingEvents)
                     {
-                        var update = new global::Improbable.Gdk.Tests.NestedComponent.Update();
-                        update.SetNestedType(global::Generated.Improbable.Gdk.Tests.TypeName.ToSpatial(componentData.NestedType));
-                        SendComponentUpdate(connection, entityId, update);
-
-                        componentData.DirtyBit = false;
-                        componentDataArray[i] = componentData;
-
+                        continue;
                     }
+
+                    var update = new global::Improbable.Gdk.Tests.NestedComponent.Update();
+                    update.SetNestedType(global::Generated.Improbable.Gdk.Tests.TypeName.ToSpatial(componentData.NestedType));
+                    SendComponentUpdate(connection, entityId, update);
+
+                    componentData.DirtyBit = false;
+                    componentDataArray[i] = componentData;
+
                 }
             }
 

--- a/workers/unity/Assets/Playground/Scripts/Bootstrap.cs
+++ b/workers/unity/Assets/Playground/Scripts/Bootstrap.cs
@@ -14,13 +14,10 @@ namespace Playground
     public class Bootstrap : MonoBehaviour
     {
         public GameObject Level;
-
-        private const int TargetFrameRate = -1; // Turns off VSync
-
         public const string LoggerName = "Bootstrap";
 
+        private const int TargetFrameRate = -1; // Turns off VSync
         private static readonly List<WorkerBase> Workers = new List<WorkerBase>();
-
         private static ConnectionConfig connectionConfig;
 
         public void Awake()
@@ -31,9 +28,9 @@ namespace Playground
             PlayerLoopManager.RegisterDomainUnload(DomainUnloadShutdown, 10000); // Clean up worlds and player loop
 
             Application.targetFrameRate = TargetFrameRate;
+#if UNITY_EDITOR
             if (Application.isEditor)
             {
-#if UNITY_EDITOR
                 var workerConfigurations =
                     AssetDatabase.LoadAssetAtPath<ScriptableWorkerConfiguration>(ScriptableWorkerConfiguration
                         .AssetPath);
@@ -49,11 +46,13 @@ namespace Playground
                     Workers.Add(worker);
                 }
 
-                connectionConfig = new ReceptionistConfig();
-                connectionConfig.UseExternalIp = workerConfigurations.UseExternalIp;
-#endif
+                connectionConfig = new ReceptionistConfig
+                {
+                    UseExternalIp = workerConfigurations.UseExternalIp
+                };
             }
             else
+#endif
             {
                 var commandLineArguments = System.Environment.GetCommandLineArgs();
                 Debug.LogFormat("Command line {0}", string.Join(" ", commandLineArguments.ToArray()));
@@ -65,7 +64,7 @@ namespace Playground
                     CommandLineUtility.GetCommandLineValue(commandLineArgs, RuntimeConfigNames.WorkerId,
                         string.Empty);
 
-                // because the launcher does not pass in the worker type as an argument
+                // Because the launcher does not pass in the worker type as an argument
                 var worker = workerType.Equals(string.Empty)
                     ? WorkerRegistry.CreateWorker<UnityClient>($"{workerType}-{Guid.NewGuid()}", new Vector3(0, 0, 0))
                     : WorkerRegistry.CreateWorker(workerType, workerId, new Vector3(0, 0, 0));

--- a/workers/unity/Assets/Playground/Scripts/DisconnectSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/DisconnectSystem.cs
@@ -12,7 +12,6 @@ namespace Playground
         {
             public readonly int Length;
             [ReadOnly] public SharedComponentDataArray<OnDisconnected> DisconnectMessage;
-
             [ReadOnly] public ComponentDataArray<WorkerEntityTag> DenotesWorkerEntity;
         }
 

--- a/workers/unity/Assets/Playground/Scripts/EntityInitialization/ArchetypeInitializationSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/EntityInitialization/ArchetypeInitializationSystem.cs
@@ -70,9 +70,8 @@ namespace Playground
                 var archetypeName = data.ArchetypeComponents[i].ArchetypeName;
                 var entity = data.Entities[i];
 
-                ComponentType[] componentTypesToAdd;
                 if (!ArchetypeConfig.WorkerTypeToArchetypeNameToComponentTypes[workerType]
-                    .TryGetValue(archetypeName, out componentTypesToAdd))
+                    .TryGetValue(archetypeName, out var componentTypesToAdd))
                 {
                     view.LogDispatcher.HandleLog(LogType.Error, new LogEvent(ArchetypeMappingNotFound)
                         .WithField(LoggingUtils.LoggerName, LoggerName)
@@ -86,8 +85,7 @@ namespace Playground
                     var type = componentType.GetManagedType();
                     var componentInstance = Activator.CreateInstance(type);
 
-                    bool isComponentData;
-                    if (!typeToIsComponentData.TryGetValue(type, out isComponentData))
+                    if (!typeToIsComponentData.TryGetValue(type, out var isComponentData))
                     {
                         isComponentData = type.GetInterfaces().Contains(typeof(IComponentData));
                         typeToIsComponentData[type] = isComponentData;
@@ -95,15 +93,14 @@ namespace Playground
 
                     if (isComponentData)
                     {
-                        MethodInfo addComponentMethodGeneric;
-                        if (!typeToAddComponentGenericMethodInfo.TryGetValue(type, out addComponentMethodGeneric))
+                        if (!typeToAddComponentGenericMethodInfo.TryGetValue(type, out var addComponentMethodGeneric))
                         {
                             addComponentMethodGeneric = addComponentMethod.MakeGenericMethod(type);
                             typeToAddComponentGenericMethodInfo[type] = addComponentMethodGeneric;
                         }
 
                         addComponentMethodGeneric.Invoke(PostUpdateCommands,
-                            new object[] { entity, componentInstance });
+                            new[] { entity, componentInstance });
                     }
                     else
                     {

--- a/workers/unity/Assets/Playground/Scripts/EntityInitialization/EntityGameObjectCreator.cs
+++ b/workers/unity/Assets/Playground/Scripts/EntityInitialization/EntityGameObjectCreator.cs
@@ -19,8 +19,7 @@ namespace Playground
         public GameObject CreateEntityGameObject(Entity entity, string prefabPath, Vector3 position,
             Quaternion rotation, long spatialEntityId)
         {
-            GameObject prefab;
-            if (!cachedPrefabs.TryGetValue(prefabPath, out prefab))
+            if (!cachedPrefabs.TryGetValue(prefabPath, out var prefab))
             {
                 prefab = Resources.Load<GameObject>(prefabPath);
                 if (prefab == null)

--- a/workers/unity/Assets/Playground/Scripts/EntityInitialization/GameObjectInitializationSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/EntityInitialization/GameObjectInitializationSystem.cs
@@ -96,8 +96,7 @@ namespace Playground
             for (var i = 0; i < removedEntitiesData.Length; i++)
             {
                 var entityIndex = removedEntitiesData.Entities[i].Index;
-                GameObject gameObject;
-                if (!entityGameObjectCache.TryGetValue(entityIndex, out gameObject))
+                if (!entityGameObjectCache.TryGetValue(entityIndex, out var gameObject))
                 {
                     view.LogDispatcher.HandleLog(LogType.Error, new LogEvent(
                             "GameObject corresponding to removed entity not found.")

--- a/workers/unity/Assets/Playground/Scripts/Metrics/MetricSendSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/Metrics/MetricSendSystem.cs
@@ -35,9 +35,9 @@ namespace Playground
             if (timeElapsedSinceUpdate >= TimeBetweenMetricUpdatesSecs)
             {
                 timeElapsedSinceUpdate = 0;
-                float fps = CalculateFps();
-                var load = DefaultLoadCalculation(fps);
-                Improbable.Worker.Metrics metrics = new Improbable.Worker.Metrics
+                var framesPerSecond = CalculateFps();
+                var load = DefaultLoadCalculation(framesPerSecond);
+                var metrics = new Improbable.Worker.Metrics
                 {
                     Load = load
                 };
@@ -45,10 +45,10 @@ namespace Playground
             }
         }
 
-        private float DefaultLoadCalculation(float fps)
+        private float DefaultLoadCalculation(float framesPerSecond)
         {
             float targetFps = Application.targetFrameRate;
-            return Mathf.Max(0.0f, (targetFps - fps) / (0.5f * targetFps));
+            return Mathf.Max(0.0f, (targetFps - framesPerSecond) / (0.5f * targetFps));
         }
 
         private void AddFpsSample()
@@ -63,14 +63,14 @@ namespace Playground
 
         private float CalculateFps()
         {
-            float fps = 0.0f;
+            var framesPerSecond = 0.0f;
             foreach (var measurement in fpsMeasurements)
             {
-                fps += measurement;
+                framesPerSecond += measurement;
             }
 
-            fps /= fpsMeasurements.Count;
-            return fps;
+            framesPerSecond /= fpsMeasurements.Count;
+            return framesPerSecond;
         }
     }
 }

--- a/workers/unity/Assets/Playground/Scripts/Player/PlayerCommandsSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/Player/PlayerCommandsSystem.cs
@@ -69,8 +69,7 @@ namespace Playground
             }
 
             var ray = Camera.main.ScreenPointToRay(UIComponent.Main.Reticle.transform.position);
-            RaycastHit info;
-            if (!Physics.Raycast(ray, out info) || info.rigidbody == null)
+            if (!Physics.Raycast(ray, out var info) || info.rigidbody == null)
             {
                 return;
             }

--- a/workers/unity/Assets/Playground/Scripts/Player/ProcessLaunchCommandSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/Player/ProcessLaunchCommandSystem.cs
@@ -53,8 +53,7 @@ namespace Playground
 
                 var requests = launchCommandData.CommandRequests[i].Buffer;
                 var energyLeft = launcher.EnergyLeft;
-                var j = 0;
-                while (energyLeft > 0f && j < requests.Count)
+                for (var j=0; j < requests.Count && energyLeft > 0f; j++)
                 {
                     var info = requests[j].RawRequest;
                     var energy = math.min(info.LaunchEnergy, energyLeft);
@@ -65,7 +64,6 @@ namespace Playground
                         LaunchEnergy = energy
                     });
                     energyLeft -= energy;
-                    j++;
                 }
 
                 if (energyLeft <= 0.01f)

--- a/workers/unity/Assets/Playground/Scripts/Player/ProcessLaunchCommandSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/Player/ProcessLaunchCommandSystem.cs
@@ -53,7 +53,7 @@ namespace Playground
 
                 var requests = launchCommandData.CommandRequests[i].Buffer;
                 var energyLeft = launcher.EnergyLeft;
-                for (var j=0; j < requests.Count && energyLeft > 0f; j++)
+                for (var j = 0; j < requests.Count && energyLeft > 0f; j++)
                 {
                     var info = requests[j].RawRequest;
                     var energy = math.min(info.LaunchEnergy, energyLeft);

--- a/workers/unity/Assets/Playground/Scripts/Player/ProcessRechargeSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/Player/ProcessRechargeSystem.cs
@@ -24,11 +24,10 @@ namespace Playground
 
         protected override void OnUpdate()
         {
-            var dt = Time.deltaTime;
             for (var i = 0; i < data.Length; i++)
             {
                 var launcher = data.Launcher[i];
-                launcher.RechargeTimeLeft -= dt;
+                launcher.RechargeTimeLeft -= Time.deltaTime;
                 if (launcher.RechargeTimeLeft < 0.0f)
                 {
                     launcher.RechargeTimeLeft = 0.0f;

--- a/workers/unity/Assets/Playground/Scripts/UI/InitUISystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/UI/InitUISystem.cs
@@ -25,11 +25,10 @@ namespace Playground
         {
             for (var i = 0; i < data.Length; i++)
             {
-                var ui = Resources.Load("Prefabs/UIGameObject");
-                var inst = (GameObject) Object.Instantiate(ui, Vector3.zero, Quaternion.identity);
-                var uiComponent = inst.GetComponent<UIComponent>();
-                UIComponent.Main = uiComponent;
-                uiComponent.TestText.text = $"Energy: {data.Launcher[i].EnergyLeft}";
+                var prefab = Resources.Load<GameObject>("Prefabs/UIGameObject");
+                var instance = GameObject.Instantiate(prefab, Vector3.zero, Quaternion.identity);
+                UIComponent.Main = instance.GetComponent<UIComponent>();
+                UIComponent.Main.TestText.text = $"Energy: {data.Launcher[i].EnergyLeft}";
             }
 
             // Disable system after first run.

--- a/workers/unity/Assets/Playground/Scripts/UI/UIComponent.cs
+++ b/workers/unity/Assets/Playground/Scripts/UI/UIComponent.cs
@@ -12,7 +12,6 @@ namespace Playground.Scripts.UI
         public Text TestText;
         public RawImage Reticle;
 
-
         public static Rect ToScreenRect(RectTransform transform)
         {
             var size = Vector2.Scale(transform.rect.size, transform.lossyScale);

--- a/workers/unity/Packages/com.improbable.gdk.core/Components/ComponentTranslation.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Components/ComponentTranslation.cs
@@ -45,7 +45,10 @@ namespace Improbable.Gdk.Core.Components
         public static readonly Dictionary<uint, ComponentTranslation> HandleToTranslation =
             new Dictionary<uint, ComponentTranslation>();
 
-        private static uint GetNextHandle() => (uint) HandleToTranslation.Count;
+        private static uint GetNextHandle()
+        {
+            return (uint) HandleToTranslation.Count;
+        }
 
         protected uint translationHandle { get; }
 

--- a/workers/unity/Packages/com.improbable.gdk.core/Components/ComponentTranslation.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Components/ComponentTranslation.cs
@@ -23,20 +23,19 @@ namespace Improbable.Gdk.Core.Components
 
         public abstract ComponentType TargetComponentType { get; }
         protected readonly MutableView view;
-        protected readonly ILogDispatcher LogDispatcher;
+        protected readonly ILogger Logger;
 
-        protected ComponentTranslation(MutableView view)
+        protected ComponentTranslation(MutableView view, ILogger logger)
         {
             this.view = view;
-            LogDispatcher = view.LogDispatcher;
+            this.Logger = logger;
             translationHandle = GetNextHandle();
             HandleToTranslation.Add(translationHandle, this);
         }
 
         public void Dispose()
         {
-            ComponentTranslation translationForHandle;
-            if (HandleToTranslation.TryGetValue(translationHandle, out translationForHandle) &&
+            if (HandleToTranslation.TryGetValue(translationHandle, out var translationForHandle) &&
                 translationForHandle == this)
             {
                 HandleToTranslation.Remove(translationHandle);

--- a/workers/unity/Packages/com.improbable.gdk.core/Components/Option.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Components/Option.cs
@@ -53,7 +53,7 @@ namespace Improbable.Gdk.Core
 
         public override bool Equals(object other)
         {
-            return other is Option<T> && this.Equals((Option<T>) other);
+            return other is Option<T> option && this.Equals(option);
         }
 
         public bool Equals(Option<T> other)

--- a/workers/unity/Packages/com.improbable.gdk.core/Components/WorldCommandsTranslation.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Components/WorldCommandsTranslation.cs
@@ -125,12 +125,15 @@ namespace Improbable.Gdk.Core
     {
         private long EntityId { get; }
 
-        private readonly WorldCommandsTranslation translation;
+        private readonly uint handleToTranslation;
+
+        private WorldCommandsTranslation translation =>
+            (WorldCommandsTranslation) ComponentTranslation.HandleToTranslation[handleToTranslation];
 
         public WorldCommandSender(long entityId, uint handleToTranslation)
         {
             EntityId = entityId;
-            translation = (WorldCommandsTranslation) ComponentTranslation.HandleToTranslation[handleToTranslation];
+            this.handleToTranslation = handleToTranslation;
         }
 
         public void SendCreateEntityRequest(Worker.Entity entity, long entityId = 0, uint timeoutMillis = 0)
@@ -236,16 +239,13 @@ namespace Improbable.Gdk.Core
                 () => new CommandResponses<EntityQueryResponse>(),
                 component => component.Buffer.Clear());
 
-        private const string LoggerName = "WorldCommandsTranslation";
-
         private const string EntityNotFoundForRequestId =
             "Entity not found when attempting to get EntityId from RequestId.";
 
         private const string EntityNotFoundForEntityId =
             "Entity not found when attempting to get Entity from EntityId.";
 
-        public WorldCommandsTranslation(MutableView view) : base(view,
-            view.LogDispatcher.GetLogger(nameof(WorldCommandsTranslation)))
+        public WorldCommandsTranslation(MutableView view, ILogger logger) : base(view, logger)
         {
         }
 

--- a/workers/unity/Packages/com.improbable.gdk.core/Components/WorldCommandsTranslation.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Components/WorldCommandsTranslation.cs
@@ -130,7 +130,7 @@ namespace Improbable.Gdk.Core
         public WorldCommandSender(long entityId, uint handleToTranslation)
         {
             EntityId = entityId;
-            translation = (WorldCommandsTranslation)ComponentTranslation.HandleToTranslation[handleToTranslation];
+            translation = (WorldCommandsTranslation) ComponentTranslation.HandleToTranslation[handleToTranslation];
         }
 
         public void SendCreateEntityRequest(Worker.Entity entity, long entityId = 0, uint timeoutMillis = 0)
@@ -244,7 +244,8 @@ namespace Improbable.Gdk.Core
         private const string EntityNotFoundForEntityId =
             "Entity not found when attempting to get Entity from EntityId.";
 
-        public WorldCommandsTranslation(MutableView view) : base(view, view.LogDispatcher.GetLogger(nameof(WorldCommandsTranslation)))
+        public WorldCommandsTranslation(MutableView view) : base(view,
+            view.LogDispatcher.GetLogger(nameof(WorldCommandsTranslation)))
         {
         }
 

--- a/workers/unity/Packages/com.improbable.gdk.core/Config/LocatorConfig.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Config/LocatorConfig.cs
@@ -16,7 +16,7 @@ namespace Improbable.Gdk.Core
         public override void Validate()
         {
             ValidateConfig(LocatorHost, RuntimeConfigNames.LocatorHost);
-            if (LocatorParameters.CredentialsType.Equals(LocatorCredentialsType.LoginToken))
+            if (LocatorParameters.CredentialsType == LocatorCredentialsType.LoginToken)
             {
                 ValidateConfig(LocatorParameters.LoginToken.Token, RuntimeConfigNames.LoginToken);
                 ValidateConfig(LocatorParameters.ProjectName, RuntimeConfigNames.ProjectName);

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/EntityGameObjectLinker.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/EntityGameObjectLinker.cs
@@ -8,13 +8,16 @@ namespace Improbable.Gdk.Core
     public class EntityGameObjectLinker
     {
         private readonly World world;
-        private MutableView view;
+        private readonly MutableView view;
         private readonly HashSet<Type> gameObjectComponentTypes = new HashSet<Type>();
+
+        private readonly ILogger logger;
 
         public EntityGameObjectLinker(World world, MutableView view)
         {
             this.world = world;
             this.view = view;
+            logger = view.LogDispatcher.GetLogger(nameof(EntityGameObjectLinker));
         }
 
         public void LinkGameObjectToEntity(GameObject gameObject, Entity entity, long spatialEntityId,
@@ -26,7 +29,7 @@ namespace Improbable.Gdk.Core
                 var componentType = component.GetType();
                 if (gameObjectComponentTypes.Contains(componentType))
                 {
-                    view.LogDispatcher.HandleLog(LogType.Warning, new LogEvent(
+                    logger.Log(LogType.Warning, new LogEvent(
                             "GameObject contains multiple instances of the same component type. Only one instance of each component type will be added to the corresponding ECS entity.")
                         .WithField("EntityId", spatialEntityId)
                         .WithField("ComponentType", componentType));

--- a/workers/unity/Packages/com.improbable.gdk.core/Logging/ForwardingDispatcher.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Logging/ForwardingDispatcher.cs
@@ -43,6 +43,11 @@ namespace Improbable.Gdk.Core
             this.connection = connection;
         }
 
+        public ILogger GetLogger(string loggerName)
+        {
+            return new Logger(this, loggerName);
+        }
+
         public void HandleLog(LogType type, LogEvent logEvent)
         {
             Debug.unityLogger.Log(type, logEvent);

--- a/workers/unity/Packages/com.improbable.gdk.core/Logging/ForwardingDispatcher.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Logging/ForwardingDispatcher.cs
@@ -51,7 +51,7 @@ namespace Improbable.Gdk.Core
         public void HandleLog(LogType type, LogEvent logEvent)
         {
             Debug.unityLogger.Log(type, logEvent);
-            LogLevel logLevel = LogTypeMapping[type];
+            var logLevel = LogTypeMapping[type];
 
             if (connection == null || logLevel < minimumLogLevel)
             {

--- a/workers/unity/Packages/com.improbable.gdk.core/Logging/ForwardingDispatcher.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Logging/ForwardingDispatcher.cs
@@ -34,7 +34,7 @@ namespace Improbable.Gdk.Core
             // This is required to avoid duplicate forwarding caused by HandleLog also logging to console
             if (type == LogType.Exception)
             {
-                connection.SendLogMessage(LogLevel.Error, connection.GetWorkerId(), $"{message}\n{stackTrace}");
+                connection?.SendLogMessage(LogLevel.Error, connection.GetWorkerId(), $"{message}\n{stackTrace}");
             }
         }
 

--- a/workers/unity/Packages/com.improbable.gdk.core/Logging/ILogDispatcher.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Logging/ILogDispatcher.cs
@@ -4,6 +4,7 @@ namespace Improbable.Gdk.Core
 {
     public interface ILogDispatcher
     {
+        ILogger GetLogger(string loggerName);
         void HandleLog(LogType type, LogEvent logEvent);
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.core/Logging/ILogger.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Logging/ILogger.cs
@@ -1,0 +1,9 @@
+using UnityEngine;
+
+namespace Improbable.Gdk.Core
+{
+    public interface ILogger
+    {
+        void Log(LogType type, LogEvent logEvent);
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.core/Logging/ILogger.cs.meta
+++ b/workers/unity/Packages/com.improbable.gdk.core/Logging/ILogger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8f7e646b076159f4f80f4e4d14bac5fb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/com.improbable.gdk.core/Logging/Logger.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Logging/Logger.cs
@@ -2,7 +2,7 @@ using UnityEngine;
 
 namespace Improbable.Gdk.Core
 {
-    class Logger : ILogger
+    public class Logger : ILogger
     {
         private readonly ILogDispatcher dispatcher;
         private readonly string loggerName;

--- a/workers/unity/Packages/com.improbable.gdk.core/Logging/Logger.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Logging/Logger.cs
@@ -1,0 +1,21 @@
+using UnityEngine;
+
+namespace Improbable.Gdk.Core
+{
+    class Logger : ILogger
+    {
+        private readonly ILogDispatcher dispatcher;
+        private readonly string loggerName;
+
+        public Logger(ILogDispatcher dispatcher, string loggerName)
+        {
+            this.dispatcher = dispatcher;
+            this.loggerName = loggerName;
+        }
+
+        public void Log(LogType type, LogEvent logEvent)
+        {
+            dispatcher.HandleLog(type, logEvent.WithField("LoggerName", loggerName));
+        }
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.core/Logging/Logger.cs.meta
+++ b/workers/unity/Packages/com.improbable.gdk.core/Logging/Logger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5ee4692f1e2efc84ba3dc9a744fd2e8d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/com.improbable.gdk.core/Logging/LoggingDispatcher.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Logging/LoggingDispatcher.cs
@@ -11,5 +11,10 @@ namespace Improbable.Gdk.Core
         {
             Debug.unityLogger.Log(type, logEvent);
         }
+
+        public ILogger GetLogger(string loggerName)
+        {
+            return new Logger(this, loggerName);
+        }
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.core/Logging/LoggingUtils.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Logging/LoggingUtils.cs
@@ -7,20 +7,18 @@ namespace Improbable.Gdk.Core
         public const string UnknownLogger = "UnknownLogger";
         public const string EntityId = "EntityId";
         public const string LoggerName = "LoggerName";
+        public const string Component = "Component";
 
         public static Collections.Option<EntityId> ExtractEntityId(Dictionary<string, object> data)
         {
-            object dataEntityId;
-            if (data.TryGetValue(EntityId, out dataEntityId))
+            if (data.TryGetValue(EntityId, out var dataEntityId))
             {
-                if (dataEntityId is EntityId)
+                switch (dataEntityId)
                 {
-                    return (EntityId)dataEntityId;
-                }
-
-                if (dataEntityId is long)
-                {
-                    return new EntityId((long)dataEntityId);
+                    case EntityId entityId:
+                        return entityId;
+                    case long id:
+                        return new EntityId(id);
                 }
             }
 
@@ -32,8 +30,7 @@ namespace Improbable.Gdk.Core
             if (data.ContainsKey(LoggerName))
             {
                 var loggerName = data[LoggerName];
-                var name = loggerName as string;
-                if (name != null)
+                if (loggerName is string name)
                 {
                     return name;
                 }

--- a/workers/unity/Packages/com.improbable.gdk.core/Systems/CleanReactiveComponentsSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Systems/CleanReactiveComponentsSystem.cs
@@ -33,13 +33,14 @@ namespace Improbable.Gdk.Core
             foreach (var translationUnit in view.TranslationUnits.Values)
             {
                 translationUnit.CleanUpComponentGroups = new List<ComponentGroup>();
-                foreach (ComponentType componentType in translationUnit.CleanUpComponentTypes)
+                foreach (var componentType in translationUnit.CleanUpComponentTypes)
                 {
-                    translationUnit.CleanUpComponentGroups.Add(GetComponentGroup(componentType));
+                    var componentGroup = GetComponentGroup(componentType);
+                    translationUnit.CleanUpComponentGroups.Add(componentGroup);
                 }
             }
 
-            MethodInfo addRemoveComponentActionMethod =
+            var addRemoveComponentActionMethod =
                 typeof(CleanReactiveComponentsSystem).GetMethod("AddRemoveComponentAction",
                     BindingFlags.NonPublic | BindingFlags.Instance);
 

--- a/workers/unity/Packages/com.improbable.gdk.core/Tests/Editmode/Components/OptionTests.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Tests/Editmode/Components/OptionTests.cs
@@ -181,7 +181,7 @@ namespace Improbable.Gdk.Core.EditmodeTests
             var option = new Option<bool>();
             Assert.Throws<CalledValueOnEmptyOptionException>(() =>
             {
-                bool value = option.Value;
+                var value = option.Value;
             });
         }
     }

--- a/workers/unity/Packages/com.improbable.gdk.core/Tests/Editmode/Config/LocatorConfigTests.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Tests/Editmode/Config/LocatorConfigTests.cs
@@ -87,10 +87,10 @@ namespace Improbable.Gdk.Core.EditmodeTests
         [Test]
         public void CreateConnectionConfigFromCommandLine_should_parse_correctly()
         {
-            string loginToken = "myToken";
-            string projectName = "myproject";
-            string host = "myhost";
-            string networkType = NetworkConnectionType.Tcp.ToString();
+            var loginToken = "myToken";
+            var projectName = "myproject";
+            var host = "myhost";
+            var networkType = NetworkConnectionType.Tcp.ToString();
 
             var parsedArgs = new Dictionary<string, string>
             {

--- a/workers/unity/Packages/com.improbable.gdk.core/Tests/Editmode/Config/ReceptionistConfigTests.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Tests/Editmode/Config/ReceptionistConfigTests.cs
@@ -43,9 +43,9 @@ namespace Improbable.Gdk.Core.EditmodeTests
         [Test]
         public void CreateConnectionConfigFromCommandLine_should_parse_correctly()
         {
-            string host = "myhost";
+            var host = "myhost";
             short port = 10;
-            string networkType = NetworkConnectionType.Tcp.ToString();
+            var networkType = NetworkConnectionType.Tcp.ToString();
 
             var parsedArgs = new Dictionary<string, string>
             {

--- a/workers/unity/Packages/com.improbable.gdk.core/Tests/Editmode/Utility/CommandLineUtilityTest.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Tests/Editmode/Utility/CommandLineUtilityTest.cs
@@ -6,7 +6,7 @@ namespace Improbable.Gdk.Core.EditmodeTests
     [TestFixture]
     public class CommandLineUtilityTest
     {
-        enum TestEnum
+        private enum TestEnum
         {
             Zero = 0,
             ValueOne,

--- a/workers/unity/Packages/com.improbable.gdk.core/Utility/BlittableBool.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Utility/BlittableBool.cs
@@ -33,7 +33,7 @@ namespace Improbable.Gdk.Core
                 return false;
             }
 
-            return obj is BlittableBool && Equals((BlittableBool) obj);
+            return obj is BlittableBool b && Equals(b);
         }
 
         public override int GetHashCode()

--- a/workers/unity/Packages/com.improbable.gdk.core/Utility/CommandLineUtility.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Utility/CommandLineUtility.cs
@@ -8,8 +8,7 @@ namespace Improbable.Gdk.Core
         public static T GetCommandLineValue<T>(Dictionary<string, string> commandLineDictionary, string configKey,
             T defaultValue)
         {
-            T configValue;
-            if (TryGetConfigValue(commandLineDictionary, configKey, out configValue))
+            if (TryGetConfigValue(commandLineDictionary, configKey, out T configValue))
             {
                 return configValue;
             }
@@ -31,9 +30,8 @@ namespace Improbable.Gdk.Core
 
         public static bool TryGetConfigValue<T>(Dictionary<string, string> dictionary, string configName, out T value)
         {
-            string strValue;
             var desiredType = typeof(T);
-            if (dictionary.TryGetValue(configName, out strValue))
+            if (dictionary.TryGetValue(configName, out var strValue))
             {
                 if (desiredType.IsEnum)
                 {

--- a/workers/unity/Packages/com.improbable.gdk.core/Utility/ConnectionUtility.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Utility/ConnectionUtility.cs
@@ -48,10 +48,8 @@ namespace Improbable.Gdk.Core
             {
                 return LocatorConfig.CreateConnectionConfigFromCommandLine(parsedArgs);
             }
-            else
-            {
-                return ReceptionistConfig.CreateConnectionConfigFromCommandLine(parsedArgs);
-            }
+
+            return ReceptionistConfig.CreateConnectionConfigFromCommandLine(parsedArgs);
         }
 
         private static ConnectionParameters CreateConnectionParameters(ConnectionConfig config, string workerType)

--- a/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerBase.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerBase.cs
@@ -51,18 +51,17 @@ namespace Improbable.Gdk.Core
 
         public virtual void Connect(ConnectionConfig config)
         {
-            if (config is ReceptionistConfig)
+            switch (config)
             {
-                Connection = ConnectionUtility.ConnectToSpatial((ReceptionistConfig) config, GetWorkerType, WorkerId);
-            }
-            else if (config is LocatorConfig)
-            {
-                Connection = ConnectionUtility.LocatorConnectToSpatial((LocatorConfig) config, GetWorkerType);
-            }
-            else
-            {
-                throw new InvalidConfigurationException($"Invalid connection config was provided: '{config}' Only" +
-                    "ReceptionistConfig and LocatorConfig are supported.");
+                case ReceptionistConfig receptionistConfig:
+                    Connection = ConnectionUtility.ConnectToSpatial(receptionistConfig, GetWorkerType, WorkerId);
+                    break;
+                case LocatorConfig locatorConfig:
+                    Connection = ConnectionUtility.LocatorConnectToSpatial(locatorConfig, GetWorkerType);
+                    break;
+                default:
+                    throw new InvalidConfigurationException($"Invalid connection config was provided: '{config}' Only" +
+                        "ReceptionistConfig and LocatorConfig are supported.");
             }
 
             Application.quitting += () =>

--- a/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerRegistry.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerRegistry.cs
@@ -27,9 +27,7 @@ namespace Improbable.Gdk.Core
 
         public static void UnsetWorkerForWorld(WorkerBase worker)
         {
-            WorkerBase workerForWorld;
-
-            if (WorldToWorker.TryGetValue(worker.World, out workerForWorld) && workerForWorld == worker)
+            if (WorldToWorker.TryGetValue(worker.World, out var workerForWorld) && workerForWorld == worker)
             {
                 WorldToWorker.Remove(worker.World);
             }
@@ -37,14 +35,13 @@ namespace Improbable.Gdk.Core
 
         public static WorkerBase GetWorkerForWorld(World world)
         {
-            WorkerBase worker;
-            WorldToWorker.TryGetValue(world, out worker);
+            WorldToWorker.TryGetValue(world, out var worker);
             return worker;
         }
 
         public static void RegisterWorkerType<T>() where T : WorkerBase
         {
-            string workerType = (string) typeof(T).GetField("WorkerType").GetValue(null);
+            var workerType = (string) typeof(T).GetField("WorkerType").GetValue(null);
             WorkerTypeToAttributeSet.Add(
                 typeof(T),
                 new WorkerAttributeSet(new Improbable.Collections.List<string> { workerType })
@@ -62,8 +59,7 @@ namespace Improbable.Gdk.Core
 
         public static WorkerBase CreateWorker(string workerType, string workerId, Vector3 origin)
         {
-            Func<string, Vector3, WorkerBase> createWorker;
-            if (!WorkerTypeToInitializationFunction.TryGetValue(workerType, out createWorker))
+            if (!WorkerTypeToInitializationFunction.TryGetValue(workerType, out var createWorker))
             {
                 throw new ArgumentException("No worker found for worker type '{0}'", workerType);
             }

--- a/workers/unity/Packages/com.improbable.gdk.testutils/HybridGdkSystemTestBase.cs
+++ b/workers/unity/Packages/com.improbable.gdk.testutils/HybridGdkSystemTestBase.cs
@@ -46,7 +46,8 @@ namespace Improbable.Gdk.TestUtils
 
         public static void CleanupAllInjectionHooks()
         {
-            var hooksFieldInfo = typeof(InjectionHookSupport).GetField("k_Hooks", BindingFlags.Static | BindingFlags.NonPublic);
+            var hooksFieldInfo =
+                typeof(InjectionHookSupport).GetField("k_Hooks", BindingFlags.Static | BindingFlags.NonPublic);
 
             var staticValue = hooksFieldInfo.GetValue(null);
 

--- a/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/LocalTransformSyncSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/LocalTransformSyncSystem.cs
@@ -61,7 +61,7 @@ namespace Improbable.Gdk.TransformSynchronization
                     var rotationDifference = UnityEngine.Quaternion.Angle(rigidbody.rotation, nativeRotation);
                     if (rotationDifference <= ToleranceAngle)
                     {
-                        var differencesGreaterThanZero = (positionDifference == 0.0f && rotationDifference == 0.0f);
+                        var differencesGreaterThanZero = positionDifference == 0.0f && rotationDifference == 0.0f;
                         if (differencesGreaterThanZero || tickSystem.GlobalTick - transform.Tick < MaxTicksUntilSync)
                         {
                             continue;

--- a/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/PositionSendSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/PositionSendSystem.cs
@@ -26,7 +26,7 @@ namespace Improbable.Gdk.TransformSynchronization
         {
             // Send update at SendRateHz.
             timeSinceLastSend += Time.deltaTime;
-            if (timeSinceLastSend < (1.0f / SendRateHz))
+            if (timeSinceLastSend < 1.0f / SendRateHz)
             {
                 return;
             }

--- a/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/TransformSendSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/TransformSendSystem.cs
@@ -26,7 +26,7 @@ namespace Improbable.Gdk.TransformSynchronization
         {
             // Send update at SendRateHz.
             timeSinceLastSend += Time.deltaTime;
-            if (timeSinceLastSend < (1.0f / SendRateHz))
+            if (timeSinceLastSend < 1.0f / SendRateHz)
             {
                 return;
             }

--- a/workers/unity/Packages/manifest.json
+++ b/workers/unity/Packages/manifest.json
@@ -5,10 +5,10 @@
     "com.improbable.gdk.playerlifecycle": "file:com.improbable.gdk.playerlifecycle",
     "com.improbable.gdk.testutils": "file:com.improbable.gdk.testutils",
     "com.improbable.gdk.transformsynchronization": "file:com.improbable.gdk.transformsynchronization",
-    "com.unity.burst": "0.2.4-preview.18",
+    "com.unity.burst": "0.2.4-preview.21",
     "com.unity.entities": "0.0.12-preview.8",
-    "com.unity.incrementalcompiler": "0.0.42-preview.14",
-    "com.unity.package-manager-ui": "1.9.9",
+    "com.unity.incrementalcompiler": "0.0.42-preview.16",
+    "com.unity.package-manager-ui": "1.9.11",
     "com.unity.modules.physics": "1.0.0",
     "com.unity.modules.ui": "1.0.0"
   },


### PR DESCRIPTION
#### Description
Refactor code to use the new C# 7 functionality unity provides
Small refactor on Logging to allow de-duplication of logger name everywhere.

#### Primary reviewers
@jamiebrynes7 @martinzlocha 