### PR TITLE
UTY-938: Moved EntityGameObjectLinker out of WorkerBase

### DIFF
--- a/workers/unity/Assets/Playground/Scripts/EntityInitialization/GameObjectInitializationSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/EntityInitialization/GameObjectInitializationSystem.cs
@@ -43,6 +43,7 @@ namespace Playground
         private EntityGameObjectCreator entityGameObjectCreator;
         private uint currentHandle;
         private readonly Dictionary<int, GameObject> entityGameObjectCache = new Dictionary<int, GameObject>();
+        private EntityGameObjectLinker entityGameObjectLinker;
 
         protected override void OnCreateManager(int capacity)
         {
@@ -52,6 +53,7 @@ namespace Playground
             view = worker.View;
             origin = worker.Origin;
             entityGameObjectCreator = new EntityGameObjectCreator(World);
+            entityGameObjectLinker = new EntityGameObjectLinker(World, view);
         }
 
         protected override void OnUpdate()
@@ -94,7 +96,7 @@ namespace Playground
                 PostUpdateCommands.AddComponent(addedEntitiesData.Entities[i],
                     requiresSpatialOSBehaviourManagerComponent);
                 PostUpdateCommands.AddComponent(addedEntitiesData.Entities[i], gameObjectReferenceHandleComponent);
-                worker.EntityGameObjectLinker.LinkGameObjectToEntity(gameObject, entity, spatialEntityId,
+                entityGameObjectLinker.LinkGameObjectToEntity(gameObject, entity, spatialEntityId,
                     viewCommandBuffer);
             }
 

--- a/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerBase.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerBase.cs
@@ -20,8 +20,6 @@ namespace Improbable.Gdk.Core
 
         public abstract string GetWorkerType { get; }
 
-        public EntityGameObjectLinker EntityGameObjectLinker { get; private set; }
-
         public bool UseDynamicId { get; protected set; }
 
         protected WorkerBase(string workerId, Vector3 origin) : this(workerId, origin, new LoggingDispatcher())
@@ -46,8 +44,6 @@ namespace Improbable.Gdk.Core
 
             View = new MutableView(World, loggingDispatcher);
             Origin = origin;
-
-            EntityGameObjectLinker = new EntityGameObjectLinker(World, View);
         }
 
         public void Dispose()


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
The GameObjectRepresentation stuff is supposed to act like a feature module, so Core things should not need references to it. This is only broken in one place at the moment, the EntityGameObjectLinker instance is a field of WorkerBase. This PR moves that into the GameObjectInitializationSystem, which is the only place using it.

The GameObjectInitializationSystem is also subject to change, currently it is in Playground while most of its functionality should be in the feature module. And we might want to expose the EntityGameObjectLinker to the users eventually, in which case they need a more convenient place to access it, probably through a static helper class. But that can be done when we work on that entry point to the API and is not in scope of this PR.

#### Tests
Tests pass, Playground works
#### Documentation
N/A
#### Primary reviewers
@firtina-improbable @jessicafalk 