### PR TITLE
UTY-764: World Commands Rewrite

### DIFF
--- a/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands.cs
@@ -1,87 +1,788 @@
-
+using System;
 using System.Collections.Generic;
+using System.Linq;
 using Improbable.Worker;
 using Improbable.Worker.Core;
+using Unity.Entities;
+using Entity = Improbable.Worker.Core.Entity;
 
 namespace Improbable.Gdk.Core.Commands
 {
-    public class CreateEntity
+    public static class WorldCommands
     {
-        public struct Request
+        internal static void AddWorldCommandRequesters(World world, EntityManager manager, Unity.Entities.Entity entity)
         {
-            public Worker.Core.Entity Entity;
-            public EntityId? EntityId;
-            public uint? TimeoutMillis;
-            public uint SenderEntityId;
-
-            internal RequestId<CreateEntityRequest> Send(Connection connection)
+            var createEntitySender = new CreateEntity.CommandSender
             {
-                return connection.SendCreateEntityRequest(Entity, EntityId, TimeoutMillis);
-            } 
+                Handle = CreateEntity.RequestsProvider.Allocate(world)
+            };
+
+            createEntitySender.RequestsToSend = new List<CreateEntity.Request>();
+            manager.AddComponentData(entity, createEntitySender);
+
+            var deleteEntitySender = new DeleteEntity.CommandSender
+            {
+                Handle = DeleteEntity.RequestsProvider.Allocate(world)
+            };
+
+            deleteEntitySender.RequestsToSend = new List<DeleteEntity.Request>();
+            manager.AddComponentData(entity, deleteEntitySender);
+
+            var reserveEntityIdsSender = new ReserveEntityIds.CommandSender
+            {
+                Handle = ReserveEntityIds.RequestsProvider.Allocate(world)
+            };
+
+            reserveEntityIdsSender.RequestsToSend = new List<ReserveEntityIds.Request>();
+            manager.AddComponentData(entity, reserveEntityIdsSender);
+
+            var entityQuerySender = new EntityQuery.CommandSender
+            {
+                Handle = EntityQuery.RequestsProvider.Allocate(world)
+            };
+
+            entityQuerySender.RequestsToSend = new List<EntityQuery.Request>();
+            manager.AddComponentData(entity, entityQuerySender);
         }
 
-        public struct Response : IIncomingCommandResponse
+        internal static void DeallocateWorldCommandRequesters(EntityManager manager, Unity.Entities.Entity entity)
         {
-            public StatusCode StatusCode { get; }
-            public string Message { get; }
-            public EntityId EntityId { get; }
+            var createEntityData = manager.GetComponentData<CreateEntity.CommandSender>(entity);
+            CreateEntity.RequestsProvider.Free(createEntityData.Handle);
+
+            var deleteEntityData = manager.GetComponentData<DeleteEntity.CommandSender>(entity);
+            DeleteEntity.RequestsProvider.Free(deleteEntityData.Handle);
+
+            var reserveEntityIdsData = manager.GetComponentData<ReserveEntityIds.CommandSender>(entity);
+            ReserveEntityIds.RequestsProvider.Free(reserveEntityIdsData.Handle);
+
+            var entityQueryData = manager.GetComponentData<EntityQuery.CommandSender>(entity);
+            EntityQuery.RequestsProvider.Free(entityQueryData.Handle);
         }
-    }
 
