### PR TITLE
Move Monobehaviour features to the Core.Monobehaviours namespace

### DIFF
--- a/workers/unity/Assets/Playground/Scripts/EntityInitialization/GameObjectInitializationSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/EntityInitialization/GameObjectInitializationSystem.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using Generated.Improbable.Transform;
 using Generated.Playground;
 using Improbable.Gdk.Core;
+using Improbable.Gdk.Core.MonoBehaviours;
 using Unity.Collections;
 using Unity.Entities;
 using UnityEngine;

--- a/workers/unity/Assets/Playground/Scripts/Player/PlayerCommandsSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/Player/PlayerCommandsSystem.cs
@@ -2,6 +2,7 @@ using System;
 using Generated.Improbable;
 using Generated.Playground;
 using Improbable.Gdk.Core;
+using Improbable.Gdk.Core.MonoBehaviours;
 using Playground.Scripts.UI;
 using Unity.Collections;
 using Unity.Entities;

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/ComponentIdAttribute.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/ComponentIdAttribute.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Improbable.Gdk.Core
+namespace Improbable.Gdk.Core.MonoBehaviours
 {
     /// <summary>
     ///     Associates a unique component Id with a specific interface.

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/Delegates.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/Delegates.cs
@@ -1,7 +1,7 @@
 ﻿using Improbable.Worker;
 using Unity.Entities;
 
-namespace Improbable.Gdk.Core
+namespace Improbable.Gdk.Core.MonoBehaviours
 {
     public static class GameObjectDelegates
     {

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/EntityGameObjectLinker.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/EntityGameObjectLinker.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using Unity.Entities;
 using UnityEngine;
 
-namespace Improbable.Gdk.Core
+namespace Improbable.Gdk.Core.MonoBehaviours
 {
     public class EntityGameObjectLinker
     {

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/GameObjectComponentDispatcherBase.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/GameObjectComponentDispatcherBase.cs
@@ -1,8 +1,8 @@
 using Unity.Entities;
 
-namespace Improbable.Gdk.Core
+namespace Improbable.Gdk.Core.MonoBehaviours
 {
-    public abstract class GameObjectComponentDispatcherBase
+    internal abstract class GameObjectComponentDispatcherBase
     {
         public abstract ComponentType[] ComponentAddedComponentTypes { get; }
         public ComponentGroup ComponentAddedComponentGroup { get; set; }

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/GameObjectDispatcherSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/GameObjectDispatcherSystem.cs
@@ -3,13 +3,13 @@ using System.Collections.Generic;
 using System.Linq;
 using Unity.Entities;
 
-namespace Improbable.Gdk.Core
+namespace Improbable.Gdk.Core.MonoBehaviours
 {
     /// <summary>
     ///     Gathers incoming dispatcher ops and invokes callbacks on relevant GameObjects.
     /// </summary>
     [UpdateInGroup(typeof(SpatialOSReceiveGroup.GameObjectReceiveGroup))]
-    public class GameObjectDispatcherSystem : ComponentSystem
+    internal class GameObjectDispatcherSystem : ComponentSystem
     {
         private readonly Dictionary<int, SpatialOSBehaviourManager> entityIndexToSpatialOSBehaviourManager =
             new Dictionary<int, SpatialOSBehaviourManager>();

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/GameObjectReference.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/GameObjectReference.cs
@@ -1,6 +1,6 @@
 using UnityEngine;
 
-namespace Improbable.Gdk.Core
+namespace Improbable.Gdk.Core.MonoBehaviours
 {
     /// <summary>
     ///     Stores a reference to the GameObject representing an entity.

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/GameObjectReferenceHandle.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/GameObjectReferenceHandle.cs
@@ -1,6 +1,6 @@
 using Unity.Entities;
 
-namespace Improbable.Gdk.Core
+namespace Improbable.Gdk.Core.MonoBehaviours
 {
     public struct GameObjectReferenceHandle : ISystemStateComponentData
     {

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/ReaderInterfaceAttribute.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/ReaderInterfaceAttribute.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Improbable.Gdk.Core
+namespace Improbable.Gdk.Core.MonoBehaviours
 {
     /// <summary>
     ///     Marks an interface as a SpatialOS Component Reader Interface.

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/ReaderWriterFactory.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/ReaderWriterFactory.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Improbable.Gdk.Core
+namespace Improbable.Gdk.Core.MonoBehaviours
 {
     public static class ReaderWriterFactory
     {

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/RequireAttribute.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/RequireAttribute.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Improbable.Gdk.Core
+namespace Improbable.Gdk.Core.MonoBehaviours
 {
     /// <summary>
     ///     Marks fields of MonoBehaviours that require a Reader or Writer to be injected into them.

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/RequiresSpatialOSBehaviourManager.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/RequiresSpatialOSBehaviourManager.cs
@@ -1,6 +1,6 @@
 using Unity.Entities;
 
-namespace Improbable.Gdk.Core
+namespace Improbable.Gdk.Core.MonoBehaviours
 {
     /// <summary>
     ///     Tag component for marking entities that require a RequiresSpatialOSBehaviourManager.

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/SpatialOSBehaviourLibrary.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/SpatialOSBehaviourLibrary.cs
@@ -4,7 +4,7 @@ using System.Reflection;
 using Unity.Entities;
 using UnityEngine;
 
-namespace Improbable.Gdk.Core
+namespace Improbable.Gdk.Core.MonoBehaviours
 {
     /// <summary>
     ///     Retrieves Reader and Writer fields from MonoBehaviours and handles injection into them.
@@ -186,7 +186,7 @@ namespace Improbable.Gdk.Core
                     fields.Add(field);
                 }
             }
-            
+
             return fields;
         }
     }

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/SpatialOSBehaviourManager.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/SpatialOSBehaviourManager.cs
@@ -2,17 +2,13 @@ using System.Collections.Generic;
 using Improbable.Worker;
 using UnityEngine;
 
-namespace Improbable.Gdk.Core
+namespace Improbable.Gdk.Core.MonoBehaviours
 {
-    public class ReaderWriterImpl
-    {
-        // This is placeholder code.
-    }
 
     /// <summary>
     ///     Invokes dispatcher callbacks on GameObjects that represent entities.
     /// </summary>
-    public class SpatialOSBehaviourManager
+    internal class SpatialOSBehaviourManager
     {
         public GameObject GameObject;
         private Dictionary<uint, List<MonoBehaviour>> componentIdToReaderSpatialOSBehaviours;
@@ -20,14 +16,14 @@ namespace Improbable.Gdk.Core
         private Dictionary<MonoBehaviour, int> numUnsatisfiedComponents;
         private List<MonoBehaviour> spatialOSBehavioursToEnable;
         private List<MonoBehaviour> spatialOSBehavioursToDisable;
-        private Dictionary<uint, Dictionary<MonoBehaviour, ReaderWriterImpl>> readersWriters;
+        private Dictionary<uint, Dictionary<MonoBehaviour, IReaderInternal>> readersWriters;
 
         public SpatialOSBehaviourManager(GameObject gameObject)
         {
             // Setup caches
         }
 
-        public List<ReaderWriterImpl> GetReadersWriters(uint componentId)
+        public List<IReaderInternal> GetReadersWriters(uint componentId)
         {
             return null;
         }

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/SpatialOSBehaviourManagerInitializationSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/SpatialOSBehaviourManagerInitializationSystem.cs
@@ -1,7 +1,7 @@
 using Unity.Collections;
 using Unity.Entities;
 
-namespace Improbable.Gdk.Core
+namespace Improbable.Gdk.Core.MonoBehaviours
 {
     /// <summary>
     ///     Creates and removes SpatialOSBehaviourManager object for EntityGameObjects.

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/SpatialOSComponent.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/SpatialOSComponent.cs
@@ -1,7 +1,7 @@
 using Unity.Entities;
 using UnityEngine;
 
-namespace Improbable.Gdk.Core
+namespace Improbable.Gdk.Core.MonoBehaviours
 {
     public class SpatialOSComponent : MonoBehaviour
     {

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/WriterInterfaceAttribute.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/WriterInterfaceAttribute.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Improbable.Gdk.Core
+namespace Improbable.Gdk.Core.MonoBehaviours
 {
     /// <summary>
     ///     Marks an interface as a SpatialOS Component Writer interface.

--- a/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerBase.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerBase.cs
@@ -1,4 +1,5 @@
 using System;
+using Improbable.Gdk.Core.MonoBehaviours;
 using Improbable.Worker;
 using Unity.Entities;
 using UnityEngine;


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Just moved everything involving Monobehaviours from the Improbable.Gdk.Core namespace to Improbable.Gdk.Core.Monobehaviours. Also replaced the placeholder ReaderWriterImpl with the actual type, IReaderInternal, and made a few classes internal so that no public method on a public class returned it.

#### Tests
Not relevant
#### Documentation
Not relevant
#### Primary reviewers
@JonasImprobable 