### PR TITLE
Preprocess prefabs before entering playmode or building

### DIFF
--- a/workers/unity/Assets/Playground/Editor/Prefabs.meta
+++ b/workers/unity/Assets/Playground/Editor/Prefabs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7c8c192344e570c4bb12a3cbd67ff8eb
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Assets/Playground/Editor/Prefabs/PrefabPreprocessor.cs
+++ b/workers/unity/Assets/Playground/Editor/Prefabs/PrefabPreprocessor.cs
@@ -43,7 +43,8 @@ namespace Playground.Editor
                 .Select(AssetDatabase.GUIDToAssetPath)
                 .Where(assetPath => assetPath.Contains("Resources"))
                 .Select(AssetDatabase.LoadAssetAtPath<GameObject>)
-                .Where(prefabObject => prefabObject != null);
+                .Where(prefabObject => prefabObject != null)
+                .ToArray();
 
             foreach (var prefabObject in allPrefabObjectsInResources)
             {

--- a/workers/unity/Assets/Playground/Editor/Prefabs/PrefabPreprocessor.cs
+++ b/workers/unity/Assets/Playground/Editor/Prefabs/PrefabPreprocessor.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Improbable.Gdk.Core.GameObjectRepresentation;
+using UnityEditor;
+using UnityEditor.Build;
+using UnityEditor.Build.Reporting;
+using UnityEngine;
+using Object = UnityEngine.Object;
+
+namespace Playground.Editor
+{
+    [InitializeOnLoad]
+    public class PrefabPreprocessor : IPreprocessBuildWithReport
+    {
+        // Needed for IPreprocessBuildWithReport
+        public int callbackOrder => 0;
+
+        static PrefabPreprocessor()
+        {
+            EditorApplication.playModeStateChanged += OnPlaymodeStateChanged;
+        }
+
+        void IPreprocessBuildWithReport.OnPreprocessBuild(BuildReport report)
+        {
+            PreprocessPrefabs();
+        }
+
+        private static void OnPlaymodeStateChanged(PlayModeStateChange playModeStateChange)
+        {
+            if (playModeStateChange == PlayModeStateChange.ExitingEditMode)
+            {
+                PreprocessPrefabs();
+            }
+        }
+
+        private static void PreprocessPrefabs()
+        {
+            var assetsUpdated = false;
+
+            var allPrefabObjectsInResources = AssetDatabase.FindAssets("t:Prefab")
+                .Select(AssetDatabase.GUIDToAssetPath)
+                .Where(assetPath => assetPath.Contains("Resources"))
+                .Select(AssetDatabase.LoadAssetAtPath<GameObject>)
+                .Where(prefabObject => prefabObject != null);
+
+            foreach (var prefabObject in allPrefabObjectsInResources)
+            {
+                var prefabWasFixed = false;
+
+                foreach (var monoBehaviour in prefabObject
+                    .GetComponents<MonoBehaviour>()
+                    .Where(DoesBehaviourNeedFixing))
+                {
+                    assetsUpdated = true;
+                    prefabWasFixed = true;
+
+                    Undo.RecordObject(monoBehaviour, "Disable MonoBehaviours with [Require] fields on prefabs.");
+
+                    monoBehaviour.enabled = false;
+                }
+
+                if (prefabWasFixed)
+                {
+                    EditorUtility.SetDirty(prefabObject);
+                }
+            }
+
+            if (assetsUpdated)
+            {
+                AssetDatabase.SaveAssets();
+            }
+        }
+
+        private static bool IsBehaviourEnabledInEditor(Object obj)
+        {
+            return !ReferenceEquals(obj, null)
+                && EditorUtility.GetObjectEnabled(obj) == 1;
+        }
+
+        private static bool DoesBehaviourRequireReadersOrWriters(Type targetType)
+        {
+            return targetType
+                .GetFields(BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public)
+                .Any(field => Attribute.IsDefined(field, typeof(RequireAttribute), false));
+        }
+
+        private static bool DoesBehaviourNeedFixing(MonoBehaviour monoBehaviour)
+        {
+            return IsBehaviourEnabledInEditor(monoBehaviour) &&
+                DoesBehaviourRequireReadersOrWriters(monoBehaviour.GetType());
+        }
+    }
+}

--- a/workers/unity/Assets/Playground/Editor/Prefabs/PrefabPreprocessor.cs.meta
+++ b/workers/unity/Assets/Playground/Editor/Prefabs/PrefabPreprocessor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a7222603732cbf649915f0a7e26894af
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Assets/Playground/Resources/Prefabs/Spinner.prefab
+++ b/workers/unity/Assets/Playground/Resources/Prefabs/Spinner.prefab
@@ -106,7 +106,7 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1198430049189278}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 5acf7b07e53f47be81fa9afc4f0f2712, type: 3}
   m_Name: 
@@ -117,13 +117,12 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1198430049189278}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 3474cc00af7642447b37f09cd4cd4cb1, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   flashTime: 0.2
-  flashColor: {r: 1, g: 0, b: 0, a: 1}
 --- !u!114 &114446978971394342
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -141,7 +140,7 @@ MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1198430049189278}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 40c6f4a65d31e884ba3f035255fec5d6, type: 3}
   m_Name: 


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
SpatialOS GDK for Unity takes ownership of MonoBehaviour activation if they [Require] Readers/Writers/Command Senders/Command Response Handlers. Let’s call these Spatial Behaviours.

This is because they should not be receiving OnEnable callbacks if their reader/writers are null.
When a prefab is instantiated, all of the active MonoBehaviours will be enabled immediately. This results in undesired behaviour if any of these MonoBehaviours are Spatial Behaviours. For example if they would like to, within OnEnable, immediately fetch SpatialOS component info through a Reader, the Reader will be null.

##### Solution
Spatial Behaviours should be disabled before a prefab that may contain them can be instantiated.
We propose an editor script to resolve this.

#### Tests
Tested locally
- by enabling behaviours, hitting play: they get disabled ✅ 
- by enabling behaviours and doing a build: they get disabled ✅ 

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
@zeroZshadow @MPeti01 