-    public class DeleteEntity
-    {
-        public struct Request {
-            public EntityId EntityId;
-            public uint? TimeoutMillis;
-            public long SenderEntityId;
-
-            internal RequestId<DeleteEntityRequest> Send(Connection connection)
+        public static class CreateEntity
+        {
+            public struct Request
             {
-                return connection.SendDeleteEntityRequest(EntityId, TimeoutMillis);
+                public Entity Entity;
+                public EntityId? EntityId;
+                public uint? TimeoutMillis;
+                public uint SenderEntityId;
+            }
+
+            public struct ReceivedResponse
+            {
+                public CreateEntityResponseOp Op { get; }
+                public Request RawRequest { get; }
+                public object Context { get; }
+
+                internal ReceivedResponse(CreateEntityResponseOp op, Request req, object context)
+                {
+                    Op = op;
+                    RawRequest = req;
+                    Context = context;
+                }
+            }
+
+            public struct CommandSender : IComponentData
+            {
+                internal uint Handle;
+
+                public List<Request> RequestsToSend
+                {
+                    get => RequestsProvider.Get(Handle);
+                    set => RequestsProvider.Set(Handle, value);
+                }
+            }
+
+            public struct CommandResponses : IComponentData
+            {
+                internal uint Handle;
+
+                public List<ReceivedResponse> Responses
+                {
+                    get => ResponsesProvider.Get(Handle);
+                    set => ResponsesProvider.Set(Handle, value);
+                }
+            }
+
+            internal static class RequestsProvider
+            {
+                private static readonly Dictionary<uint, List<Request>> Storage = new Dictionary<uint, List<Request>>();
+                private static readonly Dictionary<uint, World> WorldMapping = new Dictionary<uint, World>();
+
+                private static uint nextHandle = 0;
+
+                public static uint Allocate(World world)
+                {
+                    var handle = GetNextHandle();
+                    Storage.Add(handle, default(List<Request>));
+                    WorldMapping.Add(handle, world);
+
+                    return handle;
+                }
+
+                public static List<Request> Get(uint handle)
+                {
+                    if (!Storage.TryGetValue(handle, out var value))
+                    {
+                        throw new ArgumentException($"UpdatesProvider does not contain handle {handle}");
+                    }
+
+                    return value;
+                }
+
+                public static void Set(uint handle, List<Request> value)
+                {
+                    if (!Storage.ContainsKey(handle))
+                    {
+                        throw new ArgumentException($"UpdatesProvider does not contain handle {handle}");
+                    }
+
+                    Storage[handle] = value;
+                }
+
+                public static void Free(uint handle)
+                {
+                    Storage.Remove(handle);
+                    WorldMapping.Remove(handle);
+                }
+
+                public static void CleanDataInWorld(World world)
+                {
+                    var handles = WorldMapping.Where(pair => pair.Value == world).Select(pair => pair.Key);
+
+                    foreach (var handle in handles)
+                    {
+                        Free(handle);
+                    }
+                }
+
+                private static uint GetNextHandle()
+                {
+                    nextHandle++;
+
+                    while (Storage.ContainsKey(nextHandle))
+                    {
+                        nextHandle++;
+                    }
+
+                    return nextHandle;
+                }
+            }
+
+            internal static class ResponsesProvider
+            {
+                private static readonly Dictionary<uint, List<ReceivedResponse>> Storage = new Dictionary<uint, List<ReceivedResponse>>();
+                private static readonly Dictionary<uint, World> WorldMapping = new Dictionary<uint, World>();
+
+                private static uint nextHandle = 0;
+
+                public static uint Allocate(World world)
+                {
+                    var handle = GetNextHandle();
+                    Storage.Add(handle, default(List<ReceivedResponse>));
+                    WorldMapping.Add(handle, world);
+
+                    return handle;
+                }
+
+                public static List<ReceivedResponse> Get(uint handle)
+                {
+                    if (!Storage.TryGetValue(handle, out var value))
+                    {
+                        throw new ArgumentException($"UpdatesProvider does not contain handle {handle}");
+                    }
+
+                    return value;
+                }
+
+                public static void Set(uint handle, List<ReceivedResponse> value)
+                {
+                    if (!Storage.ContainsKey(handle))
+                    {
+                        throw new ArgumentException($"UpdatesProvider does not contain handle {handle}");
+                    }
+
+                    Storage[handle] = value;
+                }
+
+                public static void Free(uint handle)
+                {
+                    Storage.Remove(handle);
+                    WorldMapping.Remove(handle);
+                }
+
+                public static void CleanDataInWorld(World world)
+                {
+                    var handles = WorldMapping.Where(pair => pair.Value == world).Select(pair => pair.Key);
+
+                    foreach (var handle in handles)
+                    {
+                        Free(handle);
+                    }
+                }
+
+                private static uint GetNextHandle()
+                {
+                    nextHandle++;
+
+                    while (Storage.ContainsKey(nextHandle))
+                    {
+                        nextHandle++;
+                    }
+
+                    return nextHandle;
+                }
+            }
+
+            internal class Storage : CommandStorage
+            {
+                public Dictionary<uint, CommandRequestStore<Request>> CommandRequestsInFlight = new Dictionary<uint, CommandRequestStore<Request>>();
             }
         }
 
-        public struct Response : IIncomingCommandResponse
+        public static class DeleteEntity
         {
-            public StatusCode StatusCode { get; }
-            public string Message { get; }
-            public EntityId EntityId { get; }
-        }
-    }
+            public struct Request
+            {
+                public EntityId EntityId;
+                public uint? TimeoutMillis;
+                public long SenderEntityId;
+            }
 
-    public class ReserveEntityIds
-    {
-        public struct Request
-        {
-            public uint NumberOfEntityIds;
-            public uint? TimeoutMillis;
-            public long SenderEntityId;
+            public struct ReceivedResponse
+            {
+                public DeleteEntityResponseOp Op { get; }
+                public Request RawRequest { get; }
+                public object Context { get; }
+
+                internal ReceivedResponse(DeleteEntityResponseOp op, Request req, object context)
+                {
+                    Op = op;
+                    RawRequest = req;
+                    Context = context;
+                }
+            }
+
+            public struct CommandSender : IComponentData
+            {
+                internal uint Handle;
+
+                public List<Request> RequestsToSend
+                {
+                    get => RequestsProvider.Get(Handle);
+                    set => RequestsProvider.Set(Handle, value);
+                }
+            }
+
+            public struct CommandResponses : IComponentData
+            {
+                internal uint Handle;
+
+                public List<ReceivedResponse> Responses
+                {
+                    get => ResponsesProvider.Get(Handle);
+                    set => ResponsesProvider.Set(Handle, value);
+                }
+            }
+
+            internal static class RequestsProvider
+            {
+                private static readonly Dictionary<uint, List<Request>> Storage = new Dictionary<uint, List<Request>>();
+                private static readonly Dictionary<uint, World> WorldMapping = new Dictionary<uint, World>();
+
+                private static uint nextHandle = 0;
+
+                public static uint Allocate(World world)
+                {
+                    var handle = GetNextHandle();
+                    Storage.Add(handle, default(List<Request>));
+                    WorldMapping.Add(handle, world);
+
+                    return handle;
+                }
+
+                public static List<Request> Get(uint handle)
+                {
+                    if (!Storage.TryGetValue(handle, out var value))
+                    {
+                        throw new ArgumentException($"UpdatesProvider does not contain handle {handle}");
+                    }
+
+                    return value;
+                }
+
+                public static void Set(uint handle, List<Request> value)
+                {
+                    if (!Storage.ContainsKey(handle))
+                    {
+                        throw new ArgumentException($"UpdatesProvider does not contain handle {handle}");
+                    }
+
+                    Storage[handle] = value;
+                }
+
+                public static void Free(uint handle)
+                {
+                    Storage.Remove(handle);
+                    WorldMapping.Remove(handle);
+                }
+
+                public static void CleanDataInWorld(World world)
+                {
+                    var handles = WorldMapping.Where(pair => pair.Value == world).Select(pair => pair.Key);
+
+                    foreach (var handle in handles)
+                    {
+                        Free(handle);
+                    }
+                }
+
+                private static uint GetNextHandle()
+                {
+                    nextHandle++;
+
+                    while (Storage.ContainsKey(nextHandle))
+                    {
+                        nextHandle++;
+                    }
+
+                    return nextHandle;
+                }
+            }
+
+            internal static class ResponsesProvider
+            {
+                private static readonly Dictionary<uint, List<ReceivedResponse>> Storage = new Dictionary<uint, List<ReceivedResponse>>();
+                private static readonly Dictionary<uint, World> WorldMapping = new Dictionary<uint, World>();
+
+                private static uint nextHandle = 0;
+
+                public static uint Allocate(World world)
+                {
+                    var handle = GetNextHandle();
+                    Storage.Add(handle, default(List<ReceivedResponse>));
+                    WorldMapping.Add(handle, world);
+
+                    return handle;
+                }
+
+                public static List<ReceivedResponse> Get(uint handle)
+                {
+                    if (!Storage.TryGetValue(handle, out var value))
+                    {
+                        throw new ArgumentException($"UpdatesProvider does not contain handle {handle}");
+                    }
+
+                    return value;
+                }
+
+                public static void Set(uint handle, List<ReceivedResponse> value)
+                {
+                    if (!Storage.ContainsKey(handle))
+                    {
+                        throw new ArgumentException($"UpdatesProvider does not contain handle {handle}");
+                    }
+
+                    Storage[handle] = value;
+                }
+
+                public static void Free(uint handle)
+                {
+                    Storage.Remove(handle);
+                    WorldMapping.Remove(handle);
+                }
+
+                public static void CleanDataInWorld(World world)
+                {
+                    var handles = WorldMapping.Where(pair => pair.Value == world).Select(pair => pair.Key);
+
+                    foreach (var handle in handles)
+                    {
+                        Free(handle);
+                    }
+                }
+
+                private static uint GetNextHandle()
+                {
+                    nextHandle++;
+
+                    while (Storage.ContainsKey(nextHandle))
+                    {
+                        nextHandle++;
+                    }
+
+                    return nextHandle;
+                }
+            }
+
+            internal class Storage : CommandStorage
+            {
+                public Dictionary<uint, CommandRequestStore<Request>> CommandRequestsInFlight = new Dictionary<uint, CommandRequestStore<Request>>();
+            }
         }
 
-        public struct Response : IIncomingCommandResponse
+        public static class ReserveEntityIds
         {
-            public StatusCode StatusCode { get; }
-            public string Message { get; }
-            public EntityId FirstEntityId { get; }
-            public int NumberOfEntityIds { get; }
-        }
-    }
+            public struct Request
+            {
+                public uint NumberOfEntityIds;
+                public uint? TimeoutMillis;
+                public long SenderEntityId;
+            }
 
-    public class EntityQuery
-    {
-        public struct Request
-        {
-            public Worker.Query.EntityQuery EntityQuery;
-            public uint? TimeoutMillis;
-            public long SenderEntityId;
+            public struct ReceivedResponse
+            {
+                public ReserveEntityIdsResponseOp Op { get; }
+                public Request RawRequest { get; }
+                public object Context { get; }
+
+                internal ReceivedResponse(ReserveEntityIdsResponseOp op, Request req, object context)
+                {
+                    Op = op;
+                    RawRequest = req;
+                    Context = context;
+                }
+            }
+
+            public struct CommandSender : IComponentData
+            {
+                internal uint Handle;
+
+                public List<Request> RequestsToSend
+                {
+                    get => RequestsProvider.Get(Handle);
+                    set => RequestsProvider.Set(Handle, value);
+                }
+            }
+
+            public struct CommandResponses : IComponentData
+            {
+                internal uint Handle;
+
+                public List<ReceivedResponse> Responses
+                {
+                    get => ResponsesProvider.Get(Handle);
+                    set => ResponsesProvider.Set(Handle, value);
+                }
+            }
+
+            internal static class RequestsProvider
+            {
+                private static readonly Dictionary<uint, List<Request>> Storage = new Dictionary<uint, List<Request>>();
+                private static readonly Dictionary<uint, World> WorldMapping = new Dictionary<uint, World>();
+
+                private static uint nextHandle = 0;
+
+                public static uint Allocate(World world)
+                {
+                    var handle = GetNextHandle();
+                    Storage.Add(handle, default(List<Request>));
+                    WorldMapping.Add(handle, world);
+
+                    return handle;
+                }
+
+                public static List<Request> Get(uint handle)
+                {
+                    if (!Storage.TryGetValue(handle, out var value))
+                    {
+                        throw new ArgumentException($"UpdatesProvider does not contain handle {handle}");
+                    }
+
+                    return value;
+                }
+
+                public static void Set(uint handle, List<Request> value)
+                {
+                    if (!Storage.ContainsKey(handle))
+                    {
+                        throw new ArgumentException($"UpdatesProvider does not contain handle {handle}");
+                    }
+
+                    Storage[handle] = value;
+                }
+
+                public static void Free(uint handle)
+                {
+                    Storage.Remove(handle);
+                    WorldMapping.Remove(handle);
+                }
+
+                public static void CleanDataInWorld(World world)
+                {
+                    var handles = WorldMapping.Where(pair => pair.Value == world).Select(pair => pair.Key);
+
+                    foreach (var handle in handles)
+                    {
+                        Free(handle);
+                    }
+                }
+
+                private static uint GetNextHandle()
+                {
+                    nextHandle++;
+
+                    while (Storage.ContainsKey(nextHandle))
+                    {
+                        nextHandle++;
+                    }
+
+                    return nextHandle;
+                }
+            }
+
+            internal static class ResponsesProvider
+            {
+                private static readonly Dictionary<uint, List<ReceivedResponse>> Storage = new Dictionary<uint, List<ReceivedResponse>>();
+                private static readonly Dictionary<uint, World> WorldMapping = new Dictionary<uint, World>();
+
+                private static uint nextHandle = 0;
+
+                public static uint Allocate(World world)
+                {
+                    var handle = GetNextHandle();
+                    Storage.Add(handle, default(List<ReceivedResponse>));
+                    WorldMapping.Add(handle, world);
+
+                    return handle;
+                }
+
+                public static List<ReceivedResponse> Get(uint handle)
+                {
+                    if (!Storage.TryGetValue(handle, out var value))
+                    {
+                        throw new ArgumentException($"UpdatesProvider does not contain handle {handle}");
+                    }
+
+                    return value;
+                }
+
+                public static void Set(uint handle, List<ReceivedResponse> value)
+                {
+                    if (!Storage.ContainsKey(handle))
+                    {
+                        throw new ArgumentException($"UpdatesProvider does not contain handle {handle}");
+                    }
+
+                    Storage[handle] = value;
+                }
+
+                public static void Free(uint handle)
+                {
+                    Storage.Remove(handle);
+                    WorldMapping.Remove(handle);
+                }
+
+                public static void CleanDataInWorld(World world)
+                {
+                    var handles = WorldMapping.Where(pair => pair.Value == world).Select(pair => pair.Key);
+
+                    foreach (var handle in handles)
+                    {
+                        Free(handle);
+                    }
+                }
+
+                private static uint GetNextHandle()
+                {
+                    nextHandle++;
+
+                    while (Storage.ContainsKey(nextHandle))
+                    {
+                        nextHandle++;
+                    }
+
+                    return nextHandle;
+                }
+            }
+
+            internal class Storage : CommandStorage
+            {
+                public Dictionary<uint, CommandRequestStore<Request>> CommandRequestsInFlight = new Dictionary<uint, CommandRequestStore<Request>>();
+            }
         }
 
-        public struct Response : IIncomingCommandResponse
+        public static class EntityQuery
         {
-            public CommandStatusCode StatusCode { get; }
-            public string Message { get; }
-            public int ResultCount { get; }
-            public Dictionary<long, Worker.Core.Entity> Result { get; }
+            public struct Request
+            {
+                public Worker.Query.EntityQuery EntityQuery;
+                public uint? TimeoutMillis;
+                public long SenderEntityId;
+            }
+
+            public struct ReceivedResponse
+            {
+                public EntityQueryResponseOp Op { get; }
+                public Request RawRequest { get; }
+                public object Context { get; }
+
+                internal ReceivedResponse(EntityQueryResponseOp op, Request req, object context)
+                {
+                    Op = op;
+                    RawRequest = req;
+                    Context = context;
+                }
+            }
+
+            public struct CommandSender : IComponentData
+            {
+                internal uint Handle;
+
+                public List<Request> RequestsToSend
+                {
+                    get => RequestsProvider.Get(Handle);
+                    set => RequestsProvider.Set(Handle, value);
+                }
+            }
+
+            public struct CommandResponses : IComponentData
+            {
+                internal uint Handle;
+
+                public List<ReceivedResponse> Responses
+                {
+                    get => ResponsesProvider.Get(Handle);
+                    set => ResponsesProvider.Set(Handle, value);
+                }
+            }
+
+            internal static class RequestsProvider
+            {
+                private static readonly Dictionary<uint, List<Request>> Storage = new Dictionary<uint, List<Request>>();
+                private static readonly Dictionary<uint, World> WorldMapping = new Dictionary<uint, World>();
+
+                private static uint nextHandle = 0;
+
+                public static uint Allocate(World world)
+                {
+                    var handle = GetNextHandle();
+                    Storage.Add(handle, default(List<Request>));
+                    WorldMapping.Add(handle, world);
+
+                    return handle;
+                }
+
+                public static List<Request> Get(uint handle)
+                {
+                    if (!Storage.TryGetValue(handle, out var value))
+                    {
+                        throw new ArgumentException($"UpdatesProvider does not contain handle {handle}");
+                    }
+
+                    return value;
+                }
+
+                public static void Set(uint handle, List<Request> value)
+                {
+                    if (!Storage.ContainsKey(handle))
+                    {
+                        throw new ArgumentException($"UpdatesProvider does not contain handle {handle}");
+                    }
+
+                    Storage[handle] = value;
+                }
+
+                public static void Free(uint handle)
+                {
+                    Storage.Remove(handle);
+                    WorldMapping.Remove(handle);
+                }
+
+                public static void CleanDataInWorld(World world)
+                {
+                    var handles = WorldMapping.Where(pair => pair.Value == world).Select(pair => pair.Key);
+
+                    foreach (var handle in handles)
+                    {
+                        Free(handle);
+                    }
+                }
+
+                private static uint GetNextHandle()
+                {
+                    nextHandle++;
+
+                    while (Storage.ContainsKey(nextHandle))
+                    {
+                        nextHandle++;
+                    }
+
+                    return nextHandle;
+                }
+            }
+
+            internal static class ResponsesProvider
+            {
+                private static readonly Dictionary<uint, List<ReceivedResponse>> Storage = new Dictionary<uint, List<ReceivedResponse>>();
+                private static readonly Dictionary<uint, World> WorldMapping = new Dictionary<uint, World>();
+
+                private static uint nextHandle = 0;
+
+                public static uint Allocate(World world)
+                {
+                    var handle = GetNextHandle();
+                    Storage.Add(handle, default(List<ReceivedResponse>));
+                    WorldMapping.Add(handle, world);
+
+                    return handle;
+                }
+
+                public static List<ReceivedResponse> Get(uint handle)
+                {
+                    if (!Storage.TryGetValue(handle, out var value))
+                    {
+                        throw new ArgumentException($"UpdatesProvider does not contain handle {handle}");
+                    }
+
+                    return value;
+                }
+
+                public static void Set(uint handle, List<ReceivedResponse> value)
+                {
+                    if (!Storage.ContainsKey(handle))
+                    {
+                        throw new ArgumentException($"UpdatesProvider does not contain handle {handle}");
+                    }
+
+                    Storage[handle] = value;
+                }
+
+                public static void Free(uint handle)
+                {
+                    Storage.Remove(handle);
+                    WorldMapping.Remove(handle);
+                }
+
+                public static void CleanDataInWorld(World world)
+                {
+                    var handles = WorldMapping.Where(pair => pair.Value == world).Select(pair => pair.Key);
+
+                    foreach (var handle in handles)
+                    {
+                        Free(handle);
+                    }
+                }
+
+                private static uint GetNextHandle()
+                {
+                    nextHandle++;
+
+                    while (Storage.ContainsKey(nextHandle))
+                    {
+                        nextHandle++;
+                    }
+
+                    return nextHandle;
+                }
+            }
+
+            internal class Storage : CommandStorage
+            {
+                public Dictionary<uint, CommandRequestStore<Request>> CommandRequestsInFlight = new Dictionary<uint, CommandRequestStore<Request>>();
+            }
         }
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands.cs
@@ -67,7 +67,6 @@ namespace Improbable.Gdk.Core.Commands
                 public Entity Entity;
                 public EntityId? EntityId;
                 public uint? TimeoutMillis;
-                public uint SenderEntityId;
             }
 
             public struct ReceivedResponse
@@ -248,7 +247,6 @@ namespace Improbable.Gdk.Core.Commands
             {
                 public EntityId EntityId;
                 public uint? TimeoutMillis;
-                public long SenderEntityId;
             }
 
             public struct ReceivedResponse
@@ -429,7 +427,6 @@ namespace Improbable.Gdk.Core.Commands
             {
                 public uint NumberOfEntityIds;
                 public uint? TimeoutMillis;
-                public long SenderEntityId;
             }
 
             public struct ReceivedResponse
@@ -610,7 +607,6 @@ namespace Improbable.Gdk.Core.Commands
             {
                 public Worker.Query.EntityQuery EntityQuery;
                 public uint? TimeoutMillis;
-                public long SenderEntityId;
             }
 
             public struct ReceivedResponse

--- a/workers/unity/Packages/com.improbable.gdk.core/Systems/SpatialOSReceiveSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Systems/SpatialOSReceiveSystem.cs
@@ -24,7 +24,8 @@ namespace Improbable.Gdk.Core
 
         private const string LoggerName = nameof(SpatialOSReceiveSystem);
         private const string UnknownComponentIdError = "Received an op with an unknown ComponentId";
-        private const string EntityNotFound = "No entity found for entity specified in op.";
+        private const string EntityNotFound = "No entity found for SpatialOS EntityId specified in op.";
+        private const string RequestIdNotFound = "No corresponding request found for response.";
 
         private WorldCommands.CreateEntity.Storage createEntityStorage;
         private WorldCommands.DeleteEntity.Storage deleteEntityStorage;
@@ -172,9 +173,13 @@ namespace Improbable.Gdk.Core
 
         private void OnCreateEntityResponse(CreateEntityResponseOp op)
         {
-            if (!createEntityStorage.CommandRequestsInFlight.TryGetValue(op.RequestId.Id, out var requestBundle))
+            if (!createEntityStorage.CommandRequestsInFlight.TryGetValue(op.RequestId.Id, out CommandRequestStore<WorldCommands.CreateEntity.Request> requestBundle))
             {
-                throw new InvalidOperationException($"Could not find corresponding request for RequestId {op.RequestId.Id} and command CreateEntity.");
+                logDispatcher.HandleLog(LogType.Error, new LogEvent(RequestIdNotFound)
+                    .WithField(LoggingUtils.LoggerName, LoggerName)
+                    .WithField("RequestId", op.RequestId.Id)
+                    .WithField("Command Type", "CreateEntity"));
+                return;
             }
 
             var entity = requestBundle.Entity;
@@ -182,7 +187,7 @@ namespace Improbable.Gdk.Core
 
             if (!EntityManager.Exists(entity))
             {
-                logDispatcher.HandleLog(LogType.Error, new LogEvent(EntityNotFound)
+                logDispatcher.HandleLog(LogType.Log, new LogEvent(EntityNotFound)
                     .WithField(LoggingUtils.LoggerName, LoggerName)
                     .WithField("Op", "CreateEntityResponseOp")
                 );
@@ -210,9 +215,13 @@ namespace Improbable.Gdk.Core
 
         private void OnDeleteEntityResponse(DeleteEntityResponseOp op)
         {
-            if (!deleteEntityStorage.CommandRequestsInFlight.TryGetValue(op.RequestId.Id, out var requestBundle))
+            if (!deleteEntityStorage.CommandRequestsInFlight.TryGetValue(op.RequestId.Id, out CommandRequestStore<WorldCommands.DeleteEntity.Request> requestBundle))
             {
-                throw new InvalidOperationException($"Could not find corresponding request for RequestId {op.RequestId.Id} and command DeleteEntity.");
+                logDispatcher.HandleLog(LogType.Error, new LogEvent(RequestIdNotFound)
+                    .WithField(LoggingUtils.LoggerName, LoggerName)
+                    .WithField("RequestId", op.RequestId.Id)
+                    .WithField("Command Type", "DeleteEntity"));
+                return;
             }
 
             var entity = requestBundle.Entity;
@@ -220,7 +229,7 @@ namespace Improbable.Gdk.Core
 
             if (!EntityManager.Exists(entity))
             {
-                logDispatcher.HandleLog(LogType.Error, new LogEvent(EntityNotFound)
+                logDispatcher.HandleLog(LogType.Log, new LogEvent(EntityNotFound)
                     .WithField(LoggingUtils.LoggerName, LoggerName)
                     .WithField("Op", "DeleteEntityResponseOp")
                 );
@@ -248,9 +257,13 @@ namespace Improbable.Gdk.Core
 
         private void OnReserveEntityIdsResponse(ReserveEntityIdsResponseOp op)
         {
-            if (!reserveEntityIdsStorage.CommandRequestsInFlight.TryGetValue(op.RequestId.Id, out var requestBundle))
+            if (!reserveEntityIdsStorage.CommandRequestsInFlight.TryGetValue(op.RequestId.Id, out CommandRequestStore<WorldCommands.ReserveEntityIds.Request> requestBundle))
             {
-                throw new InvalidOperationException($"Could not find corresponding request for RequestId {op.RequestId.Id} and command ReserveEntityIds.");
+                logDispatcher.HandleLog(LogType.Error, new LogEvent(RequestIdNotFound)
+                    .WithField(LoggingUtils.LoggerName, LoggerName)
+                    .WithField("RequestId", op.RequestId.Id)
+                    .WithField("Command Type", "ReserveEntityIds"));
+                return;
             }
 
             var entity = requestBundle.Entity;
@@ -258,7 +271,7 @@ namespace Improbable.Gdk.Core
 
             if (!EntityManager.Exists(entity))
             {
-                logDispatcher.HandleLog(LogType.Error, new LogEvent(EntityNotFound)
+                logDispatcher.HandleLog(LogType.Log, new LogEvent(EntityNotFound)
                     .WithField(LoggingUtils.LoggerName, LoggerName)
                     .WithField("Op", "ReserveEntityIdsResponseOp")
                 );
@@ -286,9 +299,13 @@ namespace Improbable.Gdk.Core
 
         private void OnEntityQueryResponse(EntityQueryResponseOp op)
         {
-            if (!entityQueryStorage.CommandRequestsInFlight.TryGetValue(op.RequestId.Id, out var requestBundle))
+            if (!entityQueryStorage.CommandRequestsInFlight.TryGetValue(op.RequestId.Id, out CommandRequestStore<WorldCommands.EntityQuery.Request> requestBundle))
             {
-                throw new InvalidOperationException($"Could not find corresponding request for RequestId {op.RequestId.Id} and command EntityQuery.");
+                logDispatcher.HandleLog(LogType.Error, new LogEvent(RequestIdNotFound)
+                    .WithField(LoggingUtils.LoggerName, LoggerName)
+                    .WithField("RequestId", op.RequestId.Id)
+                    .WithField("Command Type", "EntityQuery"));
+                return;
             }
 
             var entity = requestBundle.Entity;
@@ -296,7 +313,7 @@ namespace Improbable.Gdk.Core
 
             if (!EntityManager.Exists(entity))
             {
-                logDispatcher.HandleLog(LogType.Error, new LogEvent(EntityNotFound)
+                logDispatcher.HandleLog(LogType.Log, new LogEvent(EntityNotFound)
                     .WithField(LoggingUtils.LoggerName, LoggerName)
                     .WithField("Op", "EntityQueryResponseOp")
                 );

--- a/workers/unity/Packages/com.improbable.gdk.core/Systems/SpatialOSReceiveSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Systems/SpatialOSReceiveSystem.cs
@@ -337,6 +337,7 @@ namespace Improbable.Gdk.Core
                 componentSpecificDispatchers.Add(componentDispatcher.ComponentId, componentDispatcher);
                 // TODO: UTY-836 temporary work around until Jess's worker refactor comes in.
                 view.AddAllCommandComponents.Add(componentDispatcher.AddCommandComponents);
+                componentDispatcher.AddCommandComponents(view.WorkerEntity);
             }
 
             dispatcher.OnAddEntity(OnAddEntity);

--- a/workers/unity/Packages/com.improbable.gdk.core/Systems/SpatialOSReceiveSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Systems/SpatialOSReceiveSystem.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Improbable.Gdk.Core.CodegenAdapters;
+using Improbable.Gdk.Core.Commands;
 using Improbable.Worker.Core;
 using Unity.Entities;
 using UnityEngine;
@@ -13,14 +14,22 @@ namespace Improbable.Gdk.Core
     {
         private WorkerBase worker;
         private MutableView view;
+        private ILogDispatcher logDispatcher;
         private Dispatcher dispatcher;
 
         private readonly Dictionary<uint, ComponentDispatcherHandler> componentSpecificDispatchers =
             new Dictionary<uint, ComponentDispatcherHandler>();
 
-        private bool inCriticalSection = false;
+        private bool inCriticalSection;
 
+        private const string LoggerName = nameof(SpatialOSReceiveSystem);
         private const string UnknownComponentIdError = "Received an op with an unknown ComponentId";
+        private const string EntityNotFound = "No entity found for entity specified in op.";
+
+        private WorldCommands.CreateEntity.Storage createEntityStorage;
+        private WorldCommands.DeleteEntity.Storage deleteEntityStorage;
+        private WorldCommands.ReserveEntityIds.Storage reserveEntityIdsStorage;
+        private WorldCommands.EntityQuery.Storage entityQueryStorage;
 
         protected override void OnCreateManager(int capacity)
         {
@@ -28,9 +37,16 @@ namespace Improbable.Gdk.Core
 
             worker = WorkerRegistry.GetWorkerForWorld(World);
             view = worker.View;
+            logDispatcher = view.LogDispatcher;
 
             dispatcher = new Dispatcher();
             SetupDispatcherHandlers();
+
+            var requestTracker = World.GetOrCreateManager<CommandRequestTrackerSystem>();
+            createEntityStorage = requestTracker.GetCommandStorageForType<WorldCommands.CreateEntity.Storage>();
+            deleteEntityStorage = requestTracker.GetCommandStorageForType<WorldCommands.DeleteEntity.Storage>();
+            reserveEntityIdsStorage = requestTracker.GetCommandStorageForType<WorldCommands.ReserveEntityIds.Storage>();
+            entityQueryStorage = requestTracker.GetCommandStorageForType<WorldCommands.EntityQuery.Storage>();
         }
 
         protected override void OnDestroyManager()
@@ -154,6 +170,158 @@ namespace Improbable.Gdk.Core
             specificDispatcher.OnCommandResponse(op);
         }
 
+        private void OnCreateEntityResponse(CreateEntityResponseOp op)
+        {
+            if (!createEntityStorage.CommandRequestsInFlight.TryGetValue(op.RequestId.Id, out var requestBundle))
+            {
+                throw new InvalidOperationException($"Could not find corresponding request for RequestId {op.RequestId.Id} and command CreateEntity.");
+            }
+
+            var entity = requestBundle.Entity;
+            createEntityStorage.CommandRequestsInFlight.Remove(op.RequestId.Id);
+
+            if (!EntityManager.Exists(entity))
+            {
+                logDispatcher.HandleLog(LogType.Error, new LogEvent(EntityNotFound)
+                    .WithField(LoggingUtils.LoggerName, LoggerName)
+                    .WithField("Op", "CreateEntityResponseOp")
+                );
+                return;
+            }
+
+            List<WorldCommands.CreateEntity.ReceivedResponse> responses;
+            if (EntityManager.HasComponent<WorldCommands.CreateEntity.CommandResponses>(entity))
+            {
+                responses = EntityManager.GetComponentData<WorldCommands.CreateEntity.CommandResponses>(entity)
+                    .Responses;
+            }
+            else
+            {
+                var data = new WorldCommands.CreateEntity.CommandResponses
+                {
+                    Handle = WorldCommands.CreateEntity.ResponsesProvider.Allocate(World)
+                };
+                responses = data.Responses = new List<WorldCommands.CreateEntity.ReceivedResponse>();
+                EntityManager.AddComponentData(entity, data);
+            }
+
+            responses.Add(new WorldCommands.CreateEntity.ReceivedResponse(op, requestBundle.Request, requestBundle.Context));
+        }
+
+        private void OnDeleteEntityResponse(DeleteEntityResponseOp op)
+        {
+            if (!deleteEntityStorage.CommandRequestsInFlight.TryGetValue(op.RequestId.Id, out var requestBundle))
+            {
+                throw new InvalidOperationException($"Could not find corresponding request for RequestId {op.RequestId.Id} and command DeleteEntity.");
+            }
+
+            var entity = requestBundle.Entity;
+            deleteEntityStorage.CommandRequestsInFlight.Remove(op.RequestId.Id);
+
+            if (!EntityManager.Exists(entity))
+            {
+                logDispatcher.HandleLog(LogType.Error, new LogEvent(EntityNotFound)
+                    .WithField(LoggingUtils.LoggerName, LoggerName)
+                    .WithField("Op", "DeleteEntityResponseOp")
+                );
+                return;
+            }
+
+            List<WorldCommands.DeleteEntity.ReceivedResponse> responses;
+            if (EntityManager.HasComponent<WorldCommands.DeleteEntity.CommandResponses>(entity))
+            {
+                responses = EntityManager.GetComponentData<WorldCommands.DeleteEntity.CommandResponses>(entity)
+                    .Responses;
+            }
+            else
+            {
+                var data = new WorldCommands.DeleteEntity.CommandResponses
+                {
+                    Handle = WorldCommands.DeleteEntity.ResponsesProvider.Allocate(World)
+                };
+                responses = data.Responses = new List<WorldCommands.DeleteEntity.ReceivedResponse>();
+                EntityManager.AddComponentData(entity, data);
+            }
+
+            responses.Add(new WorldCommands.DeleteEntity.ReceivedResponse(op, requestBundle.Request, requestBundle.Context));
+        }
+
+        private void OnReserveEntityIdsResponse(ReserveEntityIdsResponseOp op)
+        {
+            if (!reserveEntityIdsStorage.CommandRequestsInFlight.TryGetValue(op.RequestId.Id, out var requestBundle))
+            {
+                throw new InvalidOperationException($"Could not find corresponding request for RequestId {op.RequestId.Id} and command ReserveEntityIds.");
+            }
+
+            var entity = requestBundle.Entity;
+            reserveEntityIdsStorage.CommandRequestsInFlight.Remove(op.RequestId.Id);
+
+            if (!EntityManager.Exists(entity))
+            {
+                logDispatcher.HandleLog(LogType.Error, new LogEvent(EntityNotFound)
+                    .WithField(LoggingUtils.LoggerName, LoggerName)
+                    .WithField("Op", "ReserveEntityIdsResponseOp")
+                );
+                return;
+            }
+
+            List<WorldCommands.ReserveEntityIds.ReceivedResponse> responses;
+            if (EntityManager.HasComponent<WorldCommands.ReserveEntityIds.CommandResponses>(entity))
+            {
+                responses = EntityManager.GetComponentData<WorldCommands.ReserveEntityIds.CommandResponses>(entity)
+                    .Responses;
+            }
+            else
+            {
+                var data = new WorldCommands.ReserveEntityIds.CommandResponses
+                {
+                    Handle = WorldCommands.ReserveEntityIds.ResponsesProvider.Allocate(World)
+                };
+                responses = data.Responses = new List<WorldCommands.ReserveEntityIds.ReceivedResponse>();
+                EntityManager.AddComponentData(entity, data);
+            }
+
+            responses.Add(new WorldCommands.ReserveEntityIds.ReceivedResponse(op, requestBundle.Request, requestBundle.Context));
+        }
+
+        private void OnEntityQueryResponse(EntityQueryResponseOp op)
+        {
+            if (!entityQueryStorage.CommandRequestsInFlight.TryGetValue(op.RequestId.Id, out var requestBundle))
+            {
+                throw new InvalidOperationException($"Could not find corresponding request for RequestId {op.RequestId.Id} and command EntityQuery.");
+            }
+
+            var entity = requestBundle.Entity;
+            entityQueryStorage.CommandRequestsInFlight.Remove(op.RequestId.Id);
+
+            if (!EntityManager.Exists(entity))
+            {
+                logDispatcher.HandleLog(LogType.Error, new LogEvent(EntityNotFound)
+                    .WithField(LoggingUtils.LoggerName, LoggerName)
+                    .WithField("Op", "EntityQueryResponseOp")
+                );
+                return;
+            }
+
+            List<WorldCommands.EntityQuery.ReceivedResponse> responses;
+            if (EntityManager.HasComponent<WorldCommands.EntityQuery.CommandResponses>(entity))
+            {
+                responses = EntityManager.GetComponentData<WorldCommands.EntityQuery.CommandResponses>(entity)
+                    .Responses;
+            }
+            else
+            {
+                var data = new WorldCommands.EntityQuery.CommandResponses
+                {
+                    Handle = WorldCommands.EntityQuery.ResponsesProvider.Allocate(World)
+                };
+                responses = data.Responses = new List<WorldCommands.EntityQuery.ReceivedResponse>();
+                EntityManager.AddComponentData(entity, data);
+            }
+
+            responses.Add(new WorldCommands.EntityQuery.ReceivedResponse(op, requestBundle.Request, requestBundle.Context));
+        }
+
         private void SetupDispatcherHandlers()
         {
             // Find all component specific dispatchers and create an instance.
@@ -183,6 +351,11 @@ namespace Improbable.Gdk.Core
 
             dispatcher.OnCommandRequest(OnCommandRequest);
             dispatcher.OnCommandResponse(OnCommandResponse);
+
+            dispatcher.OnCreateEntityResponse(OnCreateEntityResponse);
+            dispatcher.OnDeleteEntityResponse(OnDeleteEntityResponse);
+            dispatcher.OnReserveEntityIdsResponse(OnReserveEntityIdsResponse);
+            dispatcher.OnEntityQueryResponse(OnEntityQueryResponse);
         }
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.core/Systems/WorldCommandsCleanSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Systems/WorldCommandsCleanSystem.cs
@@ -1,0 +1,86 @@
+﻿using Improbable.Gdk.Core.Commands;
+using Unity.Collections;
+using Unity.Entities;
+
+namespace Improbable.Gdk.Core
+{
+    [UpdateInGroup(typeof(SpatialOSSendGroup.InternalSpatialOSCleanGroup))]
+    public class WorldCommandsCleanSystem : ComponentSystem
+    {
+        private struct CreateEntityResponsesData
+        {
+            public readonly int Length;
+            public EntityArray Entities;
+            [ReadOnly] public ComponentDataArray<WorldCommands.CreateEntity.CommandResponses> Responses;
+        }
+
+        [Inject] private CreateEntityResponsesData createEntityResponsesData;
+
+        private struct DeleteEntityResponsesData
+        {
+            public readonly int Length;
+            public EntityArray Entities;
+            [ReadOnly] public ComponentDataArray<WorldCommands.DeleteEntity.CommandResponses> Responses;
+        }
+
+        [Inject] private DeleteEntityResponsesData deleteEntityResponsesData;
+
+        private struct ReserveEntityIdsResponsesData
+        {
+            public readonly int Length;
+            public EntityArray Entities;
+            [ReadOnly] public ComponentDataArray<WorldCommands.ReserveEntityIds.CommandResponses> Responses;
+        }
+
+        [Inject] private ReserveEntityIdsResponsesData reserveEntityIdsResponsesData;
+
+        private struct EntityQueryResponsesData
+        {
+            public readonly int Length;
+            public EntityArray Entities;
+            [ReadOnly] public ComponentDataArray<WorldCommands.EntityQuery.CommandResponses> Responses;
+        }
+
+        [Inject] private EntityQueryResponsesData entityQueryResponsesData;
+
+
+        protected override void OnUpdate()
+        {
+            for (var i = 0; i < createEntityResponsesData.Length; i++)
+            {
+                var responses = createEntityResponsesData.Responses[i];
+                var entity = createEntityResponsesData.Entities[i];
+
+                WorldCommands.CreateEntity.ResponsesProvider.Free(responses.Handle);
+                PostUpdateCommands.RemoveComponent<WorldCommands.CreateEntity.CommandResponses>(entity);
+            }
+
+            for (var i = 0; i < deleteEntityResponsesData.Length; i++)
+            {
+                var responses = deleteEntityResponsesData.Responses[i];
+                var entity = deleteEntityResponsesData.Entities[i];
+
+                WorldCommands.DeleteEntity.ResponsesProvider.Free(responses.Handle);
+                PostUpdateCommands.RemoveComponent<WorldCommands.DeleteEntity.CommandResponses>(entity);
+            }
+
+            for (var i = 0; i < reserveEntityIdsResponsesData.Length; i++)
+            {
+                var responses = reserveEntityIdsResponsesData.Responses[i];
+                var entity = reserveEntityIdsResponsesData.Entities[i];
+
+                WorldCommands.ReserveEntityIds.ResponsesProvider.Free(responses.Handle);
+                PostUpdateCommands.RemoveComponent<WorldCommands.ReserveEntityIds.CommandResponses>(entity);
+            }
+
+            for (var i = 0; i < entityQueryResponsesData.Length; i++)
+            {
+                var responses = entityQueryResponsesData.Responses[i];
+                var entity = entityQueryResponsesData.Entities[i];
+
+                WorldCommands.EntityQuery.ResponsesProvider.Free(responses.Handle);
+                PostUpdateCommands.RemoveComponent<WorldCommands.EntityQuery.CommandResponses>(entity);
+            }
+        }
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.core/Systems/WorldCommandsCleanSystem.cs.meta
+++ b/workers/unity/Packages/com.improbable.gdk.core/Systems/WorldCommandsCleanSystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2fcdb5c0c4a55d64ba47aa3ca612093b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/com.improbable.gdk.core/Systems/WorldCommandsSendSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Systems/WorldCommandsSendSystem.cs
@@ -1,0 +1,126 @@
+﻿using Improbable.Gdk.Core.Commands;
+using Unity.Collections;
+using Unity.Entities;
+
+namespace Improbable.Gdk.Core
+{
+    [UpdateInGroup(typeof(SpatialOSSendGroup.InternalSpatialOSSendGroup))]
+    public class WorldCommandsSendSystem : ComponentSystem
+    {
+        private WorkerBase worker;
+
+        private struct CreateEntitySenderData
+        {
+            public readonly int Length;
+            public EntityArray Entities;
+            [ReadOnly] public ComponentDataArray<WorldCommands.CreateEntity.CommandSender> Senders;
+        }
+
+        [Inject] private CreateEntitySenderData createEntitySenderData;
+
+        private struct DeleteEntitySenderData
+        {
+            public readonly int Length;
+            public EntityArray Entities;
+            [ReadOnly] public ComponentDataArray<WorldCommands.DeleteEntity.CommandSender> Senders;
+        }
+
+        [Inject] private DeleteEntitySenderData deleteEntitySenderData;
+
+        private struct ReserveEntityIdsSenderData
+        {
+            public readonly int Length;
+            public EntityArray Entities;
+            [ReadOnly] public ComponentDataArray<WorldCommands.ReserveEntityIds.CommandSender> Senders;
+        }
+
+        [Inject] private ReserveEntityIdsSenderData reserveEntityIdsSenderData;
+
+        private struct EntityQuerySenderData
+        {
+            public readonly int Length;
+            public EntityArray Entities;
+            [ReadOnly] public ComponentDataArray<WorldCommands.EntityQuery.CommandSender> Senders;
+        }
+
+        [Inject] private EntityQuerySenderData entityQuerySenderData;
+
+        private WorldCommands.CreateEntity.Storage createEntityStorage;
+        private WorldCommands.DeleteEntity.Storage deleteEntityStorage;
+        private WorldCommands.ReserveEntityIds.Storage reserveEntityIdsStorage;
+        private WorldCommands.EntityQuery.Storage entityQueryStorage;
+
+        protected override void OnCreateManager(int capacity)
+        {
+            base.OnCreateManager(capacity);
+            worker = WorkerRegistry.GetWorkerForWorld(World);
+
+            var requestTracker = World.GetOrCreateManager<CommandRequestTrackerSystem>();
+            createEntityStorage = requestTracker.GetCommandStorageForType<WorldCommands.CreateEntity.Storage>();
+            deleteEntityStorage = requestTracker.GetCommandStorageForType<WorldCommands.DeleteEntity.Storage>();
+            reserveEntityIdsStorage = requestTracker.GetCommandStorageForType<WorldCommands.ReserveEntityIds.Storage>();
+            entityQueryStorage = requestTracker.GetCommandStorageForType<WorldCommands.EntityQuery.Storage>();
+        }
+
+        protected override void OnUpdate()
+        {
+            if (worker.Connection == null)
+            {
+                return;
+            }
+
+            for (var i = 0; i < createEntitySenderData.Length; i++)
+            {
+                var sender = createEntitySenderData.Senders[i];
+                var entity = createEntitySenderData.Entities[i];
+                foreach (var req in sender.RequestsToSend)
+                {
+                    var reqId = worker.Connection.SendCreateEntityRequest(req.Entity, req.EntityId, req.TimeoutMillis);
+                    createEntityStorage.CommandRequestsInFlight.Add(reqId.Id, new CommandRequestStore<WorldCommands.CreateEntity.Request>(entity, req, null));
+                }
+
+                sender.RequestsToSend.Clear();
+            }
+
+            for (var i = 0; i < deleteEntitySenderData.Length; i++)
+            {
+                var sender = deleteEntitySenderData.Senders[i];
+                var entity = deleteEntitySenderData.Entities[i];
+                foreach (var req in sender.RequestsToSend)
+                {
+                    var reqId = worker.Connection.SendDeleteEntityRequest(req.EntityId, req.TimeoutMillis);
+                    deleteEntityStorage.CommandRequestsInFlight.Add(reqId.Id, new CommandRequestStore<WorldCommands.DeleteEntity.Request>(entity, req, null));
+                }
+
+                sender.RequestsToSend.Clear();
+            }
+
+
+            for (var i = 0; i < reserveEntityIdsSenderData.Length; i++)
+            {
+                var sender = reserveEntityIdsSenderData.Senders[i];
+                var entity = reserveEntityIdsSenderData.Entities[i];
+                foreach (var req in sender.RequestsToSend)
+                {
+                    var reqId = worker.Connection.SendReserveEntityIdsRequest(req.NumberOfEntityIds, req.TimeoutMillis);
+                    reserveEntityIdsStorage.CommandRequestsInFlight.Add(reqId.Id, new CommandRequestStore<WorldCommands.ReserveEntityIds.Request>(entity, req, null));
+                }
+
+                sender.RequestsToSend.Clear();
+            }
+
+            for (var i = 0; i < entityQuerySenderData.Length; i++)
+            {
+                var sender = entityQuerySenderData.Senders[i];
+                var entity = entityQuerySenderData.Entities[i];
+                foreach (var req in sender.RequestsToSend)
+                {
+                    var reqId = worker.Connection.SendEntityQueryRequest(req.EntityQuery, req.TimeoutMillis);
+                    entityQueryStorage.CommandRequestsInFlight.Add(reqId.Id, new CommandRequestStore<WorldCommands.EntityQuery.Request>(entity, req, null));
+                }
+
+                sender.RequestsToSend.Clear();
+            }
+        }
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.core/Systems/WorldCommandsSendSystem.cs.meta
+++ b/workers/unity/Packages/com.improbable.gdk.core/Systems/WorldCommandsSendSystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f4f2623a1cf08244ca700ad742bd1c31
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/com.improbable.gdk.core/Utility/EntityBuilder.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Utility/EntityBuilder.cs
@@ -114,6 +114,7 @@ namespace Improbable.Gdk.Core
         public Entity Build()
         {
             entity.Add(acl.Build());
+            componentsAdded.Add(EntityAclComponentId);
             CheckRequiredComponents();
             return entity;
         }

--- a/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerBase.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Worker/WorkerBase.cs
@@ -86,6 +86,9 @@ namespace Improbable.Gdk.Core
             World.GetOrCreateManager<SpatialOSReceiveSystem>();
             World.GetOrCreateManager<SpatialOSSendSystem>();
             World.GetOrCreateManager<CleanReactiveComponentsSystem>();
+
+            World.GetOrCreateManager<WorldCommandsCleanSystem>();
+            World.GetOrCreateManager<WorldCommandsSendSystem>();
         }
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerCreation/HandleCreatePlayerRequestSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerCreation/HandleCreatePlayerRequestSystem.cs
@@ -1,6 +1,9 @@
 using System;
+using System.Diagnostics;
 using Generated.Improbable.PlayerLifecycle;
 using Improbable.Gdk.Core;
+using Improbable.Gdk.Core.Commands;
+using Improbable.Worker;
 using Unity.Collections;
 using Unity.Entities;
 
@@ -14,7 +17,7 @@ namespace Improbable.Gdk.PlayerLifecycle
             public readonly int Length;
             [ReadOnly] public ComponentDataArray<PlayerCreator.CommandRequests.CreatePlayer> CreatePlayerRequests;
             [ReadOnly] public ComponentDataArray<PlayerCreator.CommandResponders.CreatePlayer> CreatePlayerResponders;
-            // TODO: [ReadOnly] public ComponentDataArray<WorldCommandSender> WorldCommandSenders;
+            [ReadOnly] public ComponentDataArray<WorldCommands.CreateEntity.CommandSender> CreateEntitySender;
         }
 
         [Inject] private CreatePlayerData createPlayerData;
@@ -35,9 +38,12 @@ namespace Improbable.Gdk.PlayerLifecycle
 
                     var playerEntity = PlayerLifecycleConfig.CreatePlayerEntityTemplate(request.CallerAttributeSet,
                         request.RawRequest.Position);
-                    // TODO: createPlayerData.WorldCommandSenders[i].SendCreateEntityRequest(playerEntity);
+                    createPlayerData.CreateEntitySender[i].RequestsToSend.Add(new WorldCommands.CreateEntity.Request
+                    {
+                        Entity = playerEntity
+                    });
 
-                    // TODO: responders.Add(PlayerCreator.CreatePlayer.Response.CreateResponse(request, new CreatePlayerResponseType(somePlayerEntityIdHere)));
+                    responders.Add(PlayerCreator.CreatePlayer.Response.CreateResponse(request, new CreatePlayerResponseType()));
                 }
             }
         }

--- a/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerHeartbeat/HandlePlayerHeartbeatResponseSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerHeartbeat/HandlePlayerHeartbeatResponseSystem.cs
@@ -1,5 +1,6 @@
 using Generated.Improbable.PlayerLifecycle;
 using Improbable.Gdk.Core;
+using Improbable.Gdk.Core.Commands;
 using Improbable.Worker.Core;
 using Unity.Collections;
 using Unity.Entities;
@@ -17,7 +18,7 @@ namespace Improbable.Gdk.PlayerLifecycle
             [ReadOnly] public ComponentDataArray<PlayerHeartbeatClient.CommandResponses.PlayerHeartbeat>
                 PlayerHeartbeatResponses;
 
-            // TODO: [ReadOnly] public ComponentDataArray<WorldCommandSender> WorldCommandSenders;
+            [ReadOnly] public ComponentDataArray<WorldCommands.DeleteEntity.CommandSender> WorldCommandSenders;
             [ReadOnly] public ComponentDataArray<SpatialEntityId> SpatialEntityIds;
             [ReadOnly] public ComponentDataArray<AwaitingHeartbeatResponseTag> AwaitingHeartbeatResponses;
             public EntityArray Entities;
@@ -58,7 +59,10 @@ namespace Improbable.Gdk.PlayerLifecycle
                             PlayerLifecycleConfig.MaxNumFailedPlayerHeartbeats)
                         {
                             Debug.LogFormat(Messages.DeletingPlayer, entityId);
-                            // TODO: data.WorldCommandSenders[i].SendDeleteEntityRequest(entityId);
+                            data.WorldCommandSenders[i].RequestsToSend.Add(new WorldCommands.DeleteEntity.Request
+                            {
+                                EntityId = entityId,
+                            });
                         }
                     }
                     else


### PR DESCRIPTION
#### Description
Added World Commands and all the associated types to match the current API.
Lots and lots of ~generated~ handwritten code.

Note that I've put the handling of the response ops into the `SpatialOSReceiveSystem` directly. If people prefer - I can refactor that out into a `WorldCommandsReceiveSystem` and make the dispatcher on the `SpatialOSReceiveSystem` internal such that the other system can register with it. 

#### Tests
It compiled! Tests coming soon ™️ 
#### Documentation
Also going to come soon
#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
@zeroZshadow 