### PR TITLE
UTY-450: Collection<Bool> Schema Codegen Fix

### DIFF
--- a/code_generator/GdkCodeGenerator/Templates/UnityReferenceTypeProviderGenerator.tt
+++ b/code_generator/GdkCodeGenerator/Templates/UnityReferenceTypeProviderGenerator.tt
@@ -13,12 +13,13 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Improbable.Gdk.Core;
 
 namespace <#= qualifiedNamespace #>
 {
     public partial class <#= componentDetails.ComponentName #>
     {
-        internal static class ReferenceTypeProviders 
+        internal static class ReferenceTypeProviders
         {
             <#= CommonGeneratorUtils.IndentEveryNewline(generator.Generate("Updates", $"List<{componentDetails.TypeName}.Update>"), 3) #>
 

--- a/schema/improbable/gdk/tests/exhaustive_test.schema
+++ b/schema/improbable/gdk/tests/exhaustive_test.schema
@@ -27,7 +27,7 @@ component ExhaustiveSingular {
 
 component ExhaustiveOptional {
   id = 197716;
-  // option<bool> field1 = 1; TODO: UTY-450 Uncomment when bool1 wrappers fixed.
+  option<bool> field1 = 1;
   option<float> field2 = 2;
   // option<bytes> field3 = 3; TODO: UTY-498 Uncomment when bytes are supported.
   option<int32> field4 = 4;
@@ -48,7 +48,7 @@ component ExhaustiveOptional {
 
 component ExhaustiveRepeated {
   id = 197717;
-  // list<bool> field1 = 1; TODO: UTY-450 Uncomment when bool1 wrappers fixed.
+  list<bool> field1 = 1;
   list<float> field2 = 2;
   // list<bytes> field3 = 3; TODO: UTY-498 Uncomment when bytes are supported.
   list<int32> field4 = 4;
@@ -69,7 +69,7 @@ component ExhaustiveRepeated {
 
 component ExhaustiveMapValue {
   id = 197718;
-  // map<string, bool> field1 = 1; TODO: UTY-450 Uncomment when bool1 wrappers fixed.
+  map<string, bool> field1 = 1;
   map<string, float> field2 = 2;
   // map<string, bytes> field3 = 3; TODO: UTY-498 Uncomment when bytes are supported.
   map<string, int32> field4 = 4;
@@ -90,7 +90,7 @@ component ExhaustiveMapValue {
 
 component ExhaustiveMapKey {
   id = 197719;
-  // map<bool, string> field1 = 1; TODO: UTY-450 Uncomment when bool1 wrappers fixed.
+  map<bool, string> field1 = 1;
   map<float, string> field2 = 2;
   // map<bytes, string> field3 = 3; TODO: UTY-498 Uncomment when bytes are supported.
   map<int32, string> field4 = 4;


### PR DESCRIPTION
#### Description
Small change required to get `collection<bool>` to compile.
#### Tests
Un-commented the parts of schema, ran codegen and had Unity compile. 
