### PR TITLE
UTY-589: Invoking callbacks on the readers

### DIFF
--- a/code_generator/GdkCodeGenerator/Templates/UnityGameObjectComponentDispatcherGenerator.tt
+++ b/code_generator/GdkCodeGenerator/Templates/UnityGameObjectComponentDispatcherGenerator.tt
@@ -20,58 +20,106 @@ namespace <#= qualifiedNamespace #>
         {
             public override ComponentType[] ComponentAddedComponentTypes => new ComponentType[]
             {
-                typeof(ComponentAdded<<#= componentDetails.TypeName #>>), typeof(GameObjectReference)
+                ComponentType.ReadOnly<ComponentAdded<<#= componentDetails.TypeName #>>>(), ComponentType.ReadOnly<GameObjectReference>()
             };
 
             public override ComponentType[] ComponentRemovedComponentTypes => new ComponentType[]
             {
-                typeof(ComponentRemoved<<#= componentDetails.TypeName #>>), typeof(GameObjectReference)
+                ComponentType.ReadOnly<ComponentRemoved<<#= componentDetails.TypeName #>>>(), ComponentType.ReadOnly<GameObjectReference>()
             };
 
             public override ComponentType[] AuthoritiesChangedComponentTypes => new ComponentType[]
             {
-                typeof(AuthoritiesChanged<<#= componentDetails.TypeName #>>), typeof(GameObjectReference)
+                ComponentType.ReadOnly<AuthoritiesChanged<<#= componentDetails.TypeName #>>>(), ComponentType.ReadOnly<GameObjectReference>()
             };
 
             public override ComponentType[] ComponentsUpdatedComponentTypes => new ComponentType[]
             {
 <# if (fieldDetailsList.Count > 0) { #>
-                typeof(ComponentsUpdated<<#= componentDetails.TypeName #>.Update>), typeof(GameObjectReference)
+                ComponentType.ReadOnly<ComponentsUpdated<<#= componentDetails.TypeName #>.Update>>(), ComponentType.ReadOnly<GameObjectReference>()
 <# } #>
             };
 
             public override ComponentType[][] EventsReceivedComponentTypeArrays => new ComponentType[][]
             {
 <# foreach(var eventDetails in eventDetailsList) { #>
-                new ComponentType[] { typeof(EventsReceived<<#= eventDetails.EventName #>Event>), typeof(GameObjectReference) },
+                new ComponentType[] { ComponentType.ReadOnly<EventsReceived<<#= eventDetails.EventName #>Event>>(), ComponentType.ReadOnly<GameObjectReference>() },
 <# } #>
             };
 
             public override ComponentType[][] CommandRequestsComponentTypeArrays => new ComponentType[][]
             {
 <# foreach(var commandDetails in commandDetailsList) { #>
-                new ComponentType[] { typeof(CommandRequests<<#= commandDetails.CommandName #>.Request>), typeof(GameObjectReference) },
+                new ComponentType[] { ComponentType.ReadOnly<CommandRequests<<#= commandDetails.CommandName #>.Request>>(), ComponentType.ReadOnly<GameObjectReference>() },
 <# } #>
             };
 
-            public override void InvokeOnAddComponentLifecycleCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
+            protected override uint getComponentId()
             {
-                var entities = ComponentAddedComponentGroup.GetEntityArray();
-                for (var i = 0; i < entities.Length; i++)
-                {
-                    var spatialOSBehaviourManager = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index);
-                    spatialOSBehaviourManager.AddComponent(<#= unityComponentDefinition.Id #>);
-                }
+                return <#= unityComponentDefinition.Id #>;
             }
 
-            public override void InvokeOnRemoveComponentLifecycleCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
+            public override void InvokeOnComponentUpdateUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
             {
-                var entities = ComponentRemovedComponentGroup.GetEntityArray();
+<# if (fieldDetailsList.Count > 0) { #>
+                var entities = ComponentsUpdatedComponentGroup.GetEntityArray();
+                var updateLists = ComponentsUpdatedComponentGroup.GetComponentArray<ComponentsUpdated<<#= componentDetails.TypeName #>.Update>();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var spatialOSBehaviourManager = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index);
-                    spatialOSBehaviourManager.RemoveComponent(<#= unityComponentDefinition.Id #>);
+                    var readers = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index)
+                        .GetReadersWriters(getComponentId());
+                    var updateList = updateLists[i];
+                    foreach (var reader in readers)
+                    {
+                        foreach (var update in updateList.Buffer)
+                        {
+                            ((<#= componentDetails.TypeName #>.ReaderWriterImpl) reader).OnComponentUpdate(update);
+                        }
+                    }
                 }
+<# } #>
+            }
+
+            public override void InvokeOnEventUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
+            {
+<# for (var i = 0; i < eventDetailsList.Count; i++) { #>
+                var entities = EventsReceivedComponentGroups[<#= i #>].GetEntityArray();
+                var eventLists = EventsReceivedComponentGroups[<#= i #>].GetComponentArray<EventsReceived<<#= eventDetailsList[i].EventName #>Event>>();
+                for (var i = 0; i < entities.Length; i++)
+                {
+                    var readers = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index)
+                        .GetReadersWriters(getComponentId());
+                    var eventList = eventLists[i];
+                    foreach (var reader in readers)
+                    {
+                        foreach (var e in eventList.Buffer)
+                        {
+                            ((<#= componentDetails.TypeName #>.ReaderWriterImpl) reader).OnEvent(<#= i #>, e);
+                        }
+                    }
+                }
+<# } #>
+            }
+
+            public override void InvokeOnCommandRequestUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
+            {
+<# for (var i = 0; i < commandDetailsList.Count; i++) { #>
+                var entities = CommandRequestsComponentGroups[<#= i #>].GetEntityArray();
+                var commandLists = CommandRequestsComponentGroups[<#= i #>].GetComponentArray<CommandRequests<<#= commandDetailsList[i].CommandName #>.Request>();
+                for (var i = 0; i < entities.Length; i++)
+                {
+                    var readers = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index)
+                        .GetReadersWriters(getComponentId());
+                    var commandList = commandLists[i];
+                    foreach (var reader in readers)
+                    {
+                        foreach (var req in commandList.Buffer)
+                        {
+                            ((<#= componentDetails.TypeName #>.ReaderWriterImpl) reader).OnCommandRequest(<#= i #>, req);
+                        }
+                    }
+                }
+<# } #>
             }
 
             public override void InvokeOnAuthorityChangeLifecycleCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
@@ -90,18 +138,21 @@ namespace <#= qualifiedNamespace #>
 
             public override void InvokeOnAuthorityChangeUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
             {
-            }
-
-            public override void InvokeOnComponentUpdateUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
-            {
-            }
-
-            public override void InvokeOnEventUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
-            {
-            }
-
-            public override void InvokeOnCommandRequestUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
-            {
+                var entities = AuthoritiesChangedComponentGroup.GetEntityArray();
+                var authChangeLists = AuthoritiesChangedComponentGroup.GetComponentArray<AuthoritiesChanged<<#= componentDetails.TypeName #>>>();
+                for (var i = 0; i < entities.Length; i++)
+                {
+                    var readers = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index)
+                        .GetReadersWriters(getComponentId());
+                    var authChanges = authChangeLists[i];
+                    foreach (var reader in readers)
+                    {
+                        foreach (var auth in authChanges.Buffer)
+                        {
+                            ((<#= componentDetails.TypeName #>.ReaderWriterImpl) reader).OnAuthorityChange(auth);
+                        }
+                    }
+                }
             }
         }
     }

--- a/code_generator/GdkCodeGenerator/Templates/UnityGameObjectComponentDispatcherGenerator.tt
+++ b/code_generator/GdkCodeGenerator/Templates/UnityGameObjectComponentDispatcherGenerator.tt
@@ -54,7 +54,7 @@ namespace <#= qualifiedNamespace #>
 <# } #>
             };
 
-            protected override uint getComponentId()
+            protected override uint GetComponentId()
             {
                 return <#= unityComponentDefinition.Id #>;
             }
@@ -63,11 +63,11 @@ namespace <#= qualifiedNamespace #>
             {
 <# if (fieldDetailsList.Count > 0) { #>
                 var entities = ComponentsUpdatedComponentGroup.GetEntityArray();
-                var updateLists = ComponentsUpdatedComponentGroup.GetComponentArray<ComponentsUpdated<<#= componentDetails.TypeName #>.Update>();
+                var updateLists = ComponentsUpdatedComponentGroup.GetComponentArray<ComponentsUpdated<<#= componentDetails.TypeName #>.Update>>();
                 for (var i = 0; i < entities.Length; i++)
                 {
                     var readers = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index)
-                        .GetReadersWriters(getComponentId());
+                        .GetReadersWriters(<#= unityComponentDefinition.Id #>);
                     var updateList = updateLists[i];
                     foreach (var reader in readers)
                     {
@@ -82,19 +82,19 @@ namespace <#= qualifiedNamespace #>
 
             public override void InvokeOnEventUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
             {
-<# for (var i = 0; i < eventDetailsList.Count; i++) { #>
-                var entities = EventsReceivedComponentGroups[<#= i #>].GetEntityArray();
-                var eventLists = EventsReceivedComponentGroups[<#= i #>].GetComponentArray<EventsReceived<<#= eventDetailsList[i].EventName #>Event>>();
+<# for (var j = 0; j < eventDetailsList.Count; j++) { #>
+                var entities = EventsReceivedComponentGroups[<#= j #>].GetEntityArray();
+                var eventLists = EventsReceivedComponentGroups[<#= j #>].GetComponentArray<EventsReceived<<#= eventDetailsList[j].EventName #>Event>>();
                 for (var i = 0; i < entities.Length; i++)
                 {
                     var readers = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index)
-                        .GetReadersWriters(getComponentId());
+                        .GetReadersWriters(<#= unityComponentDefinition.Id #>);
                     var eventList = eventLists[i];
                     foreach (var reader in readers)
                     {
                         foreach (var e in eventList.Buffer)
                         {
-                            ((<#= componentDetails.TypeName #>.ReaderWriterImpl) reader).OnEvent(<#= i #>, e);
+                            ((<#= componentDetails.TypeName #>.ReaderWriterImpl) reader).On<#= eventDetailsList[j].EventName #>Event(e);
                         }
                     }
                 }
@@ -103,19 +103,19 @@ namespace <#= qualifiedNamespace #>
 
             public override void InvokeOnCommandRequestUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
             {
-<# for (var i = 0; i < commandDetailsList.Count; i++) { #>
-                var entities = CommandRequestsComponentGroups[<#= i #>].GetEntityArray();
-                var commandLists = CommandRequestsComponentGroups[<#= i #>].GetComponentArray<CommandRequests<<#= commandDetailsList[i].CommandName #>.Request>();
+<# for (var j = 0; j < commandDetailsList.Count; j++) { #>
+                var entities = CommandRequestsComponentGroups[<#= j #>].GetEntityArray();
+                var commandLists = CommandRequestsComponentGroups[<#= j #>].GetComponentArray<CommandRequests<<#= commandDetailsList[j].CommandName #>.Request>();
                 for (var i = 0; i < entities.Length; i++)
                 {
                     var readers = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index)
-                        .GetReadersWriters(getComponentId());
+                        .GetReadersWriters(<#= unityComponentDefinition.Id #>);
                     var commandList = commandLists[i];
                     foreach (var reader in readers)
                     {
                         foreach (var req in commandList.Buffer)
                         {
-                            ((<#= componentDetails.TypeName #>.ReaderWriterImpl) reader).OnCommandRequest(<#= i #>, req);
+                            ((<#= componentDetails.TypeName #>.ReaderWriterImpl) reader).On<#= commandDetailsList[j].CommandName #>CommandRequest(req);
                         }
                     }
                 }
@@ -143,7 +143,7 @@ namespace <#= qualifiedNamespace #>
                 for (var i = 0; i < entities.Length; i++)
                 {
                     var readers = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index)
-                        .GetReadersWriters(getComponentId());
+                        .GetReadersWriters(<#= unityComponentDefinition.Id #>);
                     var authChanges = authChangeLists[i];
                     foreach (var reader in readers)
                     {

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveBlittableSingularGameObjectComponentDispatcher.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveBlittableSingularGameObjectComponentDispatcher.cs
@@ -13,22 +13,22 @@ namespace Generated.Improbable.Gdk.Tests
         {
             public override ComponentType[] ComponentAddedComponentTypes => new ComponentType[]
             {
-                typeof(ComponentAdded<SpatialOSExhaustiveBlittableSingular>), typeof(GameObjectReference)
+                ComponentType.ReadOnly<ComponentAdded<SpatialOSExhaustiveBlittableSingular>>(), ComponentType.ReadOnly<GameObjectReference>()
             };
 
             public override ComponentType[] ComponentRemovedComponentTypes => new ComponentType[]
             {
-                typeof(ComponentRemoved<SpatialOSExhaustiveBlittableSingular>), typeof(GameObjectReference)
+                ComponentType.ReadOnly<ComponentRemoved<SpatialOSExhaustiveBlittableSingular>>(), ComponentType.ReadOnly<GameObjectReference>()
             };
 
             public override ComponentType[] AuthoritiesChangedComponentTypes => new ComponentType[]
             {
-                typeof(AuthoritiesChanged<SpatialOSExhaustiveBlittableSingular>), typeof(GameObjectReference)
+                ComponentType.ReadOnly<AuthoritiesChanged<SpatialOSExhaustiveBlittableSingular>>(), ComponentType.ReadOnly<GameObjectReference>()
             };
 
             public override ComponentType[] ComponentsUpdatedComponentTypes => new ComponentType[]
             {
-                typeof(ComponentsUpdated<SpatialOSExhaustiveBlittableSingular.Update>), typeof(GameObjectReference)
+                ComponentType.ReadOnly<ComponentsUpdated<SpatialOSExhaustiveBlittableSingular.Update>>(), ComponentType.ReadOnly<GameObjectReference>()
             };
 
             public override ComponentType[][] EventsReceivedComponentTypeArrays => new ComponentType[][]
@@ -39,24 +39,36 @@ namespace Generated.Improbable.Gdk.Tests
             {
             };
 
-            public override void InvokeOnAddComponentLifecycleCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
+            protected override uint getComponentId()
             {
-                var entities = ComponentAddedComponentGroup.GetEntityArray();
+                return 197720;
+            }
+
+            public override void InvokeOnComponentUpdateUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
+            {
+                var entities = ComponentsUpdatedComponentGroup.GetEntityArray();
+                var updateLists = ComponentsUpdatedComponentGroup.GetComponentArray<ComponentsUpdated<SpatialOSExhaustiveBlittableSingular.Update>();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var spatialOSBehaviourManager = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index);
-                    spatialOSBehaviourManager.AddComponent(197720);
+                    var readers = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index)
+                        .GetReadersWriters(getComponentId());
+                    var updateList = updateLists[i];
+                    foreach (var reader in readers)
+                    {
+                        foreach (var update in updateList.Buffer)
+                        {
+                            ((SpatialOSExhaustiveBlittableSingular.ReaderWriterImpl) reader).OnComponentUpdate(update);
+                        }
+                    }
                 }
             }
 
-            public override void InvokeOnRemoveComponentLifecycleCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
+            public override void InvokeOnEventUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
             {
-                var entities = ComponentRemovedComponentGroup.GetEntityArray();
-                for (var i = 0; i < entities.Length; i++)
-                {
-                    var spatialOSBehaviourManager = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index);
-                    spatialOSBehaviourManager.RemoveComponent(197720);
-                }
+            }
+
+            public override void InvokeOnCommandRequestUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
+            {
             }
 
             public override void InvokeOnAuthorityChangeLifecycleCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
@@ -75,18 +87,21 @@ namespace Generated.Improbable.Gdk.Tests
 
             public override void InvokeOnAuthorityChangeUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
             {
-            }
-
-            public override void InvokeOnComponentUpdateUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
-            {
-            }
-
-            public override void InvokeOnEventUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
-            {
-            }
-
-            public override void InvokeOnCommandRequestUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
-            {
+                var entities = AuthoritiesChangedComponentGroup.GetEntityArray();
+                var authChangeLists = AuthoritiesChangedComponentGroup.GetComponentArray<AuthoritiesChanged<SpatialOSExhaustiveBlittableSingular>>();
+                for (var i = 0; i < entities.Length; i++)
+                {
+                    var readers = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index)
+                        .GetReadersWriters(getComponentId());
+                    var authChanges = authChangeLists[i];
+                    foreach (var reader in readers)
+                    {
+                        foreach (var auth in authChanges.Buffer)
+                        {
+                            ((SpatialOSExhaustiveBlittableSingular.ReaderWriterImpl) reader).OnAuthorityChange(auth);
+                        }
+                    }
+                }
             }
         }
     }

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveBlittableSingularGameObjectComponentDispatcher.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveBlittableSingularGameObjectComponentDispatcher.cs
@@ -39,7 +39,7 @@ namespace Generated.Improbable.Gdk.Tests
             {
             };
 
-            protected override uint getComponentId()
+            protected override uint GetComponentId()
             {
                 return 197720;
             }
@@ -47,11 +47,11 @@ namespace Generated.Improbable.Gdk.Tests
             public override void InvokeOnComponentUpdateUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
             {
                 var entities = ComponentsUpdatedComponentGroup.GetEntityArray();
-                var updateLists = ComponentsUpdatedComponentGroup.GetComponentArray<ComponentsUpdated<SpatialOSExhaustiveBlittableSingular.Update>();
+                var updateLists = ComponentsUpdatedComponentGroup.GetComponentArray<ComponentsUpdated<SpatialOSExhaustiveBlittableSingular.Update>>();
                 for (var i = 0; i < entities.Length; i++)
                 {
                     var readers = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index)
-                        .GetReadersWriters(getComponentId());
+                        .GetReadersWriters(197720);
                     var updateList = updateLists[i];
                     foreach (var reader in readers)
                     {
@@ -92,7 +92,7 @@ namespace Generated.Improbable.Gdk.Tests
                 for (var i = 0; i < entities.Length; i++)
                 {
                     var readers = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index)
-                        .GetReadersWriters(getComponentId());
+                        .GetReadersWriters(197720);
                     var authChanges = authChangeLists[i];
                     foreach (var reader in readers)
                     {

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKeyGameObjectComponentDispatcher.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKeyGameObjectComponentDispatcher.cs
@@ -39,7 +39,7 @@ namespace Generated.Improbable.Gdk.Tests
             {
             };
 
-            protected override uint getComponentId()
+            protected override uint GetComponentId()
             {
                 return 197719;
             }
@@ -47,11 +47,11 @@ namespace Generated.Improbable.Gdk.Tests
             public override void InvokeOnComponentUpdateUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
             {
                 var entities = ComponentsUpdatedComponentGroup.GetEntityArray();
-                var updateLists = ComponentsUpdatedComponentGroup.GetComponentArray<ComponentsUpdated<SpatialOSExhaustiveMapKey.Update>();
+                var updateLists = ComponentsUpdatedComponentGroup.GetComponentArray<ComponentsUpdated<SpatialOSExhaustiveMapKey.Update>>();
                 for (var i = 0; i < entities.Length; i++)
                 {
                     var readers = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index)
-                        .GetReadersWriters(getComponentId());
+                        .GetReadersWriters(197719);
                     var updateList = updateLists[i];
                     foreach (var reader in readers)
                     {
@@ -92,7 +92,7 @@ namespace Generated.Improbable.Gdk.Tests
                 for (var i = 0; i < entities.Length; i++)
                 {
                     var readers = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index)
-                        .GetReadersWriters(getComponentId());
+                        .GetReadersWriters(197719);
                     var authChanges = authChangeLists[i];
                     foreach (var reader in readers)
                     {

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKeyGameObjectComponentDispatcher.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKeyGameObjectComponentDispatcher.cs
@@ -13,22 +13,22 @@ namespace Generated.Improbable.Gdk.Tests
         {
             public override ComponentType[] ComponentAddedComponentTypes => new ComponentType[]
             {
-                typeof(ComponentAdded<SpatialOSExhaustiveMapKey>), typeof(GameObjectReference)
+                ComponentType.ReadOnly<ComponentAdded<SpatialOSExhaustiveMapKey>>(), ComponentType.ReadOnly<GameObjectReference>()
             };
 
             public override ComponentType[] ComponentRemovedComponentTypes => new ComponentType[]
             {
-                typeof(ComponentRemoved<SpatialOSExhaustiveMapKey>), typeof(GameObjectReference)
+                ComponentType.ReadOnly<ComponentRemoved<SpatialOSExhaustiveMapKey>>(), ComponentType.ReadOnly<GameObjectReference>()
             };
 
             public override ComponentType[] AuthoritiesChangedComponentTypes => new ComponentType[]
             {
-                typeof(AuthoritiesChanged<SpatialOSExhaustiveMapKey>), typeof(GameObjectReference)
+                ComponentType.ReadOnly<AuthoritiesChanged<SpatialOSExhaustiveMapKey>>(), ComponentType.ReadOnly<GameObjectReference>()
             };
 
             public override ComponentType[] ComponentsUpdatedComponentTypes => new ComponentType[]
             {
-                typeof(ComponentsUpdated<SpatialOSExhaustiveMapKey.Update>), typeof(GameObjectReference)
+                ComponentType.ReadOnly<ComponentsUpdated<SpatialOSExhaustiveMapKey.Update>>(), ComponentType.ReadOnly<GameObjectReference>()
             };
 
             public override ComponentType[][] EventsReceivedComponentTypeArrays => new ComponentType[][]
@@ -39,24 +39,36 @@ namespace Generated.Improbable.Gdk.Tests
             {
             };
 
-            public override void InvokeOnAddComponentLifecycleCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
+            protected override uint getComponentId()
             {
-                var entities = ComponentAddedComponentGroup.GetEntityArray();
+                return 197719;
+            }
+
+            public override void InvokeOnComponentUpdateUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
+            {
+                var entities = ComponentsUpdatedComponentGroup.GetEntityArray();
+                var updateLists = ComponentsUpdatedComponentGroup.GetComponentArray<ComponentsUpdated<SpatialOSExhaustiveMapKey.Update>();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var spatialOSBehaviourManager = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index);
-                    spatialOSBehaviourManager.AddComponent(197719);
+                    var readers = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index)
+                        .GetReadersWriters(getComponentId());
+                    var updateList = updateLists[i];
+                    foreach (var reader in readers)
+                    {
+                        foreach (var update in updateList.Buffer)
+                        {
+                            ((SpatialOSExhaustiveMapKey.ReaderWriterImpl) reader).OnComponentUpdate(update);
+                        }
+                    }
                 }
             }
 
-            public override void InvokeOnRemoveComponentLifecycleCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
+            public override void InvokeOnEventUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
             {
-                var entities = ComponentRemovedComponentGroup.GetEntityArray();
-                for (var i = 0; i < entities.Length; i++)
-                {
-                    var spatialOSBehaviourManager = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index);
-                    spatialOSBehaviourManager.RemoveComponent(197719);
-                }
+            }
+
+            public override void InvokeOnCommandRequestUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
+            {
             }
 
             public override void InvokeOnAuthorityChangeLifecycleCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
@@ -75,18 +87,21 @@ namespace Generated.Improbable.Gdk.Tests
 
             public override void InvokeOnAuthorityChangeUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
             {
-            }
-
-            public override void InvokeOnComponentUpdateUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
-            {
-            }
-
-            public override void InvokeOnEventUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
-            {
-            }
-
-            public override void InvokeOnCommandRequestUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
-            {
+                var entities = AuthoritiesChangedComponentGroup.GetEntityArray();
+                var authChangeLists = AuthoritiesChangedComponentGroup.GetComponentArray<AuthoritiesChanged<SpatialOSExhaustiveMapKey>>();
+                for (var i = 0; i < entities.Length; i++)
+                {
+                    var readers = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index)
+                        .GetReadersWriters(getComponentId());
+                    var authChanges = authChangeLists[i];
+                    foreach (var reader in readers)
+                    {
+                        foreach (var auth in authChanges.Buffer)
+                        {
+                            ((SpatialOSExhaustiveMapKey.ReaderWriterImpl) reader).OnAuthorityChange(auth);
+                        }
+                    }
+                }
             }
         }
     }

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValueGameObjectComponentDispatcher.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValueGameObjectComponentDispatcher.cs
@@ -13,22 +13,22 @@ namespace Generated.Improbable.Gdk.Tests
         {
             public override ComponentType[] ComponentAddedComponentTypes => new ComponentType[]
             {
-                typeof(ComponentAdded<SpatialOSExhaustiveMapValue>), typeof(GameObjectReference)
+                ComponentType.ReadOnly<ComponentAdded<SpatialOSExhaustiveMapValue>>(), ComponentType.ReadOnly<GameObjectReference>()
             };
 
             public override ComponentType[] ComponentRemovedComponentTypes => new ComponentType[]
             {
-                typeof(ComponentRemoved<SpatialOSExhaustiveMapValue>), typeof(GameObjectReference)
+                ComponentType.ReadOnly<ComponentRemoved<SpatialOSExhaustiveMapValue>>(), ComponentType.ReadOnly<GameObjectReference>()
             };
 
             public override ComponentType[] AuthoritiesChangedComponentTypes => new ComponentType[]
             {
-                typeof(AuthoritiesChanged<SpatialOSExhaustiveMapValue>), typeof(GameObjectReference)
+                ComponentType.ReadOnly<AuthoritiesChanged<SpatialOSExhaustiveMapValue>>(), ComponentType.ReadOnly<GameObjectReference>()
             };
 
             public override ComponentType[] ComponentsUpdatedComponentTypes => new ComponentType[]
             {
-                typeof(ComponentsUpdated<SpatialOSExhaustiveMapValue.Update>), typeof(GameObjectReference)
+                ComponentType.ReadOnly<ComponentsUpdated<SpatialOSExhaustiveMapValue.Update>>(), ComponentType.ReadOnly<GameObjectReference>()
             };
 
             public override ComponentType[][] EventsReceivedComponentTypeArrays => new ComponentType[][]
@@ -39,24 +39,36 @@ namespace Generated.Improbable.Gdk.Tests
             {
             };
 
-            public override void InvokeOnAddComponentLifecycleCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
+            protected override uint getComponentId()
             {
-                var entities = ComponentAddedComponentGroup.GetEntityArray();
+                return 197718;
+            }
+
+            public override void InvokeOnComponentUpdateUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
+            {
+                var entities = ComponentsUpdatedComponentGroup.GetEntityArray();
+                var updateLists = ComponentsUpdatedComponentGroup.GetComponentArray<ComponentsUpdated<SpatialOSExhaustiveMapValue.Update>();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var spatialOSBehaviourManager = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index);
-                    spatialOSBehaviourManager.AddComponent(197718);
+                    var readers = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index)
+                        .GetReadersWriters(getComponentId());
+                    var updateList = updateLists[i];
+                    foreach (var reader in readers)
+                    {
+                        foreach (var update in updateList.Buffer)
+                        {
+                            ((SpatialOSExhaustiveMapValue.ReaderWriterImpl) reader).OnComponentUpdate(update);
+                        }
+                    }
                 }
             }
 
-            public override void InvokeOnRemoveComponentLifecycleCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
+            public override void InvokeOnEventUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
             {
-                var entities = ComponentRemovedComponentGroup.GetEntityArray();
-                for (var i = 0; i < entities.Length; i++)
-                {
-                    var spatialOSBehaviourManager = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index);
-                    spatialOSBehaviourManager.RemoveComponent(197718);
-                }
+            }
+
+            public override void InvokeOnCommandRequestUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
+            {
             }
 
             public override void InvokeOnAuthorityChangeLifecycleCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
@@ -75,18 +87,21 @@ namespace Generated.Improbable.Gdk.Tests
 
             public override void InvokeOnAuthorityChangeUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
             {
-            }
-
-            public override void InvokeOnComponentUpdateUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
-            {
-            }
-
-            public override void InvokeOnEventUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
-            {
-            }
-
-            public override void InvokeOnCommandRequestUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
-            {
+                var entities = AuthoritiesChangedComponentGroup.GetEntityArray();
+                var authChangeLists = AuthoritiesChangedComponentGroup.GetComponentArray<AuthoritiesChanged<SpatialOSExhaustiveMapValue>>();
+                for (var i = 0; i < entities.Length; i++)
+                {
+                    var readers = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index)
+                        .GetReadersWriters(getComponentId());
+                    var authChanges = authChangeLists[i];
+                    foreach (var reader in readers)
+                    {
+                        foreach (var auth in authChanges.Buffer)
+                        {
+                            ((SpatialOSExhaustiveMapValue.ReaderWriterImpl) reader).OnAuthorityChange(auth);
+                        }
+                    }
+                }
             }
         }
     }

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValueGameObjectComponentDispatcher.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValueGameObjectComponentDispatcher.cs
@@ -39,7 +39,7 @@ namespace Generated.Improbable.Gdk.Tests
             {
             };
 
-            protected override uint getComponentId()
+            protected override uint GetComponentId()
             {
                 return 197718;
             }
@@ -47,11 +47,11 @@ namespace Generated.Improbable.Gdk.Tests
             public override void InvokeOnComponentUpdateUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
             {
                 var entities = ComponentsUpdatedComponentGroup.GetEntityArray();
-                var updateLists = ComponentsUpdatedComponentGroup.GetComponentArray<ComponentsUpdated<SpatialOSExhaustiveMapValue.Update>();
+                var updateLists = ComponentsUpdatedComponentGroup.GetComponentArray<ComponentsUpdated<SpatialOSExhaustiveMapValue.Update>>();
                 for (var i = 0; i < entities.Length; i++)
                 {
                     var readers = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index)
-                        .GetReadersWriters(getComponentId());
+                        .GetReadersWriters(197718);
                     var updateList = updateLists[i];
                     foreach (var reader in readers)
                     {
@@ -92,7 +92,7 @@ namespace Generated.Improbable.Gdk.Tests
                 for (var i = 0; i < entities.Length; i++)
                 {
                     var readers = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index)
-                        .GetReadersWriters(getComponentId());
+                        .GetReadersWriters(197718);
                     var authChanges = authChangeLists[i];
                     foreach (var reader in readers)
                     {

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptionalGameObjectComponentDispatcher.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptionalGameObjectComponentDispatcher.cs
@@ -13,22 +13,22 @@ namespace Generated.Improbable.Gdk.Tests
         {
             public override ComponentType[] ComponentAddedComponentTypes => new ComponentType[]
             {
-                typeof(ComponentAdded<SpatialOSExhaustiveOptional>), typeof(GameObjectReference)
+                ComponentType.ReadOnly<ComponentAdded<SpatialOSExhaustiveOptional>>(), ComponentType.ReadOnly<GameObjectReference>()
             };
 
             public override ComponentType[] ComponentRemovedComponentTypes => new ComponentType[]
             {
-                typeof(ComponentRemoved<SpatialOSExhaustiveOptional>), typeof(GameObjectReference)
+                ComponentType.ReadOnly<ComponentRemoved<SpatialOSExhaustiveOptional>>(), ComponentType.ReadOnly<GameObjectReference>()
             };
 
             public override ComponentType[] AuthoritiesChangedComponentTypes => new ComponentType[]
             {
-                typeof(AuthoritiesChanged<SpatialOSExhaustiveOptional>), typeof(GameObjectReference)
+                ComponentType.ReadOnly<AuthoritiesChanged<SpatialOSExhaustiveOptional>>(), ComponentType.ReadOnly<GameObjectReference>()
             };
 
             public override ComponentType[] ComponentsUpdatedComponentTypes => new ComponentType[]
             {
-                typeof(ComponentsUpdated<SpatialOSExhaustiveOptional.Update>), typeof(GameObjectReference)
+                ComponentType.ReadOnly<ComponentsUpdated<SpatialOSExhaustiveOptional.Update>>(), ComponentType.ReadOnly<GameObjectReference>()
             };
 
             public override ComponentType[][] EventsReceivedComponentTypeArrays => new ComponentType[][]
@@ -39,24 +39,36 @@ namespace Generated.Improbable.Gdk.Tests
             {
             };
 
-            public override void InvokeOnAddComponentLifecycleCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
+            protected override uint getComponentId()
             {
-                var entities = ComponentAddedComponentGroup.GetEntityArray();
+                return 197716;
+            }
+
+            public override void InvokeOnComponentUpdateUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
+            {
+                var entities = ComponentsUpdatedComponentGroup.GetEntityArray();
+                var updateLists = ComponentsUpdatedComponentGroup.GetComponentArray<ComponentsUpdated<SpatialOSExhaustiveOptional.Update>();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var spatialOSBehaviourManager = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index);
-                    spatialOSBehaviourManager.AddComponent(197716);
+                    var readers = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index)
+                        .GetReadersWriters(getComponentId());
+                    var updateList = updateLists[i];
+                    foreach (var reader in readers)
+                    {
+                        foreach (var update in updateList.Buffer)
+                        {
+                            ((SpatialOSExhaustiveOptional.ReaderWriterImpl) reader).OnComponentUpdate(update);
+                        }
+                    }
                 }
             }
 
-            public override void InvokeOnRemoveComponentLifecycleCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
+            public override void InvokeOnEventUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
             {
-                var entities = ComponentRemovedComponentGroup.GetEntityArray();
-                for (var i = 0; i < entities.Length; i++)
-                {
-                    var spatialOSBehaviourManager = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index);
-                    spatialOSBehaviourManager.RemoveComponent(197716);
-                }
+            }
+
+            public override void InvokeOnCommandRequestUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
+            {
             }
 
             public override void InvokeOnAuthorityChangeLifecycleCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
@@ -75,18 +87,21 @@ namespace Generated.Improbable.Gdk.Tests
 
             public override void InvokeOnAuthorityChangeUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
             {
-            }
-
-            public override void InvokeOnComponentUpdateUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
-            {
-            }
-
-            public override void InvokeOnEventUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
-            {
-            }
-
-            public override void InvokeOnCommandRequestUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
-            {
+                var entities = AuthoritiesChangedComponentGroup.GetEntityArray();
+                var authChangeLists = AuthoritiesChangedComponentGroup.GetComponentArray<AuthoritiesChanged<SpatialOSExhaustiveOptional>>();
+                for (var i = 0; i < entities.Length; i++)
+                {
+                    var readers = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index)
+                        .GetReadersWriters(getComponentId());
+                    var authChanges = authChangeLists[i];
+                    foreach (var reader in readers)
+                    {
+                        foreach (var auth in authChanges.Buffer)
+                        {
+                            ((SpatialOSExhaustiveOptional.ReaderWriterImpl) reader).OnAuthorityChange(auth);
+                        }
+                    }
+                }
             }
         }
     }

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptionalGameObjectComponentDispatcher.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptionalGameObjectComponentDispatcher.cs
@@ -39,7 +39,7 @@ namespace Generated.Improbable.Gdk.Tests
             {
             };
 
-            protected override uint getComponentId()
+            protected override uint GetComponentId()
             {
                 return 197716;
             }
@@ -47,11 +47,11 @@ namespace Generated.Improbable.Gdk.Tests
             public override void InvokeOnComponentUpdateUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
             {
                 var entities = ComponentsUpdatedComponentGroup.GetEntityArray();
-                var updateLists = ComponentsUpdatedComponentGroup.GetComponentArray<ComponentsUpdated<SpatialOSExhaustiveOptional.Update>();
+                var updateLists = ComponentsUpdatedComponentGroup.GetComponentArray<ComponentsUpdated<SpatialOSExhaustiveOptional.Update>>();
                 for (var i = 0; i < entities.Length; i++)
                 {
                     var readers = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index)
-                        .GetReadersWriters(getComponentId());
+                        .GetReadersWriters(197716);
                     var updateList = updateLists[i];
                     foreach (var reader in readers)
                     {
@@ -92,7 +92,7 @@ namespace Generated.Improbable.Gdk.Tests
                 for (var i = 0; i < entities.Length; i++)
                 {
                     var readers = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index)
-                        .GetReadersWriters(getComponentId());
+                        .GetReadersWriters(197716);
                     var authChanges = authChangeLists[i];
                     foreach (var reader in readers)
                     {

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeatedGameObjectComponentDispatcher.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeatedGameObjectComponentDispatcher.cs
@@ -13,22 +13,22 @@ namespace Generated.Improbable.Gdk.Tests
         {
             public override ComponentType[] ComponentAddedComponentTypes => new ComponentType[]
             {
-                typeof(ComponentAdded<SpatialOSExhaustiveRepeated>), typeof(GameObjectReference)
+                ComponentType.ReadOnly<ComponentAdded<SpatialOSExhaustiveRepeated>>(), ComponentType.ReadOnly<GameObjectReference>()
             };
 
             public override ComponentType[] ComponentRemovedComponentTypes => new ComponentType[]
             {
-                typeof(ComponentRemoved<SpatialOSExhaustiveRepeated>), typeof(GameObjectReference)
+                ComponentType.ReadOnly<ComponentRemoved<SpatialOSExhaustiveRepeated>>(), ComponentType.ReadOnly<GameObjectReference>()
             };
 
             public override ComponentType[] AuthoritiesChangedComponentTypes => new ComponentType[]
             {
-                typeof(AuthoritiesChanged<SpatialOSExhaustiveRepeated>), typeof(GameObjectReference)
+                ComponentType.ReadOnly<AuthoritiesChanged<SpatialOSExhaustiveRepeated>>(), ComponentType.ReadOnly<GameObjectReference>()
             };
 
             public override ComponentType[] ComponentsUpdatedComponentTypes => new ComponentType[]
             {
-                typeof(ComponentsUpdated<SpatialOSExhaustiveRepeated.Update>), typeof(GameObjectReference)
+                ComponentType.ReadOnly<ComponentsUpdated<SpatialOSExhaustiveRepeated.Update>>(), ComponentType.ReadOnly<GameObjectReference>()
             };
 
             public override ComponentType[][] EventsReceivedComponentTypeArrays => new ComponentType[][]
@@ -39,24 +39,36 @@ namespace Generated.Improbable.Gdk.Tests
             {
             };
 
-            public override void InvokeOnAddComponentLifecycleCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
+            protected override uint getComponentId()
             {
-                var entities = ComponentAddedComponentGroup.GetEntityArray();
+                return 197717;
+            }
+
+            public override void InvokeOnComponentUpdateUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
+            {
+                var entities = ComponentsUpdatedComponentGroup.GetEntityArray();
+                var updateLists = ComponentsUpdatedComponentGroup.GetComponentArray<ComponentsUpdated<SpatialOSExhaustiveRepeated.Update>();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var spatialOSBehaviourManager = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index);
-                    spatialOSBehaviourManager.AddComponent(197717);
+                    var readers = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index)
+                        .GetReadersWriters(getComponentId());
+                    var updateList = updateLists[i];
+                    foreach (var reader in readers)
+                    {
+                        foreach (var update in updateList.Buffer)
+                        {
+                            ((SpatialOSExhaustiveRepeated.ReaderWriterImpl) reader).OnComponentUpdate(update);
+                        }
+                    }
                 }
             }
 
-            public override void InvokeOnRemoveComponentLifecycleCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
+            public override void InvokeOnEventUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
             {
-                var entities = ComponentRemovedComponentGroup.GetEntityArray();
-                for (var i = 0; i < entities.Length; i++)
-                {
-                    var spatialOSBehaviourManager = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index);
-                    spatialOSBehaviourManager.RemoveComponent(197717);
-                }
+            }
+
+            public override void InvokeOnCommandRequestUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
+            {
             }
 
             public override void InvokeOnAuthorityChangeLifecycleCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
@@ -75,18 +87,21 @@ namespace Generated.Improbable.Gdk.Tests
 
             public override void InvokeOnAuthorityChangeUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
             {
-            }
-
-            public override void InvokeOnComponentUpdateUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
-            {
-            }
-
-            public override void InvokeOnEventUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
-            {
-            }
-
-            public override void InvokeOnCommandRequestUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
-            {
+                var entities = AuthoritiesChangedComponentGroup.GetEntityArray();
+                var authChangeLists = AuthoritiesChangedComponentGroup.GetComponentArray<AuthoritiesChanged<SpatialOSExhaustiveRepeated>>();
+                for (var i = 0; i < entities.Length; i++)
+                {
+                    var readers = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index)
+                        .GetReadersWriters(getComponentId());
+                    var authChanges = authChangeLists[i];
+                    foreach (var reader in readers)
+                    {
+                        foreach (var auth in authChanges.Buffer)
+                        {
+                            ((SpatialOSExhaustiveRepeated.ReaderWriterImpl) reader).OnAuthorityChange(auth);
+                        }
+                    }
+                }
             }
         }
     }

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeatedGameObjectComponentDispatcher.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeatedGameObjectComponentDispatcher.cs
@@ -39,7 +39,7 @@ namespace Generated.Improbable.Gdk.Tests
             {
             };
 
-            protected override uint getComponentId()
+            protected override uint GetComponentId()
             {
                 return 197717;
             }
@@ -47,11 +47,11 @@ namespace Generated.Improbable.Gdk.Tests
             public override void InvokeOnComponentUpdateUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
             {
                 var entities = ComponentsUpdatedComponentGroup.GetEntityArray();
-                var updateLists = ComponentsUpdatedComponentGroup.GetComponentArray<ComponentsUpdated<SpatialOSExhaustiveRepeated.Update>();
+                var updateLists = ComponentsUpdatedComponentGroup.GetComponentArray<ComponentsUpdated<SpatialOSExhaustiveRepeated.Update>>();
                 for (var i = 0; i < entities.Length; i++)
                 {
                     var readers = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index)
-                        .GetReadersWriters(getComponentId());
+                        .GetReadersWriters(197717);
                     var updateList = updateLists[i];
                     foreach (var reader in readers)
                     {
@@ -92,7 +92,7 @@ namespace Generated.Improbable.Gdk.Tests
                 for (var i = 0; i < entities.Length; i++)
                 {
                     var readers = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index)
-                        .GetReadersWriters(getComponentId());
+                        .GetReadersWriters(197717);
                     var authChanges = authChangeLists[i];
                     foreach (var reader in readers)
                     {

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingularGameObjectComponentDispatcher.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingularGameObjectComponentDispatcher.cs
@@ -13,22 +13,22 @@ namespace Generated.Improbable.Gdk.Tests
         {
             public override ComponentType[] ComponentAddedComponentTypes => new ComponentType[]
             {
-                typeof(ComponentAdded<SpatialOSExhaustiveSingular>), typeof(GameObjectReference)
+                ComponentType.ReadOnly<ComponentAdded<SpatialOSExhaustiveSingular>>(), ComponentType.ReadOnly<GameObjectReference>()
             };
 
             public override ComponentType[] ComponentRemovedComponentTypes => new ComponentType[]
             {
-                typeof(ComponentRemoved<SpatialOSExhaustiveSingular>), typeof(GameObjectReference)
+                ComponentType.ReadOnly<ComponentRemoved<SpatialOSExhaustiveSingular>>(), ComponentType.ReadOnly<GameObjectReference>()
             };
 
             public override ComponentType[] AuthoritiesChangedComponentTypes => new ComponentType[]
             {
-                typeof(AuthoritiesChanged<SpatialOSExhaustiveSingular>), typeof(GameObjectReference)
+                ComponentType.ReadOnly<AuthoritiesChanged<SpatialOSExhaustiveSingular>>(), ComponentType.ReadOnly<GameObjectReference>()
             };
 
             public override ComponentType[] ComponentsUpdatedComponentTypes => new ComponentType[]
             {
-                typeof(ComponentsUpdated<SpatialOSExhaustiveSingular.Update>), typeof(GameObjectReference)
+                ComponentType.ReadOnly<ComponentsUpdated<SpatialOSExhaustiveSingular.Update>>(), ComponentType.ReadOnly<GameObjectReference>()
             };
 
             public override ComponentType[][] EventsReceivedComponentTypeArrays => new ComponentType[][]
@@ -39,24 +39,36 @@ namespace Generated.Improbable.Gdk.Tests
             {
             };
 
-            public override void InvokeOnAddComponentLifecycleCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
+            protected override uint getComponentId()
             {
-                var entities = ComponentAddedComponentGroup.GetEntityArray();
+                return 197715;
+            }
+
+            public override void InvokeOnComponentUpdateUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
+            {
+                var entities = ComponentsUpdatedComponentGroup.GetEntityArray();
+                var updateLists = ComponentsUpdatedComponentGroup.GetComponentArray<ComponentsUpdated<SpatialOSExhaustiveSingular.Update>();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var spatialOSBehaviourManager = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index);
-                    spatialOSBehaviourManager.AddComponent(197715);
+                    var readers = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index)
+                        .GetReadersWriters(getComponentId());
+                    var updateList = updateLists[i];
+                    foreach (var reader in readers)
+                    {
+                        foreach (var update in updateList.Buffer)
+                        {
+                            ((SpatialOSExhaustiveSingular.ReaderWriterImpl) reader).OnComponentUpdate(update);
+                        }
+                    }
                 }
             }
 
-            public override void InvokeOnRemoveComponentLifecycleCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
+            public override void InvokeOnEventUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
             {
-                var entities = ComponentRemovedComponentGroup.GetEntityArray();
-                for (var i = 0; i < entities.Length; i++)
-                {
-                    var spatialOSBehaviourManager = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index);
-                    spatialOSBehaviourManager.RemoveComponent(197715);
-                }
+            }
+
+            public override void InvokeOnCommandRequestUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
+            {
             }
 
             public override void InvokeOnAuthorityChangeLifecycleCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
@@ -75,18 +87,21 @@ namespace Generated.Improbable.Gdk.Tests
 
             public override void InvokeOnAuthorityChangeUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
             {
-            }
-
-            public override void InvokeOnComponentUpdateUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
-            {
-            }
-
-            public override void InvokeOnEventUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
-            {
-            }
-
-            public override void InvokeOnCommandRequestUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
-            {
+                var entities = AuthoritiesChangedComponentGroup.GetEntityArray();
+                var authChangeLists = AuthoritiesChangedComponentGroup.GetComponentArray<AuthoritiesChanged<SpatialOSExhaustiveSingular>>();
+                for (var i = 0; i < entities.Length; i++)
+                {
+                    var readers = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index)
+                        .GetReadersWriters(getComponentId());
+                    var authChanges = authChangeLists[i];
+                    foreach (var reader in readers)
+                    {
+                        foreach (var auth in authChanges.Buffer)
+                        {
+                            ((SpatialOSExhaustiveSingular.ReaderWriterImpl) reader).OnAuthorityChange(auth);
+                        }
+                    }
+                }
             }
         }
     }

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingularGameObjectComponentDispatcher.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingularGameObjectComponentDispatcher.cs
@@ -39,7 +39,7 @@ namespace Generated.Improbable.Gdk.Tests
             {
             };
 
-            protected override uint getComponentId()
+            protected override uint GetComponentId()
             {
                 return 197715;
             }
@@ -47,11 +47,11 @@ namespace Generated.Improbable.Gdk.Tests
             public override void InvokeOnComponentUpdateUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
             {
                 var entities = ComponentsUpdatedComponentGroup.GetEntityArray();
-                var updateLists = ComponentsUpdatedComponentGroup.GetComponentArray<ComponentsUpdated<SpatialOSExhaustiveSingular.Update>();
+                var updateLists = ComponentsUpdatedComponentGroup.GetComponentArray<ComponentsUpdated<SpatialOSExhaustiveSingular.Update>>();
                 for (var i = 0; i < entities.Length; i++)
                 {
                     var readers = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index)
-                        .GetReadersWriters(getComponentId());
+                        .GetReadersWriters(197715);
                     var updateList = updateLists[i];
                     foreach (var reader in readers)
                     {
@@ -92,7 +92,7 @@ namespace Generated.Improbable.Gdk.Tests
                 for (var i = 0; i < entities.Length; i++)
                 {
                     var readers = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index)
-                        .GetReadersWriters(getComponentId());
+                        .GetReadersWriters(197715);
                     var authChanges = authChangeLists[i];
                     foreach (var reader in readers)
                     {

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/NestedComponentGameObjectComponentDispatcher.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/NestedComponentGameObjectComponentDispatcher.cs
@@ -39,7 +39,7 @@ namespace Generated.Improbable.Gdk.Tests
             {
             };
 
-            protected override uint getComponentId()
+            protected override uint GetComponentId()
             {
                 return 20152;
             }
@@ -47,11 +47,11 @@ namespace Generated.Improbable.Gdk.Tests
             public override void InvokeOnComponentUpdateUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
             {
                 var entities = ComponentsUpdatedComponentGroup.GetEntityArray();
-                var updateLists = ComponentsUpdatedComponentGroup.GetComponentArray<ComponentsUpdated<SpatialOSNestedComponent.Update>();
+                var updateLists = ComponentsUpdatedComponentGroup.GetComponentArray<ComponentsUpdated<SpatialOSNestedComponent.Update>>();
                 for (var i = 0; i < entities.Length; i++)
                 {
                     var readers = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index)
-                        .GetReadersWriters(getComponentId());
+                        .GetReadersWriters(20152);
                     var updateList = updateLists[i];
                     foreach (var reader in readers)
                     {
@@ -92,7 +92,7 @@ namespace Generated.Improbable.Gdk.Tests
                 for (var i = 0; i < entities.Length; i++)
                 {
                     var readers = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index)
-                        .GetReadersWriters(getComponentId());
+                        .GetReadersWriters(20152);
                     var authChanges = authChangeLists[i];
                     foreach (var reader in readers)
                     {

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/NestedComponentGameObjectComponentDispatcher.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/NestedComponentGameObjectComponentDispatcher.cs
@@ -13,22 +13,22 @@ namespace Generated.Improbable.Gdk.Tests
         {
             public override ComponentType[] ComponentAddedComponentTypes => new ComponentType[]
             {
-                typeof(ComponentAdded<SpatialOSNestedComponent>), typeof(GameObjectReference)
+                ComponentType.ReadOnly<ComponentAdded<SpatialOSNestedComponent>>(), ComponentType.ReadOnly<GameObjectReference>()
             };
 
             public override ComponentType[] ComponentRemovedComponentTypes => new ComponentType[]
             {
-                typeof(ComponentRemoved<SpatialOSNestedComponent>), typeof(GameObjectReference)
+                ComponentType.ReadOnly<ComponentRemoved<SpatialOSNestedComponent>>(), ComponentType.ReadOnly<GameObjectReference>()
             };
 
             public override ComponentType[] AuthoritiesChangedComponentTypes => new ComponentType[]
             {
-                typeof(AuthoritiesChanged<SpatialOSNestedComponent>), typeof(GameObjectReference)
+                ComponentType.ReadOnly<AuthoritiesChanged<SpatialOSNestedComponent>>(), ComponentType.ReadOnly<GameObjectReference>()
             };
 
             public override ComponentType[] ComponentsUpdatedComponentTypes => new ComponentType[]
             {
-                typeof(ComponentsUpdated<SpatialOSNestedComponent.Update>), typeof(GameObjectReference)
+                ComponentType.ReadOnly<ComponentsUpdated<SpatialOSNestedComponent.Update>>(), ComponentType.ReadOnly<GameObjectReference>()
             };
 
             public override ComponentType[][] EventsReceivedComponentTypeArrays => new ComponentType[][]
@@ -39,24 +39,36 @@ namespace Generated.Improbable.Gdk.Tests
             {
             };
 
-            public override void InvokeOnAddComponentLifecycleCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
+            protected override uint getComponentId()
             {
-                var entities = ComponentAddedComponentGroup.GetEntityArray();
+                return 20152;
+            }
+
+            public override void InvokeOnComponentUpdateUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
+            {
+                var entities = ComponentsUpdatedComponentGroup.GetEntityArray();
+                var updateLists = ComponentsUpdatedComponentGroup.GetComponentArray<ComponentsUpdated<SpatialOSNestedComponent.Update>();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var spatialOSBehaviourManager = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index);
-                    spatialOSBehaviourManager.AddComponent(20152);
+                    var readers = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index)
+                        .GetReadersWriters(getComponentId());
+                    var updateList = updateLists[i];
+                    foreach (var reader in readers)
+                    {
+                        foreach (var update in updateList.Buffer)
+                        {
+                            ((SpatialOSNestedComponent.ReaderWriterImpl) reader).OnComponentUpdate(update);
+                        }
+                    }
                 }
             }
 
-            public override void InvokeOnRemoveComponentLifecycleCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
+            public override void InvokeOnEventUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
             {
-                var entities = ComponentRemovedComponentGroup.GetEntityArray();
-                for (var i = 0; i < entities.Length; i++)
-                {
-                    var spatialOSBehaviourManager = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index);
-                    spatialOSBehaviourManager.RemoveComponent(20152);
-                }
+            }
+
+            public override void InvokeOnCommandRequestUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
+            {
             }
 
             public override void InvokeOnAuthorityChangeLifecycleCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
@@ -75,18 +87,21 @@ namespace Generated.Improbable.Gdk.Tests
 
             public override void InvokeOnAuthorityChangeUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
             {
-            }
-
-            public override void InvokeOnComponentUpdateUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
-            {
-            }
-
-            public override void InvokeOnEventUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
-            {
-            }
-
-            public override void InvokeOnCommandRequestUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
-            {
+                var entities = AuthoritiesChangedComponentGroup.GetEntityArray();
+                var authChangeLists = AuthoritiesChangedComponentGroup.GetComponentArray<AuthoritiesChanged<SpatialOSNestedComponent>>();
+                for (var i = 0; i < entities.Length; i++)
+                {
+                    var readers = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index)
+                        .GetReadersWriters(getComponentId());
+                    var authChanges = authChangeLists[i];
+                    foreach (var reader in readers)
+                    {
+                        foreach (var auth in authChanges.Buffer)
+                        {
+                            ((SpatialOSNestedComponent.ReaderWriterImpl) reader).OnAuthorityChange(auth);
+                        }
+                    }
+                }
             }
         }
     }

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentGameObjectComponentDispatcher.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentGameObjectComponentDispatcher.cs
@@ -1,0 +1,172 @@
+// ===========
+// DO NOT EDIT - this file is automatically regenerated.
+// ===========
+
+using Unity.Entities;
+using Improbable.Gdk.Core;
+
+namespace Generated.Improbable.Gdk.Tests.BlittableTypes
+{
+    public partial class BlittableComponent
+    {
+        internal class GameObjectComponentDispatcher : GameObjectComponentDispatcherBase
+        {
+            public override ComponentType[] ComponentAddedComponentTypes => new ComponentType[]
+            {
+                ComponentType.ReadOnly<ComponentAdded<SpatialOSBlittableComponent>>(), ComponentType.ReadOnly<GameObjectReference>()
+            };
+
+            public override ComponentType[] ComponentRemovedComponentTypes => new ComponentType[]
+            {
+                ComponentType.ReadOnly<ComponentRemoved<SpatialOSBlittableComponent>>(), ComponentType.ReadOnly<GameObjectReference>()
+            };
+
+            public override ComponentType[] AuthoritiesChangedComponentTypes => new ComponentType[]
+            {
+                ComponentType.ReadOnly<AuthoritiesChanged<SpatialOSBlittableComponent>>(), ComponentType.ReadOnly<GameObjectReference>()
+            };
+
+            public override ComponentType[] ComponentsUpdatedComponentTypes => new ComponentType[]
+            {
+                ComponentType.ReadOnly<ComponentsUpdated<SpatialOSBlittableComponent.Update>>(), ComponentType.ReadOnly<GameObjectReference>()
+            };
+
+            public override ComponentType[][] EventsReceivedComponentTypeArrays => new ComponentType[][]
+            {
+                new ComponentType[] { ComponentType.ReadOnly<EventsReceived<FirstEventEvent>>(), ComponentType.ReadOnly<GameObjectReference>() },
+                new ComponentType[] { ComponentType.ReadOnly<EventsReceived<SecondEventEvent>>(), ComponentType.ReadOnly<GameObjectReference>() },
+            };
+
+            public override ComponentType[][] CommandRequestsComponentTypeArrays => new ComponentType[][]
+            {
+                new ComponentType[] { ComponentType.ReadOnly<CommandRequests<FirstCommand.Request>>(), ComponentType.ReadOnly<GameObjectReference>() },
+                new ComponentType[] { ComponentType.ReadOnly<CommandRequests<SecondCommand.Request>>(), ComponentType.ReadOnly<GameObjectReference>() },
+            };
+
+            protected override uint GetComponentId()
+            {
+                return 1001;
+            }
+
+            public override void InvokeOnComponentUpdateUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
+            {
+                var entities = ComponentsUpdatedComponentGroup.GetEntityArray();
+                var updateLists = ComponentsUpdatedComponentGroup.GetComponentArray<ComponentsUpdated<SpatialOSBlittableComponent.Update>>();
+                for (var i = 0; i < entities.Length; i++)
+                {
+                    var readers = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index)
+                        .GetReadersWriters(1001);
+                    var updateList = updateLists[i];
+                    foreach (var reader in readers)
+                    {
+                        foreach (var update in updateList.Buffer)
+                        {
+                            ((SpatialOSBlittableComponent.ReaderWriterImpl) reader).OnComponentUpdate(update);
+                        }
+                    }
+                }
+            }
+
+            public override void InvokeOnEventUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
+            {
+                var entities = EventsReceivedComponentGroups[0].GetEntityArray();
+                var eventLists = EventsReceivedComponentGroups[0].GetComponentArray<EventsReceived<FirstEventEvent>>();
+                for (var i = 0; i < entities.Length; i++)
+                {
+                    var readers = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index)
+                        .GetReadersWriters(1001);
+                    var eventList = eventLists[i];
+                    foreach (var reader in readers)
+                    {
+                        foreach (var e in eventList.Buffer)
+                        {
+                            ((SpatialOSBlittableComponent.ReaderWriterImpl) reader).OnFirstEventEvent(e);
+                        }
+                    }
+                }
+                var entities = EventsReceivedComponentGroups[1].GetEntityArray();
+                var eventLists = EventsReceivedComponentGroups[1].GetComponentArray<EventsReceived<SecondEventEvent>>();
+                for (var i = 0; i < entities.Length; i++)
+                {
+                    var readers = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index)
+                        .GetReadersWriters(1001);
+                    var eventList = eventLists[i];
+                    foreach (var reader in readers)
+                    {
+                        foreach (var e in eventList.Buffer)
+                        {
+                            ((SpatialOSBlittableComponent.ReaderWriterImpl) reader).OnSecondEventEvent(e);
+                        }
+                    }
+                }
+            }
+
+            public override void InvokeOnCommandRequestUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
+            {
+                var entities = CommandRequestsComponentGroups[0].GetEntityArray();
+                var commandLists = CommandRequestsComponentGroups[0].GetComponentArray<CommandRequests<FirstCommand.Request>();
+                for (var i = 0; i < entities.Length; i++)
+                {
+                    var readers = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index)
+                        .GetReadersWriters(1001);
+                    var commandList = commandLists[i];
+                    foreach (var reader in readers)
+                    {
+                        foreach (var req in commandList.Buffer)
+                        {
+                            ((SpatialOSBlittableComponent.ReaderWriterImpl) reader).OnFirstCommandCommandRequest(req);
+                        }
+                    }
+                }
+                var entities = CommandRequestsComponentGroups[1].GetEntityArray();
+                var commandLists = CommandRequestsComponentGroups[1].GetComponentArray<CommandRequests<SecondCommand.Request>();
+                for (var i = 0; i < entities.Length; i++)
+                {
+                    var readers = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index)
+                        .GetReadersWriters(1001);
+                    var commandList = commandLists[i];
+                    foreach (var reader in readers)
+                    {
+                        foreach (var req in commandList.Buffer)
+                        {
+                            ((SpatialOSBlittableComponent.ReaderWriterImpl) reader).OnSecondCommandCommandRequest(req);
+                        }
+                    }
+                }
+            }
+
+            public override void InvokeOnAuthorityChangeLifecycleCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
+            {
+                var authoritiesChangedTags = AuthoritiesChangedComponentGroup.GetComponentArray<AuthoritiesChanged<SpatialOSBlittableComponent>>();
+                var entities = AuthoritiesChangedComponentGroup.GetEntityArray();
+                for (var i = 0; i < entities.Length; i++)
+                {
+                    var spatialOSBehaviourManager = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index);
+                    for (var j = 0; j < authoritiesChangedTags[i].Buffer.Count; j++)
+                    {
+                        spatialOSBehaviourManager.ChangeAuthority(1001, authoritiesChangedTags[i].Buffer[j]);
+                    }
+                }
+            }
+
+            public override void InvokeOnAuthorityChangeUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
+            {
+                var entities = AuthoritiesChangedComponentGroup.GetEntityArray();
+                var authChangeLists = AuthoritiesChangedComponentGroup.GetComponentArray<AuthoritiesChanged<SpatialOSBlittableComponent>>();
+                for (var i = 0; i < entities.Length; i++)
+                {
+                    var readers = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index)
+                        .GetReadersWriters(1001);
+                    var authChanges = authChangeLists[i];
+                    foreach (var reader in readers)
+                    {
+                        foreach (var auth in authChanges.Buffer)
+                        {
+                            ((SpatialOSBlittableComponent.ReaderWriterImpl) reader).OnAuthorityChange(auth);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentReaderWriter.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentReaderWriter.cs
@@ -1,0 +1,59 @@
+
+// ===========
+// DO NOT EDIT - this file is automatically regenerated.
+// ===========
+
+using Unity.Entities;
+using Improbable.Gdk.Core;
+using Improbable.Gdk.Core.MonoBehaviours;
+using Improbable.Worker;
+using Entity = Unity.Entities.Entity;
+
+namespace Generated.Improbable.Gdk.Tests.BlittableTypes
+{
+    public partial class BlittableComponent
+    {
+        [ComponentId(1001)]
+        internal class ReaderWriterCreator : IReaderWriterCreator
+        {
+            public IReaderInternal CreateReaderWriter(Entity entity, EntityManager entityManager, ILogDispatcher logDispatcher)
+            {
+                return new ReaderWriterImpl(entity, entityManager, logDispatcher);
+            }
+        }
+
+        [ReaderInterface]
+        [ComponentId(1001)]
+        public interface Reader
+        {
+        }
+
+        public class ReaderWriterImpl : Reader, IReaderInternal
+        {
+            public ReaderWriterImpl(Entity entity, EntityManager entityManager, ILogDispatcher logDispatcher)
+            {
+            }
+
+            // IReaderInternal methods
+            void IReaderInternal.OnAuthorityChange(Authority authority)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            void IReaderInternal.OnComponentUpdate()
+            {
+                throw new System.NotImplementedException();
+            }
+            
+            void IReaderInternal.OnEvent(int eventIndex)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            void IReaderInternal.OnCommandRequest(int commandIndex)
+            {
+                throw new System.NotImplementedException();
+            }
+        }
+    }
+}

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentGameObjectComponentDispatcher.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentGameObjectComponentDispatcher.cs
@@ -1,0 +1,172 @@
+// ===========
+// DO NOT EDIT - this file is automatically regenerated.
+// ===========
+
+using Unity.Entities;
+using Improbable.Gdk.Core;
+
+namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
+{
+    public partial class NonBlittableComponent
+    {
+        internal class GameObjectComponentDispatcher : GameObjectComponentDispatcherBase
+        {
+            public override ComponentType[] ComponentAddedComponentTypes => new ComponentType[]
+            {
+                ComponentType.ReadOnly<ComponentAdded<SpatialOSNonBlittableComponent>>(), ComponentType.ReadOnly<GameObjectReference>()
+            };
+
+            public override ComponentType[] ComponentRemovedComponentTypes => new ComponentType[]
+            {
+                ComponentType.ReadOnly<ComponentRemoved<SpatialOSNonBlittableComponent>>(), ComponentType.ReadOnly<GameObjectReference>()
+            };
+
+            public override ComponentType[] AuthoritiesChangedComponentTypes => new ComponentType[]
+            {
+                ComponentType.ReadOnly<AuthoritiesChanged<SpatialOSNonBlittableComponent>>(), ComponentType.ReadOnly<GameObjectReference>()
+            };
+
+            public override ComponentType[] ComponentsUpdatedComponentTypes => new ComponentType[]
+            {
+                ComponentType.ReadOnly<ComponentsUpdated<SpatialOSNonBlittableComponent.Update>>(), ComponentType.ReadOnly<GameObjectReference>()
+            };
+
+            public override ComponentType[][] EventsReceivedComponentTypeArrays => new ComponentType[][]
+            {
+                new ComponentType[] { ComponentType.ReadOnly<EventsReceived<FirstEventEvent>>(), ComponentType.ReadOnly<GameObjectReference>() },
+                new ComponentType[] { ComponentType.ReadOnly<EventsReceived<SecondEventEvent>>(), ComponentType.ReadOnly<GameObjectReference>() },
+            };
+
+            public override ComponentType[][] CommandRequestsComponentTypeArrays => new ComponentType[][]
+            {
+                new ComponentType[] { ComponentType.ReadOnly<CommandRequests<FirstCommand.Request>>(), ComponentType.ReadOnly<GameObjectReference>() },
+                new ComponentType[] { ComponentType.ReadOnly<CommandRequests<SecondCommand.Request>>(), ComponentType.ReadOnly<GameObjectReference>() },
+            };
+
+            protected override uint GetComponentId()
+            {
+                return 1002;
+            }
+
+            public override void InvokeOnComponentUpdateUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
+            {
+                var entities = ComponentsUpdatedComponentGroup.GetEntityArray();
+                var updateLists = ComponentsUpdatedComponentGroup.GetComponentArray<ComponentsUpdated<SpatialOSNonBlittableComponent.Update>>();
+                for (var i = 0; i < entities.Length; i++)
+                {
+                    var readers = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index)
+                        .GetReadersWriters(1002);
+                    var updateList = updateLists[i];
+                    foreach (var reader in readers)
+                    {
+                        foreach (var update in updateList.Buffer)
+                        {
+                            ((SpatialOSNonBlittableComponent.ReaderWriterImpl) reader).OnComponentUpdate(update);
+                        }
+                    }
+                }
+            }
+
+            public override void InvokeOnEventUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
+            {
+                var entities = EventsReceivedComponentGroups[0].GetEntityArray();
+                var eventLists = EventsReceivedComponentGroups[0].GetComponentArray<EventsReceived<FirstEventEvent>>();
+                for (var i = 0; i < entities.Length; i++)
+                {
+                    var readers = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index)
+                        .GetReadersWriters(1002);
+                    var eventList = eventLists[i];
+                    foreach (var reader in readers)
+                    {
+                        foreach (var e in eventList.Buffer)
+                        {
+                            ((SpatialOSNonBlittableComponent.ReaderWriterImpl) reader).OnFirstEventEvent(e);
+                        }
+                    }
+                }
+                var entities = EventsReceivedComponentGroups[1].GetEntityArray();
+                var eventLists = EventsReceivedComponentGroups[1].GetComponentArray<EventsReceived<SecondEventEvent>>();
+                for (var i = 0; i < entities.Length; i++)
+                {
+                    var readers = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index)
+                        .GetReadersWriters(1002);
+                    var eventList = eventLists[i];
+                    foreach (var reader in readers)
+                    {
+                        foreach (var e in eventList.Buffer)
+                        {
+                            ((SpatialOSNonBlittableComponent.ReaderWriterImpl) reader).OnSecondEventEvent(e);
+                        }
+                    }
+                }
+            }
+
+            public override void InvokeOnCommandRequestUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
+            {
+                var entities = CommandRequestsComponentGroups[0].GetEntityArray();
+                var commandLists = CommandRequestsComponentGroups[0].GetComponentArray<CommandRequests<FirstCommand.Request>();
+                for (var i = 0; i < entities.Length; i++)
+                {
+                    var readers = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index)
+                        .GetReadersWriters(1002);
+                    var commandList = commandLists[i];
+                    foreach (var reader in readers)
+                    {
+                        foreach (var req in commandList.Buffer)
+                        {
+                            ((SpatialOSNonBlittableComponent.ReaderWriterImpl) reader).OnFirstCommandCommandRequest(req);
+                        }
+                    }
+                }
+                var entities = CommandRequestsComponentGroups[1].GetEntityArray();
+                var commandLists = CommandRequestsComponentGroups[1].GetComponentArray<CommandRequests<SecondCommand.Request>();
+                for (var i = 0; i < entities.Length; i++)
+                {
+                    var readers = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index)
+                        .GetReadersWriters(1002);
+                    var commandList = commandLists[i];
+                    foreach (var reader in readers)
+                    {
+                        foreach (var req in commandList.Buffer)
+                        {
+                            ((SpatialOSNonBlittableComponent.ReaderWriterImpl) reader).OnSecondCommandCommandRequest(req);
+                        }
+                    }
+                }
+            }
+
+            public override void InvokeOnAuthorityChangeLifecycleCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
+            {
+                var authoritiesChangedTags = AuthoritiesChangedComponentGroup.GetComponentArray<AuthoritiesChanged<SpatialOSNonBlittableComponent>>();
+                var entities = AuthoritiesChangedComponentGroup.GetEntityArray();
+                for (var i = 0; i < entities.Length; i++)
+                {
+                    var spatialOSBehaviourManager = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index);
+                    for (var j = 0; j < authoritiesChangedTags[i].Buffer.Count; j++)
+                    {
+                        spatialOSBehaviourManager.ChangeAuthority(1002, authoritiesChangedTags[i].Buffer[j]);
+                    }
+                }
+            }
+
+            public override void InvokeOnAuthorityChangeUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
+            {
+                var entities = AuthoritiesChangedComponentGroup.GetEntityArray();
+                var authChangeLists = AuthoritiesChangedComponentGroup.GetComponentArray<AuthoritiesChanged<SpatialOSNonBlittableComponent>>();
+                for (var i = 0; i < entities.Length; i++)
+                {
+                    var readers = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index)
+                        .GetReadersWriters(1002);
+                    var authChanges = authChangeLists[i];
+                    foreach (var reader in readers)
+                    {
+                        foreach (var auth in authChanges.Buffer)
+                        {
+                            ((SpatialOSNonBlittableComponent.ReaderWriterImpl) reader).OnAuthorityChange(auth);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentReaderWriter.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentReaderWriter.cs
@@ -1,0 +1,59 @@
+
+// ===========
+// DO NOT EDIT - this file is automatically regenerated.
+// ===========
+
+using Unity.Entities;
+using Improbable.Gdk.Core;
+using Improbable.Gdk.Core.MonoBehaviours;
+using Improbable.Worker;
+using Entity = Unity.Entities.Entity;
+
+namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
+{
+    public partial class NonBlittableComponent
+    {
+        [ComponentId(1002)]
+        internal class ReaderWriterCreator : IReaderWriterCreator
+        {
+            public IReaderInternal CreateReaderWriter(Entity entity, EntityManager entityManager, ILogDispatcher logDispatcher)
+            {
+                return new ReaderWriterImpl(entity, entityManager, logDispatcher);
+            }
+        }
+
+        [ReaderInterface]
+        [ComponentId(1002)]
+        public interface Reader
+        {
+        }
+
+        public class ReaderWriterImpl : Reader, IReaderInternal
+        {
+            public ReaderWriterImpl(Entity entity, EntityManager entityManager, ILogDispatcher logDispatcher)
+            {
+            }
+
+            // IReaderInternal methods
+            void IReaderInternal.OnAuthorityChange(Authority authority)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            void IReaderInternal.OnComponentUpdate()
+            {
+                throw new System.NotImplementedException();
+            }
+            
+            void IReaderInternal.OnEvent(int eventIndex)
+            {
+                throw new System.NotImplementedException();
+            }
+
+            void IReaderInternal.OnCommandRequest(int commandIndex)
+            {
+                throw new System.NotImplementedException();
+            }
+        }
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/GameObjectComponentDispatcherBase.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/GameObjectComponentDispatcherBase.cs
@@ -1,3 +1,7 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using Improbable.Gdk.Core.MonoBehaviours;
 using Unity.Entities;
 
 namespace Improbable.Gdk.Core
@@ -18,13 +22,32 @@ namespace Improbable.Gdk.Core
         public abstract ComponentType[][] CommandRequestsComponentTypeArrays { get; }
         public ComponentGroup[] CommandRequestsComponentGroups { get; set; }
 
-        public abstract void InvokeOnAddComponentLifecycleCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem);
-        public abstract void InvokeOnRemoveComponentLifecycleCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem);
-        public abstract void InvokeOnAuthorityChangeLifecycleCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem);
+        protected abstract uint getComponentId();
 
-        public abstract void InvokeOnAuthorityChangeUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem);
+        public void InvokeOnAddComponentLifecycleCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
+        {
+            var entities = ComponentAddedComponentGroup.GetEntityArray();
+            for (var i = 0; i < entities.Length; i++)
+            {
+                var spatialOSBehaviourManager = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index);
+                spatialOSBehaviourManager.AddComponent(getComponentId());
+            }
+        }
+
+        public void InvokeOnRemoveComponentLifecycleCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
+        {
+            var entities = ComponentRemovedComponentGroup.GetEntityArray();
+            for (var i = 0; i < entities.Length; i++)
+            {
+                var spatialOSBehaviourManager = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index);
+                spatialOSBehaviourManager.RemoveComponent(getComponentId());
+            }
+        }
+
         public abstract void InvokeOnComponentUpdateUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem);
         public abstract void InvokeOnEventUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem);
         public abstract void InvokeOnCommandRequestUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem);
+        public abstract void InvokeOnAuthorityChangeLifecycleCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem);
+        public abstract void InvokeOnAuthorityChangeUserCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem);
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/GameObjectComponentDispatcherBase.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/GameObjectComponentDispatcherBase.cs
@@ -22,7 +22,7 @@ namespace Improbable.Gdk.Core
         public abstract ComponentType[][] CommandRequestsComponentTypeArrays { get; }
         public ComponentGroup[] CommandRequestsComponentGroups { get; set; }
 
-        protected abstract uint getComponentId();
+        protected abstract uint GetComponentId();
 
         public void InvokeOnAddComponentLifecycleCallbacks(GameObjectDispatcherSystem gameObjectDispatcherSystem)
         {
@@ -30,7 +30,7 @@ namespace Improbable.Gdk.Core
             for (var i = 0; i < entities.Length; i++)
             {
                 var spatialOSBehaviourManager = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index);
-                spatialOSBehaviourManager.AddComponent(getComponentId());
+                spatialOSBehaviourManager.AddComponent(GetComponentId());
             }
         }
 
@@ -40,7 +40,7 @@ namespace Improbable.Gdk.Core
             for (var i = 0; i < entities.Length; i++)
             {
                 var spatialOSBehaviourManager = gameObjectDispatcherSystem.GetSpatialOSBehaviourManager(entities[i].Index);
-                spatialOSBehaviourManager.RemoveComponent(getComponentId());
+                spatialOSBehaviourManager.RemoveComponent(GetComponentId());
             }
         }
 


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Implemented invoking callbacks on the internal ReaderWriter implementations with the appropriate payloads, which should in turn invoke user callbacks in the future. This is done by the code generated GameObjectComponentDispatcherSystems, by looking for the appropriate ECS reactive components and passing the relevant update/event/etc objects into the Readers obtained through the SpatialOSBehaviourManager objects associated with each GameObject.

The current implementation assumes a currently nonexistent of a *ComponentName*.ReaderWriterImpl class. (That exact name and location is subject to change, but it will exist under some name.)

The exact way of sending events and commands is also subject to change, eg we might have specific calls code generated for each event/command type instead of passing the index. The general flow of "calling some known method on the Impl" is intended to stay the same though.

Also driveby improvement of replacing typeof() calls with ComponentType.ReadOnly<> by Martijn's suggestion.

See comment for example generated code.

#### Tests
Lacking the ReaderWriterImpls, tests are to be added later for this.
#### Documentation
No additional documentation needed, just filling out blanks really.
#### Primary reviewers
@mattyoung-improbable @firtina-improbable 