### PR TITLE
UTY-473: Fix Dotnet Path for Mac TC Agents

### DIFF
--- a/ci/includes/pinned-tools.sh
+++ b/ci/includes/pinned-tools.sh
@@ -23,6 +23,13 @@ function cleanUnity() {
 }
 
 
+# Ensure for the Mac TC agents that dotnet is on the path.
+if isMacOS; then
+  if ! which dotnet; then
+    export PATH="${PATH}:/usr/local/share/dotnet/"
+  fi
+fi
+
 # Print the .NETCore version to aid debugging,
 # as well as ensuring that later calls to the tool don't print the welcome message on first run.
 dotnet --version


### PR DESCRIPTION
#### Description
Paths are borked on the mac TC agents. We know exactly where dotnet is though.
#### Tests
Ran the CI build step. Dotnet actually ran but the build failed for other reasons (similar to Mac crashes I imagine)
#### Documentation
N/A
#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.