### PR TITLE
[Core C# SDK] UTY-718: Refactor Worker Registry

### DIFF
--- a/workers/unity/Assets/Playground/Config/PlayerTemplate.cs
+++ b/workers/unity/Assets/Playground/Config/PlayerTemplate.cs
@@ -1,18 +1,20 @@
 using System.Collections.Generic;
-using Improbable;
+using Generated.Improbable;
 using Improbable.Gdk.Core;
 using Improbable.Gdk.Legacy;
-using Improbable.Worker;
 
 namespace Playground
 {
     public static class PlayerTemplate
     {
-        private static readonly WorkerRequirementSet GameLogicSet =
-            WorkerRegistry.GetWorkerRequirementSet(typeof(UnityGameLogic));
+        private static readonly WorkerRequirementSet GameLogicSet = new WorkerRequirementSet
+        {
+              AttributeSet  = {UnityGameLogic.WorkerAttributeSet}
+        };
 
-        private static readonly WorkerRequirementSet AllWorkersSet =
-            WorkerRegistry.GetWorkerRequirementSet(typeof(UnityClient), typeof(UnityGameLogic));
+        private static readonly WorkerRequirementSet AllWorkerSet = new WorkerRequirementSet {
+            AttributeSet = { UnityGameLogic.WorkerAttributeSet, UnityClient.WorkerAttributeSet }
+        };
 
         public static Entity CreatePlayerEntityTemplate(List<string> clientAttributeSet,
             Generated.Improbable.Vector3f position)

--- a/workers/unity/Assets/Playground/Scripts/Workers/UnityClient.cs
+++ b/workers/unity/Assets/Playground/Scripts/Workers/UnityClient.cs
@@ -1,3 +1,4 @@
+using Generated.Improbable;
 using Improbable.Gdk.Core;
 using Improbable.Gdk.PlayerLifecycle;
 using Improbable.Gdk.TransformSynchronization;
@@ -12,6 +13,11 @@ namespace Playground
         public override string GetWorkerType => WorkerType;
 
         private readonly ForwardingDispatcher forwardingDispatcher;
+
+        public static readonly WorkerAttributeSet WorkerAttributeSet = new WorkerAttributeSet
+        {
+            Attribute = { "UnityClient" }
+        };
 
         public UnityClient(string workerId, Vector3 origin) : base(workerId, origin, new ForwardingDispatcher())
         {

--- a/workers/unity/Assets/Playground/Scripts/Workers/UnityGameLogic.cs
+++ b/workers/unity/Assets/Playground/Scripts/Workers/UnityGameLogic.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using Generated.Improbable;
 using Improbable.Gdk.Core;
 using Improbable.Gdk.PlayerLifecycle;
 using Improbable.Gdk.TransformSynchronization;
@@ -12,6 +14,11 @@ namespace Playground
         public override string GetWorkerType => WorkerType;
 
         private readonly ForwardingDispatcher forwardingDispatcher;
+
+        public static readonly WorkerAttributeSet WorkerAttributeSet = new WorkerAttributeSet
+        {
+            Attribute = { "UnityGameLogic" }
+        };
 
         public UnityGameLogic(string workerId, Vector3 origin) : base(workerId, origin, new ForwardingDispatcher())
         {

--- a/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerRegistry.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerRegistry.cs
@@ -12,9 +12,6 @@ namespace Improbable.Gdk.Core
         private static readonly Dictionary<string, Func<string, Vector3, WorkerBase>> WorkerTypeToInitializationFunction
             = new Dictionary<string, Func<string, Vector3, WorkerBase>>();
 
-        private static readonly Dictionary<Type, WorkerAttributeSet> WorkerTypeToAttributeSet =
-            new Dictionary<Type, WorkerAttributeSet>();
-
         public static void SetWorkerForWorld(WorkerBase worker)
         {
             if (WorldToWorker.ContainsKey(worker.World))
@@ -45,10 +42,6 @@ namespace Improbable.Gdk.Core
         public static void RegisterWorkerType<T>() where T : WorkerBase
         {
             string workerType = (string) typeof(T).GetField("WorkerType").GetValue(null);
-            WorkerTypeToAttributeSet.Add(
-                typeof(T),
-                new WorkerAttributeSet(new Improbable.Collections.List<string> { workerType })
-            );
 
             WorkerTypeToInitializationFunction.Add(workerType, CreateWorker<T>);
         }
@@ -69,18 +62,6 @@ namespace Improbable.Gdk.Core
             }
 
             return createWorker(workerId, origin);
-        }
-
-        public static WorkerRequirementSet GetWorkerRequirementSet(Type workerType, params Type[] workerTypes)
-        {
-            var workerAttributes = new Improbable.Collections.List<WorkerAttributeSet>();
-            workerAttributes.Add(WorkerTypeToAttributeSet[workerType]);
-            foreach (var nextType in workerTypes)
-            {
-                workerAttributes.Add(WorkerTypeToAttributeSet[nextType]);
-            }
-
-            return new WorkerRequirementSet(workerAttributes);
         }
     }
 }


### PR DESCRIPTION
#### Description
Small refactor to get the Core module to compile. Can't use `WorkerAttributeSet` and `WorkerRequirementsSet` as these are C# SDK generated code. 

Each work owns its own "layer" and any usage of the requirement sets are refactored to use that.

#### Tests
Core compiles
#### Documentation
N/A
#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.