### PR TITLE
UTY-831: Draw playground cubes in batches

### DIFF
--- a/workers/unity/Assets/Playground/Scripts/Cubes/ProcessColorChangeSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/Cubes/ProcessColorChangeSystem.cs
@@ -42,10 +42,8 @@ namespace Playground
                 var renderer = data.Renderers[i];
                 foreach (var colorEvent in component.Buffer)
                 {
-                    if (materialPropertyBlocks.TryGetValue(colorEvent.Payload.Color, out var materialPropertyBlock))
-                    {
-                        renderer.SetPropertyBlock(materialPropertyBlock);
-                    }
+                    var materialPropertyBlock = materialPropertyBlocks[colorEvent.Payload.Color];
+                    renderer.SetPropertyBlock(materialPropertyBlock);
                 }
             }
         }

--- a/workers/unity/Assets/Playground/Scripts/Cubes/ProcessColorChangeSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/Cubes/ProcessColorChangeSystem.cs
@@ -25,8 +25,8 @@ namespace Playground
             public ComponentArray<MeshRenderer> Renderers;
         }
 
-        private Dictionary<Generated.Playground.Color, MaterialPropertyBlock> materialPropertyBlocks;
         [Inject] private Data data;
+        private Dictionary<Generated.Playground.Color, MaterialPropertyBlock> materialPropertyBlocks;
 
         protected override void OnCreateManager(int capacity)
         {


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Cube colour change is now done with predetermined MaterialPropertyBlocks, allowing them to be drawn in batches and improving rendering performance.
#### Tests
How did you test these changes prior to submitting this pull request?
What automated tests are included in this PR?
#### Documentation
How is this documented (for example: release note, upgrade guide, feature page, in-code documentation)?
#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.