### PR TITLE
Removing functionality from the Mutable View

### DIFF
--- a/code_generator/GdkCodeGenerator/Templates/UnityComponentConversionGenerator.tt
+++ b/code_generator/GdkCodeGenerator/Templates/UnityComponentConversionGenerator.tt
@@ -109,7 +109,7 @@ namespace <#= qualifiedNamespace #>
             public override void AddCommandRequestSender(Unity.Entities.Entity entity, long entityId)
             {
 <# if(commandDetailsList.Count > 0) { #>
-                view.AddComponent(entity, new CommandRequestSender<<#= componentDetails.TypeName #>>(entityId, translationHandle));
+                view.EntityManager.AddComponentData(entity, new CommandRequestSender<<#= componentDetails.TypeName #>>(entityId, translationHandle));
 <# } #>
             }
 
@@ -135,19 +135,19 @@ namespace <#= qualifiedNamespace #>
                 <#= componentDetails.CamelCaseTypeName#>.DirtyBit = false;
 
 <# if (componentDetails.IsBlittable) { #>
-                view.AddComponent(entity, <#= componentDetails.CamelCaseTypeName#>);
+                view.EntityManager.AddComponentData(entity, <#= componentDetails.CamelCaseTypeName#>);
 <# } else { #>
                 view.SetComponentObject(entity, <#= componentDetails.CamelCaseTypeName #>);
 <# } #>
-                view.AddComponent(entity, new NotAuthoritative<<#= componentDetails.TypeName #>>());
+                view.EntityManager.AddComponentData(entity, new NotAuthoritative<<#= componentDetails.TypeName #>>());
 
-                if (view.HasComponent<ComponentRemoved<<#= componentDetails.TypeName #>>>(entity))
+                if (view.EntityManager.HasComponent<ComponentRemoved<<#= componentDetails.TypeName #>>>(entity))
                 {
-                    view.RemoveComponent<ComponentRemoved<<#= componentDetails.TypeName #>>>(entity);
+                    view.EntityManager.RemoveComponent<ComponentRemoved<<#= componentDetails.TypeName #>>>(entity);
                 }
-                else if (!view.HasComponent<ComponentAdded<<#= componentDetails.TypeName #>>>(entity))
+                else if (!view.EntityManager.HasComponent<ComponentAdded<<#= componentDetails.TypeName #>>>(entity))
                 {
-                    view.AddComponent(entity, new ComponentAdded<<#= componentDetails.TypeName #>>());
+                    view.EntityManager.AddComponentData(entity, new ComponentAdded<<#= componentDetails.TypeName #>>());
                 }
                 else
                 {
@@ -172,16 +172,16 @@ namespace <#= qualifiedNamespace #>
                 }
 
 <# if (componentDetails.IsBlittable) { #>
-                var componentData = view.GetComponent<<#= componentDetails.TypeName #>>(entity);
+                var componentData = view.EntityManager.GetComponentData<<#= componentDetails.TypeName #>>(entity);
 <# } else { #>
-                var componentData = view.GetComponentObject<<#= componentDetails.TypeName #>>(entity);
+                var componentData = view.EntityManager.GetComponentObject<<#= componentDetails.TypeName #>>(entity);
 <# } #>
 <# if(fieldDetailsList.Count > 0 || eventDetailsList.Count > 0) { #>
                 var update = op.Update.Get();
 <# } #>
 
 <# if(fieldDetailsList.Count > 0) { #>
-                if (view.HasComponent<NotAuthoritative<<#= componentDetails.TypeName #>>>(entity))
+                if (view.EntityManager.HasComponent<NotAuthoritative<<#= componentDetails.TypeName #>>>(entity))
                 {
 <# foreach (var fieldDetails in fieldDetailsList) { #>
                     if (update.<#= fieldDetails.CamelCaseName #>.HasValue)
@@ -242,15 +242,15 @@ namespace <#= qualifiedNamespace #>
                     return;
                 }
 
-                view.RemoveComponent<<#= componentDetails.TypeName #>>(entity);
+                view.EntityManager.RemoveComponent<<#= componentDetails.TypeName #>>(entity);
 
-                if (view.HasComponent<ComponentAdded<<#= componentDetails.TypeName #>>>(entity))
+                if (view.EntityManager.HasComponent<ComponentAdded<<#= componentDetails.TypeName #>>>(entity))
                 {
-                    view.RemoveComponent<ComponentAdded<<#= componentDetails.TypeName #>>>(entity);
+                    view.EntityManager.RemoveComponent<ComponentAdded<<#= componentDetails.TypeName #>>>(entity);
                 }
-                else if (!view.HasComponent<ComponentRemoved<<#= componentDetails.TypeName #>>>(entity))
+                else if (!view.EntityManager.HasComponent<ComponentRemoved<<#= componentDetails.TypeName #>>>(entity))
                 {
-                    view.AddComponent(entity, new ComponentRemoved<<#= componentDetails.TypeName #>>());
+                    view.EntityManager.AddComponentData(entity, new ComponentRemoved<<#= componentDetails.TypeName #>>());
                 }
                 else
                 {
@@ -265,20 +265,29 @@ namespace <#= qualifiedNamespace #>
             public void OnAuthorityChange(AuthorityChangeOp op)
             {
                 var entityId = op.EntityId.Id;
+                Unity.Entities.Entity entity;
+                if (!view.TryGetEntity(entityId, out entity))
+                {
+                    LogDispatcher.HandleLog(LogType.Error, new LogEvent("Entity not found during OnAuthorityChange.")
+                        .WithField(LoggingUtils.LoggerName, LoggerName)
+                        .WithField(LoggingUtils.EntityId, op.EntityId.Id)
+                        .WithField(MutableView.Component, "<#= componentDetails.TypeName #>"));
+                    return;
+                }
 <# if(eventDetailsList.Count > 0) { #>
                 if (op.Authority == Authority.Authoritative)
                 {
 <# foreach(var eventDetails in eventDetailsList) { #>
                     EntityIdTo<#= eventDetails.EventName #>Events[entityId] = new List<<#= eventDetails.FullyQualifiedPayloadTypeName #>>();
 <# } #>
-                    view.AddComponent(entityId, new EventSender<<#= componentDetails.TypeName #>>(entityId, translationHandle));
+                    view.EntityManager.AddComponentData(entity, new EventSender<<#= componentDetails.TypeName #>>(entityId, translationHandle));
                 }
                 else if (op.Authority == Authority.NotAuthoritative)
                 {
 <# foreach(var eventDetails in eventDetailsList) { #>
                     EntityIdTo<#= eventDetails.EventName #>Events.Remove(entityId);
 <# } #>
-                    view.RemoveComponent<EventSender<<#= componentDetails.TypeName #>>>(entityId);
+                    view.EntityManager.RemoveComponent<EventSender<<#= componentDetails.TypeName #>>>(entity);
                 }
 <# } #>
                 view.HandleAuthorityChange(entityId, op.Authority, AuthsPool);

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveBlittableSingularTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveBlittableSingularTranslation.cs
@@ -94,16 +94,16 @@ namespace Generated.Improbable.Gdk.Tests
                 spatialOSExhaustiveBlittableSingular.Field17 = global::Generated.Improbable.Gdk.Tests.SomeType.ToNative(data.field17);
                 spatialOSExhaustiveBlittableSingular.DirtyBit = false;
 
-                view.AddComponent(entity, spatialOSExhaustiveBlittableSingular);
-                view.AddComponent(entity, new NotAuthoritative<SpatialOSExhaustiveBlittableSingular>());
+                view.EntityManager.AddComponentData(entity, spatialOSExhaustiveBlittableSingular);
+                view.EntityManager.AddComponentData(entity, new NotAuthoritative<SpatialOSExhaustiveBlittableSingular>());
 
-                if (view.HasComponent<ComponentRemoved<SpatialOSExhaustiveBlittableSingular>>(entity))
+                if (view.EntityManager.HasComponent<ComponentRemoved<SpatialOSExhaustiveBlittableSingular>>(entity))
                 {
-                    view.RemoveComponent<ComponentRemoved<SpatialOSExhaustiveBlittableSingular>>(entity);
+                    view.EntityManager.RemoveComponent<ComponentRemoved<SpatialOSExhaustiveBlittableSingular>>(entity);
                 }
-                else if (!view.HasComponent<ComponentAdded<SpatialOSExhaustiveBlittableSingular>>(entity))
+                else if (!view.EntityManager.HasComponent<ComponentAdded<SpatialOSExhaustiveBlittableSingular>>(entity))
                 {
-                    view.AddComponent(entity, new ComponentAdded<SpatialOSExhaustiveBlittableSingular>());
+                    view.EntityManager.AddComponentData(entity, new ComponentAdded<SpatialOSExhaustiveBlittableSingular>());
                 }
                 else
                 {
@@ -127,10 +127,10 @@ namespace Generated.Improbable.Gdk.Tests
                     return;
                 }
 
-                var componentData = view.GetComponent<SpatialOSExhaustiveBlittableSingular>(entity);
+                var componentData = view.EntityManager.GetComponentData<SpatialOSExhaustiveBlittableSingular>(entity);
                 var update = op.Update.Get();
 
-                if (view.HasComponent<NotAuthoritative<SpatialOSExhaustiveBlittableSingular>>(entity))
+                if (view.EntityManager.HasComponent<NotAuthoritative<SpatialOSExhaustiveBlittableSingular>>(entity))
                 {
                     if (update.field1.HasValue)
                     {
@@ -294,15 +294,15 @@ namespace Generated.Improbable.Gdk.Tests
                     return;
                 }
 
-                view.RemoveComponent<SpatialOSExhaustiveBlittableSingular>(entity);
+                view.EntityManager.RemoveComponent<SpatialOSExhaustiveBlittableSingular>(entity);
 
-                if (view.HasComponent<ComponentAdded<SpatialOSExhaustiveBlittableSingular>>(entity))
+                if (view.EntityManager.HasComponent<ComponentAdded<SpatialOSExhaustiveBlittableSingular>>(entity))
                 {
-                    view.RemoveComponent<ComponentAdded<SpatialOSExhaustiveBlittableSingular>>(entity);
+                    view.EntityManager.RemoveComponent<ComponentAdded<SpatialOSExhaustiveBlittableSingular>>(entity);
                 }
-                else if (!view.HasComponent<ComponentRemoved<SpatialOSExhaustiveBlittableSingular>>(entity))
+                else if (!view.EntityManager.HasComponent<ComponentRemoved<SpatialOSExhaustiveBlittableSingular>>(entity))
                 {
-                    view.AddComponent(entity, new ComponentRemoved<SpatialOSExhaustiveBlittableSingular>());
+                    view.EntityManager.AddComponentData(entity, new ComponentRemoved<SpatialOSExhaustiveBlittableSingular>());
                 }
                 else
                 {
@@ -317,6 +317,15 @@ namespace Generated.Improbable.Gdk.Tests
             public void OnAuthorityChange(AuthorityChangeOp op)
             {
                 var entityId = op.EntityId.Id;
+                Unity.Entities.Entity entity;
+                if (!view.TryGetEntity(entityId, out entity))
+                {
+                    LogDispatcher.HandleLog(LogType.Error, new LogEvent("Entity not found during OnAuthorityChange.")
+                        .WithField(LoggingUtils.LoggerName, LoggerName)
+                        .WithField(LoggingUtils.EntityId, op.EntityId.Id)
+                        .WithField(MutableView.Component, "SpatialOSExhaustiveBlittableSingular"));
+                    return;
+                }
                 view.HandleAuthorityChange(entityId, op.Authority, AuthsPool);
             }
 

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKeyTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKeyTranslation.cs
@@ -95,15 +95,15 @@ namespace Generated.Improbable.Gdk.Tests
                 spatialOSExhaustiveMapKey.DirtyBit = false;
 
                 view.SetComponentObject(entity, spatialOSExhaustiveMapKey);
-                view.AddComponent(entity, new NotAuthoritative<SpatialOSExhaustiveMapKey>());
+                view.EntityManager.AddComponentData(entity, new NotAuthoritative<SpatialOSExhaustiveMapKey>());
 
-                if (view.HasComponent<ComponentRemoved<SpatialOSExhaustiveMapKey>>(entity))
+                if (view.EntityManager.HasComponent<ComponentRemoved<SpatialOSExhaustiveMapKey>>(entity))
                 {
-                    view.RemoveComponent<ComponentRemoved<SpatialOSExhaustiveMapKey>>(entity);
+                    view.EntityManager.RemoveComponent<ComponentRemoved<SpatialOSExhaustiveMapKey>>(entity);
                 }
-                else if (!view.HasComponent<ComponentAdded<SpatialOSExhaustiveMapKey>>(entity))
+                else if (!view.EntityManager.HasComponent<ComponentAdded<SpatialOSExhaustiveMapKey>>(entity))
                 {
-                    view.AddComponent(entity, new ComponentAdded<SpatialOSExhaustiveMapKey>());
+                    view.EntityManager.AddComponentData(entity, new ComponentAdded<SpatialOSExhaustiveMapKey>());
                 }
                 else
                 {
@@ -127,10 +127,10 @@ namespace Generated.Improbable.Gdk.Tests
                     return;
                 }
 
-                var componentData = view.GetComponentObject<SpatialOSExhaustiveMapKey>(entity);
+                var componentData = view.EntityManager.GetComponentObject<SpatialOSExhaustiveMapKey>(entity);
                 var update = op.Update.Get();
 
-                if (view.HasComponent<NotAuthoritative<SpatialOSExhaustiveMapKey>>(entity))
+                if (view.EntityManager.HasComponent<NotAuthoritative<SpatialOSExhaustiveMapKey>>(entity))
                 {
                     if (update.field2.HasValue)
                     {
@@ -294,15 +294,15 @@ namespace Generated.Improbable.Gdk.Tests
                     return;
                 }
 
-                view.RemoveComponent<SpatialOSExhaustiveMapKey>(entity);
+                view.EntityManager.RemoveComponent<SpatialOSExhaustiveMapKey>(entity);
 
-                if (view.HasComponent<ComponentAdded<SpatialOSExhaustiveMapKey>>(entity))
+                if (view.EntityManager.HasComponent<ComponentAdded<SpatialOSExhaustiveMapKey>>(entity))
                 {
-                    view.RemoveComponent<ComponentAdded<SpatialOSExhaustiveMapKey>>(entity);
+                    view.EntityManager.RemoveComponent<ComponentAdded<SpatialOSExhaustiveMapKey>>(entity);
                 }
-                else if (!view.HasComponent<ComponentRemoved<SpatialOSExhaustiveMapKey>>(entity))
+                else if (!view.EntityManager.HasComponent<ComponentRemoved<SpatialOSExhaustiveMapKey>>(entity))
                 {
-                    view.AddComponent(entity, new ComponentRemoved<SpatialOSExhaustiveMapKey>());
+                    view.EntityManager.AddComponentData(entity, new ComponentRemoved<SpatialOSExhaustiveMapKey>());
                 }
                 else
                 {
@@ -317,6 +317,15 @@ namespace Generated.Improbable.Gdk.Tests
             public void OnAuthorityChange(AuthorityChangeOp op)
             {
                 var entityId = op.EntityId.Id;
+                Unity.Entities.Entity entity;
+                if (!view.TryGetEntity(entityId, out entity))
+                {
+                    LogDispatcher.HandleLog(LogType.Error, new LogEvent("Entity not found during OnAuthorityChange.")
+                        .WithField(LoggingUtils.LoggerName, LoggerName)
+                        .WithField(LoggingUtils.EntityId, op.EntityId.Id)
+                        .WithField(MutableView.Component, "SpatialOSExhaustiveMapKey"));
+                    return;
+                }
                 view.HandleAuthorityChange(entityId, op.Authority, AuthsPool);
             }
 

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValueTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValueTranslation.cs
@@ -95,15 +95,15 @@ namespace Generated.Improbable.Gdk.Tests
                 spatialOSExhaustiveMapValue.DirtyBit = false;
 
                 view.SetComponentObject(entity, spatialOSExhaustiveMapValue);
-                view.AddComponent(entity, new NotAuthoritative<SpatialOSExhaustiveMapValue>());
+                view.EntityManager.AddComponentData(entity, new NotAuthoritative<SpatialOSExhaustiveMapValue>());
 
-                if (view.HasComponent<ComponentRemoved<SpatialOSExhaustiveMapValue>>(entity))
+                if (view.EntityManager.HasComponent<ComponentRemoved<SpatialOSExhaustiveMapValue>>(entity))
                 {
-                    view.RemoveComponent<ComponentRemoved<SpatialOSExhaustiveMapValue>>(entity);
+                    view.EntityManager.RemoveComponent<ComponentRemoved<SpatialOSExhaustiveMapValue>>(entity);
                 }
-                else if (!view.HasComponent<ComponentAdded<SpatialOSExhaustiveMapValue>>(entity))
+                else if (!view.EntityManager.HasComponent<ComponentAdded<SpatialOSExhaustiveMapValue>>(entity))
                 {
-                    view.AddComponent(entity, new ComponentAdded<SpatialOSExhaustiveMapValue>());
+                    view.EntityManager.AddComponentData(entity, new ComponentAdded<SpatialOSExhaustiveMapValue>());
                 }
                 else
                 {
@@ -127,10 +127,10 @@ namespace Generated.Improbable.Gdk.Tests
                     return;
                 }
 
-                var componentData = view.GetComponentObject<SpatialOSExhaustiveMapValue>(entity);
+                var componentData = view.EntityManager.GetComponentObject<SpatialOSExhaustiveMapValue>(entity);
                 var update = op.Update.Get();
 
-                if (view.HasComponent<NotAuthoritative<SpatialOSExhaustiveMapValue>>(entity))
+                if (view.EntityManager.HasComponent<NotAuthoritative<SpatialOSExhaustiveMapValue>>(entity))
                 {
                     if (update.field2.HasValue)
                     {
@@ -294,15 +294,15 @@ namespace Generated.Improbable.Gdk.Tests
                     return;
                 }
 
-                view.RemoveComponent<SpatialOSExhaustiveMapValue>(entity);
+                view.EntityManager.RemoveComponent<SpatialOSExhaustiveMapValue>(entity);
 
-                if (view.HasComponent<ComponentAdded<SpatialOSExhaustiveMapValue>>(entity))
+                if (view.EntityManager.HasComponent<ComponentAdded<SpatialOSExhaustiveMapValue>>(entity))
                 {
-                    view.RemoveComponent<ComponentAdded<SpatialOSExhaustiveMapValue>>(entity);
+                    view.EntityManager.RemoveComponent<ComponentAdded<SpatialOSExhaustiveMapValue>>(entity);
                 }
-                else if (!view.HasComponent<ComponentRemoved<SpatialOSExhaustiveMapValue>>(entity))
+                else if (!view.EntityManager.HasComponent<ComponentRemoved<SpatialOSExhaustiveMapValue>>(entity))
                 {
-                    view.AddComponent(entity, new ComponentRemoved<SpatialOSExhaustiveMapValue>());
+                    view.EntityManager.AddComponentData(entity, new ComponentRemoved<SpatialOSExhaustiveMapValue>());
                 }
                 else
                 {
@@ -317,6 +317,15 @@ namespace Generated.Improbable.Gdk.Tests
             public void OnAuthorityChange(AuthorityChangeOp op)
             {
                 var entityId = op.EntityId.Id;
+                Unity.Entities.Entity entity;
+                if (!view.TryGetEntity(entityId, out entity))
+                {
+                    LogDispatcher.HandleLog(LogType.Error, new LogEvent("Entity not found during OnAuthorityChange.")
+                        .WithField(LoggingUtils.LoggerName, LoggerName)
+                        .WithField(LoggingUtils.EntityId, op.EntityId.Id)
+                        .WithField(MutableView.Component, "SpatialOSExhaustiveMapValue"));
+                    return;
+                }
                 view.HandleAuthorityChange(entityId, op.Authority, AuthsPool);
             }
 

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptionalTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptionalTranslation.cs
@@ -94,15 +94,15 @@ namespace Generated.Improbable.Gdk.Tests
                 spatialOSExhaustiveOptional.DirtyBit = false;
 
                 view.SetComponentObject(entity, spatialOSExhaustiveOptional);
-                view.AddComponent(entity, new NotAuthoritative<SpatialOSExhaustiveOptional>());
+                view.EntityManager.AddComponentData(entity, new NotAuthoritative<SpatialOSExhaustiveOptional>());
 
-                if (view.HasComponent<ComponentRemoved<SpatialOSExhaustiveOptional>>(entity))
+                if (view.EntityManager.HasComponent<ComponentRemoved<SpatialOSExhaustiveOptional>>(entity))
                 {
-                    view.RemoveComponent<ComponentRemoved<SpatialOSExhaustiveOptional>>(entity);
+                    view.EntityManager.RemoveComponent<ComponentRemoved<SpatialOSExhaustiveOptional>>(entity);
                 }
-                else if (!view.HasComponent<ComponentAdded<SpatialOSExhaustiveOptional>>(entity))
+                else if (!view.EntityManager.HasComponent<ComponentAdded<SpatialOSExhaustiveOptional>>(entity))
                 {
-                    view.AddComponent(entity, new ComponentAdded<SpatialOSExhaustiveOptional>());
+                    view.EntityManager.AddComponentData(entity, new ComponentAdded<SpatialOSExhaustiveOptional>());
                 }
                 else
                 {
@@ -126,10 +126,10 @@ namespace Generated.Improbable.Gdk.Tests
                     return;
                 }
 
-                var componentData = view.GetComponentObject<SpatialOSExhaustiveOptional>(entity);
+                var componentData = view.EntityManager.GetComponentObject<SpatialOSExhaustiveOptional>(entity);
                 var update = op.Update.Get();
 
-                if (view.HasComponent<NotAuthoritative<SpatialOSExhaustiveOptional>>(entity))
+                if (view.EntityManager.HasComponent<NotAuthoritative<SpatialOSExhaustiveOptional>>(entity))
                 {
                     if (update.field2.HasValue)
                     {
@@ -284,15 +284,15 @@ namespace Generated.Improbable.Gdk.Tests
                     return;
                 }
 
-                view.RemoveComponent<SpatialOSExhaustiveOptional>(entity);
+                view.EntityManager.RemoveComponent<SpatialOSExhaustiveOptional>(entity);
 
-                if (view.HasComponent<ComponentAdded<SpatialOSExhaustiveOptional>>(entity))
+                if (view.EntityManager.HasComponent<ComponentAdded<SpatialOSExhaustiveOptional>>(entity))
                 {
-                    view.RemoveComponent<ComponentAdded<SpatialOSExhaustiveOptional>>(entity);
+                    view.EntityManager.RemoveComponent<ComponentAdded<SpatialOSExhaustiveOptional>>(entity);
                 }
-                else if (!view.HasComponent<ComponentRemoved<SpatialOSExhaustiveOptional>>(entity))
+                else if (!view.EntityManager.HasComponent<ComponentRemoved<SpatialOSExhaustiveOptional>>(entity))
                 {
-                    view.AddComponent(entity, new ComponentRemoved<SpatialOSExhaustiveOptional>());
+                    view.EntityManager.AddComponentData(entity, new ComponentRemoved<SpatialOSExhaustiveOptional>());
                 }
                 else
                 {
@@ -307,6 +307,15 @@ namespace Generated.Improbable.Gdk.Tests
             public void OnAuthorityChange(AuthorityChangeOp op)
             {
                 var entityId = op.EntityId.Id;
+                Unity.Entities.Entity entity;
+                if (!view.TryGetEntity(entityId, out entity))
+                {
+                    LogDispatcher.HandleLog(LogType.Error, new LogEvent("Entity not found during OnAuthorityChange.")
+                        .WithField(LoggingUtils.LoggerName, LoggerName)
+                        .WithField(LoggingUtils.EntityId, op.EntityId.Id)
+                        .WithField(MutableView.Component, "SpatialOSExhaustiveOptional"));
+                    return;
+                }
                 view.HandleAuthorityChange(entityId, op.Authority, AuthsPool);
             }
 

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeatedTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeatedTranslation.cs
@@ -95,15 +95,15 @@ namespace Generated.Improbable.Gdk.Tests
                 spatialOSExhaustiveRepeated.DirtyBit = false;
 
                 view.SetComponentObject(entity, spatialOSExhaustiveRepeated);
-                view.AddComponent(entity, new NotAuthoritative<SpatialOSExhaustiveRepeated>());
+                view.EntityManager.AddComponentData(entity, new NotAuthoritative<SpatialOSExhaustiveRepeated>());
 
-                if (view.HasComponent<ComponentRemoved<SpatialOSExhaustiveRepeated>>(entity))
+                if (view.EntityManager.HasComponent<ComponentRemoved<SpatialOSExhaustiveRepeated>>(entity))
                 {
-                    view.RemoveComponent<ComponentRemoved<SpatialOSExhaustiveRepeated>>(entity);
+                    view.EntityManager.RemoveComponent<ComponentRemoved<SpatialOSExhaustiveRepeated>>(entity);
                 }
-                else if (!view.HasComponent<ComponentAdded<SpatialOSExhaustiveRepeated>>(entity))
+                else if (!view.EntityManager.HasComponent<ComponentAdded<SpatialOSExhaustiveRepeated>>(entity))
                 {
-                    view.AddComponent(entity, new ComponentAdded<SpatialOSExhaustiveRepeated>());
+                    view.EntityManager.AddComponentData(entity, new ComponentAdded<SpatialOSExhaustiveRepeated>());
                 }
                 else
                 {
@@ -127,10 +127,10 @@ namespace Generated.Improbable.Gdk.Tests
                     return;
                 }
 
-                var componentData = view.GetComponentObject<SpatialOSExhaustiveRepeated>(entity);
+                var componentData = view.EntityManager.GetComponentObject<SpatialOSExhaustiveRepeated>(entity);
                 var update = op.Update.Get();
 
-                if (view.HasComponent<NotAuthoritative<SpatialOSExhaustiveRepeated>>(entity))
+                if (view.EntityManager.HasComponent<NotAuthoritative<SpatialOSExhaustiveRepeated>>(entity))
                 {
                     if (update.field2.HasValue)
                     {
@@ -294,15 +294,15 @@ namespace Generated.Improbable.Gdk.Tests
                     return;
                 }
 
-                view.RemoveComponent<SpatialOSExhaustiveRepeated>(entity);
+                view.EntityManager.RemoveComponent<SpatialOSExhaustiveRepeated>(entity);
 
-                if (view.HasComponent<ComponentAdded<SpatialOSExhaustiveRepeated>>(entity))
+                if (view.EntityManager.HasComponent<ComponentAdded<SpatialOSExhaustiveRepeated>>(entity))
                 {
-                    view.RemoveComponent<ComponentAdded<SpatialOSExhaustiveRepeated>>(entity);
+                    view.EntityManager.RemoveComponent<ComponentAdded<SpatialOSExhaustiveRepeated>>(entity);
                 }
-                else if (!view.HasComponent<ComponentRemoved<SpatialOSExhaustiveRepeated>>(entity))
+                else if (!view.EntityManager.HasComponent<ComponentRemoved<SpatialOSExhaustiveRepeated>>(entity))
                 {
-                    view.AddComponent(entity, new ComponentRemoved<SpatialOSExhaustiveRepeated>());
+                    view.EntityManager.AddComponentData(entity, new ComponentRemoved<SpatialOSExhaustiveRepeated>());
                 }
                 else
                 {
@@ -317,6 +317,15 @@ namespace Generated.Improbable.Gdk.Tests
             public void OnAuthorityChange(AuthorityChangeOp op)
             {
                 var entityId = op.EntityId.Id;
+                Unity.Entities.Entity entity;
+                if (!view.TryGetEntity(entityId, out entity))
+                {
+                    LogDispatcher.HandleLog(LogType.Error, new LogEvent("Entity not found during OnAuthorityChange.")
+                        .WithField(LoggingUtils.LoggerName, LoggerName)
+                        .WithField(LoggingUtils.EntityId, op.EntityId.Id)
+                        .WithField(MutableView.Component, "SpatialOSExhaustiveRepeated"));
+                    return;
+                }
                 view.HandleAuthorityChange(entityId, op.Authority, AuthsPool);
             }
 

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingularTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingularTranslation.cs
@@ -96,15 +96,15 @@ namespace Generated.Improbable.Gdk.Tests
                 spatialOSExhaustiveSingular.DirtyBit = false;
 
                 view.SetComponentObject(entity, spatialOSExhaustiveSingular);
-                view.AddComponent(entity, new NotAuthoritative<SpatialOSExhaustiveSingular>());
+                view.EntityManager.AddComponentData(entity, new NotAuthoritative<SpatialOSExhaustiveSingular>());
 
-                if (view.HasComponent<ComponentRemoved<SpatialOSExhaustiveSingular>>(entity))
+                if (view.EntityManager.HasComponent<ComponentRemoved<SpatialOSExhaustiveSingular>>(entity))
                 {
-                    view.RemoveComponent<ComponentRemoved<SpatialOSExhaustiveSingular>>(entity);
+                    view.EntityManager.RemoveComponent<ComponentRemoved<SpatialOSExhaustiveSingular>>(entity);
                 }
-                else if (!view.HasComponent<ComponentAdded<SpatialOSExhaustiveSingular>>(entity))
+                else if (!view.EntityManager.HasComponent<ComponentAdded<SpatialOSExhaustiveSingular>>(entity))
                 {
-                    view.AddComponent(entity, new ComponentAdded<SpatialOSExhaustiveSingular>());
+                    view.EntityManager.AddComponentData(entity, new ComponentAdded<SpatialOSExhaustiveSingular>());
                 }
                 else
                 {
@@ -128,10 +128,10 @@ namespace Generated.Improbable.Gdk.Tests
                     return;
                 }
 
-                var componentData = view.GetComponentObject<SpatialOSExhaustiveSingular>(entity);
+                var componentData = view.EntityManager.GetComponentObject<SpatialOSExhaustiveSingular>(entity);
                 var update = op.Update.Get();
 
-                if (view.HasComponent<NotAuthoritative<SpatialOSExhaustiveSingular>>(entity))
+                if (view.EntityManager.HasComponent<NotAuthoritative<SpatialOSExhaustiveSingular>>(entity))
                 {
                     if (update.field1.HasValue)
                     {
@@ -304,15 +304,15 @@ namespace Generated.Improbable.Gdk.Tests
                     return;
                 }
 
-                view.RemoveComponent<SpatialOSExhaustiveSingular>(entity);
+                view.EntityManager.RemoveComponent<SpatialOSExhaustiveSingular>(entity);
 
-                if (view.HasComponent<ComponentAdded<SpatialOSExhaustiveSingular>>(entity))
+                if (view.EntityManager.HasComponent<ComponentAdded<SpatialOSExhaustiveSingular>>(entity))
                 {
-                    view.RemoveComponent<ComponentAdded<SpatialOSExhaustiveSingular>>(entity);
+                    view.EntityManager.RemoveComponent<ComponentAdded<SpatialOSExhaustiveSingular>>(entity);
                 }
-                else if (!view.HasComponent<ComponentRemoved<SpatialOSExhaustiveSingular>>(entity))
+                else if (!view.EntityManager.HasComponent<ComponentRemoved<SpatialOSExhaustiveSingular>>(entity))
                 {
-                    view.AddComponent(entity, new ComponentRemoved<SpatialOSExhaustiveSingular>());
+                    view.EntityManager.AddComponentData(entity, new ComponentRemoved<SpatialOSExhaustiveSingular>());
                 }
                 else
                 {
@@ -327,6 +327,15 @@ namespace Generated.Improbable.Gdk.Tests
             public void OnAuthorityChange(AuthorityChangeOp op)
             {
                 var entityId = op.EntityId.Id;
+                Unity.Entities.Entity entity;
+                if (!view.TryGetEntity(entityId, out entity))
+                {
+                    LogDispatcher.HandleLog(LogType.Error, new LogEvent("Entity not found during OnAuthorityChange.")
+                        .WithField(LoggingUtils.LoggerName, LoggerName)
+                        .WithField(LoggingUtils.EntityId, op.EntityId.Id)
+                        .WithField(MutableView.Component, "SpatialOSExhaustiveSingular"));
+                    return;
+                }
                 view.HandleAuthorityChange(entityId, op.Authority, AuthsPool);
             }
 

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/NestedComponentTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/NestedComponentTranslation.cs
@@ -80,16 +80,16 @@ namespace Generated.Improbable.Gdk.Tests
                 spatialOSNestedComponent.NestedType = global::Generated.Improbable.Gdk.Tests.TypeName.ToNative(data.nestedType);
                 spatialOSNestedComponent.DirtyBit = false;
 
-                view.AddComponent(entity, spatialOSNestedComponent);
-                view.AddComponent(entity, new NotAuthoritative<SpatialOSNestedComponent>());
+                view.EntityManager.AddComponentData(entity, spatialOSNestedComponent);
+                view.EntityManager.AddComponentData(entity, new NotAuthoritative<SpatialOSNestedComponent>());
 
-                if (view.HasComponent<ComponentRemoved<SpatialOSNestedComponent>>(entity))
+                if (view.EntityManager.HasComponent<ComponentRemoved<SpatialOSNestedComponent>>(entity))
                 {
-                    view.RemoveComponent<ComponentRemoved<SpatialOSNestedComponent>>(entity);
+                    view.EntityManager.RemoveComponent<ComponentRemoved<SpatialOSNestedComponent>>(entity);
                 }
-                else if (!view.HasComponent<ComponentAdded<SpatialOSNestedComponent>>(entity))
+                else if (!view.EntityManager.HasComponent<ComponentAdded<SpatialOSNestedComponent>>(entity))
                 {
-                    view.AddComponent(entity, new ComponentAdded<SpatialOSNestedComponent>());
+                    view.EntityManager.AddComponentData(entity, new ComponentAdded<SpatialOSNestedComponent>());
                 }
                 else
                 {
@@ -113,10 +113,10 @@ namespace Generated.Improbable.Gdk.Tests
                     return;
                 }
 
-                var componentData = view.GetComponent<SpatialOSNestedComponent>(entity);
+                var componentData = view.EntityManager.GetComponentData<SpatialOSNestedComponent>(entity);
                 var update = op.Update.Get();
 
-                if (view.HasComponent<NotAuthoritative<SpatialOSNestedComponent>>(entity))
+                if (view.EntityManager.HasComponent<NotAuthoritative<SpatialOSNestedComponent>>(entity))
                 {
                     if (update.nestedType.HasValue)
                     {
@@ -154,15 +154,15 @@ namespace Generated.Improbable.Gdk.Tests
                     return;
                 }
 
-                view.RemoveComponent<SpatialOSNestedComponent>(entity);
+                view.EntityManager.RemoveComponent<SpatialOSNestedComponent>(entity);
 
-                if (view.HasComponent<ComponentAdded<SpatialOSNestedComponent>>(entity))
+                if (view.EntityManager.HasComponent<ComponentAdded<SpatialOSNestedComponent>>(entity))
                 {
-                    view.RemoveComponent<ComponentAdded<SpatialOSNestedComponent>>(entity);
+                    view.EntityManager.RemoveComponent<ComponentAdded<SpatialOSNestedComponent>>(entity);
                 }
-                else if (!view.HasComponent<ComponentRemoved<SpatialOSNestedComponent>>(entity))
+                else if (!view.EntityManager.HasComponent<ComponentRemoved<SpatialOSNestedComponent>>(entity))
                 {
-                    view.AddComponent(entity, new ComponentRemoved<SpatialOSNestedComponent>());
+                    view.EntityManager.AddComponentData(entity, new ComponentRemoved<SpatialOSNestedComponent>());
                 }
                 else
                 {
@@ -177,6 +177,15 @@ namespace Generated.Improbable.Gdk.Tests
             public void OnAuthorityChange(AuthorityChangeOp op)
             {
                 var entityId = op.EntityId.Id;
+                Unity.Entities.Entity entity;
+                if (!view.TryGetEntity(entityId, out entity))
+                {
+                    LogDispatcher.HandleLog(LogType.Error, new LogEvent("Entity not found during OnAuthorityChange.")
+                        .WithField(LoggingUtils.LoggerName, LoggerName)
+                        .WithField(LoggingUtils.EntityId, op.EntityId.Id)
+                        .WithField(MutableView.Component, "SpatialOSNestedComponent"));
+                    return;
+                }
                 view.HandleAuthorityChange(entityId, op.Authority, AuthsPool);
             }
 

--- a/workers/unity/Assets/Playground/Scripts/Player/PlayerCommandsSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/Player/PlayerCommandsSystem.cs
@@ -80,7 +80,7 @@ namespace Playground
             var playerId = playerData.SpatialEntity[0].EntityId;
 
             var component = rigidBody.gameObject.GetComponent<SpatialOSComponent>();
-            if (component != null && view.EntityManager.HasComponent(component.Entity, typeof(SpatialOSLaunchable)))
+            if (component != null && EntityManager.HasComponent(component.Entity, typeof(SpatialOSLaunchable)))
             {
                 var impactPoint = new Vector3f { X = info.point.x, Y = info.point.y, Z = info.point.z };
                 var launchDirection = new Vector3f { X = ray.direction.x, Y = ray.direction.y, Z = ray.direction.z };

--- a/workers/unity/Assets/Playground/Scripts/Player/PlayerCommandsSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/Player/PlayerCommandsSystem.cs
@@ -80,7 +80,7 @@ namespace Playground
             var playerId = playerData.SpatialEntity[0].EntityId;
 
             var component = rigidBody.gameObject.GetComponent<SpatialOSComponent>();
-            if (component != null && view.HasComponent(component.Entity, typeof(SpatialOSLaunchable)))
+            if (component != null && view.EntityManager.HasComponent(component.Entity, typeof(SpatialOSLaunchable)))
             {
                 var impactPoint = new Vector3f { X = info.point.x, Y = info.point.y, Z = info.point.z };
                 var launchDirection = new Vector3f { X = ray.direction.x, Y = ray.direction.y, Z = ray.direction.z };

--- a/workers/unity/Packages/com.improbable.gdk.core/Components/ComponentTranslation.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Components/ComponentTranslation.cs
@@ -70,7 +70,7 @@ namespace Improbable.Gdk.Core.Components
             for (var i = 0; i < entityArray.Length; i++)
             {
                 var entity = entityArray[i];
-                if (view.HasComponent<T>(entity))
+                if (view.EntityManager.HasComponent<T>(entity))
                 {
                     entityCommandBuffer.RemoveComponent<T>(entity);
                 }
@@ -86,9 +86,9 @@ namespace Improbable.Gdk.Core.Components
             for (var i = 0; i < entityArray.Length; i++)
             {
                 var entity = entityArray[i];
-                if (view.HasComponent<T>(entity))
+                if (view.EntityManager.HasComponent<T>(entity))
                 {
-                    pool.PutComponent(view.GetComponentObject<T>(entity));
+                    pool.PutComponent(view.EntityManager.GetComponentObject<T>(entity));
                     entityCommandBuffer.RemoveComponent<T>(entity);
                 }
             }

--- a/workers/unity/Packages/com.improbable.gdk.core/Components/WorldCommandsTranslation.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Components/WorldCommandsTranslation.cs
@@ -258,7 +258,7 @@ namespace Improbable.Gdk.Core
 
         public override void AddCommandRequestSender(Entity entity, long EntityId)
         {
-            view.AddComponent(entity, new WorldCommandSender(EntityId, translationHandle));
+            view.EntityManager.AddComponentData(entity, new WorldCommandSender(EntityId, translationHandle));
         }
 
         public override void ExecuteReplication(Connection connection)

--- a/workers/unity/Packages/com.improbable.gdk.core/Utility/ViewCommandBuffer.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Utility/ViewCommandBuffer.cs
@@ -58,7 +58,7 @@ namespace Improbable.Gdk.Core
                             bufferedCommand.ComponentObj);
                         break;
                     case CommandType.RemoveComponent:
-                        view.RemoveComponent(bufferedCommand.Entity,
+                        view.EntityManager.RemoveComponent(bufferedCommand.Entity,
                             bufferedCommand.ComponentType);
                         break;
                     default:


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
The first of many PRs to get rid of the mutable view. This one simply removes all the wrapper methods that we have and don't provide any additional functionality. Any method that contains a bit more logic is still in there until I decide on how to exactly factor this out. Right now, we use the EntityManager from the view, this will also change in one of the next PRs

#### Tests
Tested that local deployment still works.

#### Documentation
no docs 

#### Primary reviewers
@jamiebrynes7 