### PR TITLE
UTY-792 Implement stubs for the reader classes

### DIFF
--- a/code_generator/GdkCodeGenerator/Templates/UnityComponentDataGenerator.tt
+++ b/code_generator/GdkCodeGenerator/Templates/UnityComponentDataGenerator.tt
@@ -9,6 +9,9 @@
 
 using Unity.Entities;
 using Improbable.Gdk.Core;
+using Improbable.Gdk.Core.MonoBehaviours;
+using Improbable.Worker;
+using Entity = Unity.Entities.Entity;
 
 namespace <#= qualifiedNamespace #>
 { 
@@ -38,5 +41,32 @@ namespace <#= qualifiedNamespace #>
 <# } #>
         }
 <# } #>
+
+        public class Reader : IReaderInternal
+        {
+            public Reader(Entity entity, EntityManager entityManager, ILogDispatcher logDispatcher)
+            {
+            }
+
+            void IReaderInternal.OnAuthorityChange(Authority authority)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            void IReaderInternal.OnComponentUpdate()
+            {
+                throw new System.NotImplementedException();
+            }
+            
+            void IReaderInternal.OnEvent(int eventIndex)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            void IReaderInternal.OnCommandRequest(int commandIndex)
+            {
+                throw new System.NotImplementedException();
+            }
+        }
     }
 }

--- a/code_generator/GdkCodeGenerator/Templates/UnityComponentGenerator.tt
+++ b/code_generator/GdkCodeGenerator/Templates/UnityComponentGenerator.tt
@@ -8,7 +8,11 @@
 <#= generatedHeader #>
 
 using UnityEngine;
+using Unity.Entities;
 using Improbable.Gdk.Core;
+using Improbable.Gdk.Core.MonoBehaviours;
+using Improbable.Worker;
+using Entity = Unity.Entities.Entity;
 
 namespace <#= qualifiedNamespace #>
 { 
@@ -38,5 +42,32 @@ namespace <#= qualifiedNamespace #>
 <# } #>
         }
 <# } #>
+
+        public class Reader : IReaderInternal
+        {
+            public Reader(Entity entity, EntityManager entityManager, ILogDispatcher logDispatcher)
+            {
+            }
+
+            void IReaderInternal.OnAuthorityChange(Authority authority)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            void IReaderInternal.OnComponentUpdate()
+            {
+                throw new System.NotImplementedException();
+            }
+            
+            void IReaderInternal.OnEvent(int eventIndex)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            void IReaderInternal.OnCommandRequest(int commandIndex)
+            {
+                throw new System.NotImplementedException();
+            }
+        }
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.core/AssemblyInfo.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/AssemblyInfo.cs
@@ -1,0 +1,1 @@
+﻿[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Improbable.Gdk.Generated")]


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
UTY-792

This unblocks reader/writer registration for components and acts as a base for their constructor signatures.

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.