### PR TITLE
Features/uty 744 il2 cpp support

### DIFF
--- a/workers/unity/Assets/Playground/Scripts/Cubes/CollisionProcessSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/Cubes/CollisionProcessSystem.cs
@@ -13,7 +13,7 @@ using Unity.Entities;
 
 namespace Playground
 {
-    [RemoveAtEndOfTick]
+    [RemoveAtEndOfTickAtrribute]
     public struct CollisionComponent : IComponentData
     {
         public Entity OwnEntity;

--- a/workers/unity/Assets/Playground/Scripts/Cubes/CollisionProcessSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/Cubes/CollisionProcessSystem.cs
@@ -13,7 +13,7 @@ using Unity.Entities;
 
 namespace Playground
 {
-    [RemoveAtEndOfTick]
+    [RemoveAtEndOfTickAttribute]
     public struct CollisionComponent : IComponentData
     {
         public Entity OwnEntity;

--- a/workers/unity/Assets/Playground/Scripts/Cubes/CollisionProcessSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/Cubes/CollisionProcessSystem.cs
@@ -13,7 +13,7 @@ using Unity.Entities;
 
 namespace Playground
 {
-    [RemoveAtEndOfTickAttribute]
+    [RemoveAtEndOfTick]
     public struct CollisionComponent : IComponentData
     {
         public Entity OwnEntity;

--- a/workers/unity/Assets/link.xml
+++ b/workers/unity/Assets/link.xml
@@ -1,0 +1,5 @@
+<linker>
+	<assembly fullname="Improbable.Gdk.Core" preserve="all"/>
+	<assembly fullname="Improbable.Gdk.TransformSynchronization" preserve="all"/>
+	<assembly fullname="Improbable.Gdk.PlayerLifecycle" preserve="all"/>
+</linker>

--- a/workers/unity/Assets/link.xml.meta
+++ b/workers/unity/Assets/link.xml.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 1bb255a5e77934b52997e18fed43b44c
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/com.improbable.gdk.core/Attributes/RemoveAtEndOfTickAttribute.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Attributes/RemoveAtEndOfTickAttribute.cs
@@ -7,8 +7,8 @@ namespace Improbable.Gdk.Core
     ///     Any component with this attribute will be removed from all entities by the CleanReactiveComponentSystem
     ///     Can be added to components extending <see cref="IComponentData" /> or <see cref="ISharedComponentData" />
     /// </summary>
-    [AttributeUsage(AttributeTargets.Struct, AllowMultiple = false, Inherited = false)]
-    public class RemoveAtEndOfTickAttribute : Attribute
+    [AttributeUsage(AttributeTargets.Struct)]
+    public class RemoveAtEndOfTick : Attribute
     {
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.core/Attributes/RemoveAtEndOfTickAttribute.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Attributes/RemoveAtEndOfTickAttribute.cs
@@ -4,11 +4,13 @@ using Unity.Entities;
 namespace Improbable.Gdk.Core
 {
     /// <summary>
-    ///     Any component with this attribute will be removed from all entities by the CleanReactiveComponentSystem
+    ///     Any component that inheriting this interrace will be removed from all entities
+    ///     by the CleanReactiveComponentSystem.
     ///     Can be added to components extending <see cref="IComponentData" /> or <see cref="ISharedComponentData" />
     /// </summary>
-    [AttributeUsage(AttributeTargets.Struct)]
-    public class RemoveAtEndOfTickAttribute : Attribute
+
+    public interface RemoveAtEndOfTick
     {
+        void RemoveComponent(EntityCommandBuffer commands, Entity entity);
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.core/Attributes/RemoveAtEndOfTickAttribute.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Attributes/RemoveAtEndOfTickAttribute.cs
@@ -10,6 +10,5 @@ namespace Improbable.Gdk.Core
     [AttributeUsage(AttributeTargets.Struct, AllowMultiple = false, Inherited = false)]
     public class RemoveAtEndOfTick : Attribute
     {
-        
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.core/Attributes/RemoveAtEndOfTickAttribute.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Attributes/RemoveAtEndOfTickAttribute.cs
@@ -8,7 +8,7 @@ namespace Improbable.Gdk.Core
     ///     Can be added to components extending <see cref="IComponentData" /> or <see cref="ISharedComponentData" />
     /// </summary>
     [AttributeUsage(AttributeTargets.Struct, AllowMultiple = false, Inherited = false)]
-    public class RemoveAtEndOfTick : Attribute
+    public class RemoveAtEndOfTickAttribute : Attribute
     {
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.core/Attributes/RemoveAtEndOfTickAttribute.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Attributes/RemoveAtEndOfTickAttribute.cs
@@ -8,7 +8,7 @@ namespace Improbable.Gdk.Core
     ///     Can be added to components extending <see cref="IComponentData" /> or <see cref="ISharedComponentData" />
     /// </summary>
     [AttributeUsage(AttributeTargets.Struct)]
-    public class RemoveAtEndOfTick : Attribute
+    public class RemoveAtEndOfTickAtrribute : Attribute
     {
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.core/Attributes/RemoveAtEndOfTickAttribute.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Attributes/RemoveAtEndOfTickAttribute.cs
@@ -4,12 +4,12 @@ using Unity.Entities;
 namespace Improbable.Gdk.Core
 {
     /// <summary>
-    ///     Any component which inherits this interface will be removed from all entities by the CleanReactiveComponentSystem.
+    ///     Any component with this attribute will be removed from all entities by the CleanReactiveComponentSystem
     ///     Can be added to components extending <see cref="IComponentData" /> or <see cref="ISharedComponentData" />
     /// </summary>
-
-    public interface IRemoveableComponent
+    [AttributeUsage(AttributeTargets.Struct, AllowMultiple = false, Inherited = false)]
+    public class RemoveAtEndOfTick : Attribute
     {
-        void RemoveComponent(EntityCommandBuffer commands, Entity entity);
+        
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.core/Attributes/RemoveAtEndOfTickAttribute.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Attributes/RemoveAtEndOfTickAttribute.cs
@@ -4,12 +4,11 @@ using Unity.Entities;
 namespace Improbable.Gdk.Core
 {
     /// <summary>
-    ///     Any component that inheriting this interrace will be removed from all entities
-    ///     by the CleanReactiveComponentSystem.
+    ///     Any component which inherits this interface will be removed from all entities by the CleanReactiveComponentSystem.
     ///     Can be added to components extending <see cref="IComponentData" /> or <see cref="ISharedComponentData" />
     /// </summary>
 
-    public interface RemoveAtEndOfTick
+    public interface IRemoveableComponent
     {
         void RemoveComponent(EntityCommandBuffer commands, Entity entity);
     }

--- a/workers/unity/Packages/com.improbable.gdk.core/Components/NewlyAddedSpatialOSEntity.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Components/NewlyAddedSpatialOSEntity.cs
@@ -7,7 +7,7 @@ namespace Improbable.Gdk.Core
     ///     This component is automatically added to an entity upon its creation and automatically removed at the end of the
     ///     same frame.
     /// </summary>
-    public struct NewlyAddedSpatialOSEntity : IComponentData, RemoveAtEndOfTick
+    public struct NewlyAddedSpatialOSEntity : IComponentData, IRemoveableComponent
     {
         public void RemoveComponent(EntityCommandBuffer commands, Entity entity)
         {

--- a/workers/unity/Packages/com.improbable.gdk.core/Components/NewlyAddedSpatialOSEntity.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Components/NewlyAddedSpatialOSEntity.cs
@@ -7,7 +7,7 @@ namespace Improbable.Gdk.Core
     ///     This component is automatically added to an entity upon its creation and automatically removed at the end of the
     ///     same frame.
     /// </summary>
-    [RemoveAtEndOfTick]
+    [RemoveAtEndOfTickAttribute]
     public struct NewlyAddedSpatialOSEntity : IComponentData
     {
     }

--- a/workers/unity/Packages/com.improbable.gdk.core/Components/NewlyAddedSpatialOSEntity.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Components/NewlyAddedSpatialOSEntity.cs
@@ -7,11 +7,8 @@ namespace Improbable.Gdk.Core
     ///     This component is automatically added to an entity upon its creation and automatically removed at the end of the
     ///     same frame.
     /// </summary>
-    public struct NewlyAddedSpatialOSEntity : IComponentData, IRemoveableComponent
+    [RemoveAtEndOfTick]
+    public struct NewlyAddedSpatialOSEntity : IComponentData
     {
-        public void RemoveComponent(EntityCommandBuffer commands, Entity entity)
-        {
-            commands.RemoveComponent<NewlyAddedSpatialOSEntity>(entity);
-        }
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.core/Components/NewlyAddedSpatialOSEntity.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Components/NewlyAddedSpatialOSEntity.cs
@@ -7,8 +7,11 @@ namespace Improbable.Gdk.Core
     ///     This component is automatically added to an entity upon its creation and automatically removed at the end of the
     ///     same frame.
     /// </summary>
-    [RemoveAtEndOfTick]
-    public struct NewlyAddedSpatialOSEntity : IComponentData
+    public struct NewlyAddedSpatialOSEntity : IComponentData, RemoveAtEndOfTick
     {
+        public void RemoveComponent(EntityCommandBuffer commands, Entity entity)
+        {
+            commands.RemoveComponent<NewlyAddedSpatialOSEntity>(entity);
+        }
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.core/Components/NewlyAddedSpatialOSEntity.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Components/NewlyAddedSpatialOSEntity.cs
@@ -7,7 +7,7 @@ namespace Improbable.Gdk.Core
     ///     This component is automatically added to an entity upon its creation and automatically removed at the end of the
     ///     same frame.
     /// </summary>
-    [RemoveAtEndOfTickAttribute]
+    [RemoveAtEndOfTick]
     public struct NewlyAddedSpatialOSEntity : IComponentData
     {
     }

--- a/workers/unity/Packages/com.improbable.gdk.core/Components/NewlyAddedSpatialOSEntity.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Components/NewlyAddedSpatialOSEntity.cs
@@ -7,7 +7,7 @@ namespace Improbable.Gdk.Core
     ///     This component is automatically added to an entity upon its creation and automatically removed at the end of the
     ///     same frame.
     /// </summary>
-    [RemoveAtEndOfTick]
+    [RemoveAtEndOfTickAtrribute]
     public struct NewlyAddedSpatialOSEntity : IComponentData
     {
     }

--- a/workers/unity/Packages/com.improbable.gdk.core/Components/WorkerEntityComponents.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Components/WorkerEntityComponents.cs
@@ -21,7 +21,7 @@ namespace Improbable.Gdk.Core
     ///     Component added to the worker entity immediately after establishing a connection to a SpatialOS deployment
     ///     Removed at the end of the tick it was added
     /// </summary>
-    [RemoveAtEndOfTickAttribute]
+    [RemoveAtEndOfTick]
     public struct OnConnected : IComponentData
     {
     }
@@ -30,7 +30,7 @@ namespace Improbable.Gdk.Core
     ///     Component added to the worker entity immediately after disconnecting from SpatialOS
     ///     Removed at the end of the tick it was added
     /// </summary>
-    [RemoveAtEndOfTickAttribute]
+    [RemoveAtEndOfTick]
     public struct OnDisconnected : ISharedComponentData
     {
         /// <summary>

--- a/workers/unity/Packages/com.improbable.gdk.core/Components/WorkerEntityComponents.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Components/WorkerEntityComponents.cs
@@ -21,7 +21,7 @@ namespace Improbable.Gdk.Core
     ///     Component added to the worker entity immediately after establishing a connection to a SpatialOS deployment
     ///     Removed at the end of the tick it was added
     /// </summary>
-    [RemoveAtEndOfTick]
+    [RemoveAtEndOfTickAtrribute]
     public struct OnConnected : IComponentData
     {
     }
@@ -30,7 +30,7 @@ namespace Improbable.Gdk.Core
     ///     Component added to the worker entity immediately after disconnecting from SpatialOS
     ///     Removed at the end of the tick it was added
     /// </summary>
-    [RemoveAtEndOfTick]
+    [RemoveAtEndOfTickAtrribute]
     public struct OnDisconnected : ISharedComponentData
     {
         /// <summary>

--- a/workers/unity/Packages/com.improbable.gdk.core/Components/WorkerEntityComponents.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Components/WorkerEntityComponents.cs
@@ -21,7 +21,8 @@ namespace Improbable.Gdk.Core
     ///     Component added to the worker entity immediately after establishing a connection to a SpatialOS deployment
     ///     Removed at the end of the tick it was added
     /// </summary>
-    public struct OnConnected : IComponentData, IRemoveableComponent
+    [RemoveAtEndOfTick]
+    public struct OnConnected : IComponentData
     {
         public void RemoveComponent(EntityCommandBuffer commands, Entity entity)
         {
@@ -33,7 +34,8 @@ namespace Improbable.Gdk.Core
     ///     Component added to the worker entity immediately after disconnecting from SpatialOS
     ///     Removed at the end of the tick it was added
     /// </summary>
-    public struct OnDisconnected : ISharedComponentData, IRemoveableComponent
+    [RemoveAtEndOfTick]
+    public struct OnDisconnected : ISharedComponentData
     {
         /// <summary>
         ///     The reported reason for disconnecting

--- a/workers/unity/Packages/com.improbable.gdk.core/Components/WorkerEntityComponents.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Components/WorkerEntityComponents.cs
@@ -21,7 +21,7 @@ namespace Improbable.Gdk.Core
     ///     Component added to the worker entity immediately after establishing a connection to a SpatialOS deployment
     ///     Removed at the end of the tick it was added
     /// </summary>
-    public struct OnConnected : IComponentData, RemoveAtEndOfTick
+    public struct OnConnected : IComponentData, IRemoveableComponent
     {
         public void RemoveComponent(EntityCommandBuffer commands, Entity entity)
         {
@@ -33,7 +33,7 @@ namespace Improbable.Gdk.Core
     ///     Component added to the worker entity immediately after disconnecting from SpatialOS
     ///     Removed at the end of the tick it was added
     /// </summary>
-    public struct OnDisconnected : ISharedComponentData, RemoveAtEndOfTick
+    public struct OnDisconnected : ISharedComponentData, IRemoveableComponent
     {
         /// <summary>
         ///     The reported reason for disconnecting

--- a/workers/unity/Packages/com.improbable.gdk.core/Components/WorkerEntityComponents.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Components/WorkerEntityComponents.cs
@@ -21,21 +21,27 @@ namespace Improbable.Gdk.Core
     ///     Component added to the worker entity immediately after establishing a connection to a SpatialOS deployment
     ///     Removed at the end of the tick it was added
     /// </summary>
-    [RemoveAtEndOfTick]
-    public struct OnConnected : IComponentData
+    public struct OnConnected : IComponentData, RemoveAtEndOfTick
     {
+        public void RemoveComponent(EntityCommandBuffer commands, Entity entity)
+        {
+            commands.RemoveComponent<OnConnected>(entity);
+        }
     }
 
     /// <summary>
     ///     Component added to the worker entity immediately after disconnecting from SpatialOS
     ///     Removed at the end of the tick it was added
     /// </summary>
-    [RemoveAtEndOfTick]
-    public struct OnDisconnected : ISharedComponentData
+    public struct OnDisconnected : ISharedComponentData, RemoveAtEndOfTick
     {
         /// <summary>
         ///     The reported reason for disconnecting
         /// </summary>
         public string ReasonForDisconnect;
+        public void RemoveComponent(EntityCommandBuffer commands, Entity entity)
+        {
+            commands.RemoveComponent<OnDisconnected>(entity);
+        }
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.core/Components/WorkerEntityComponents.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Components/WorkerEntityComponents.cs
@@ -21,7 +21,7 @@ namespace Improbable.Gdk.Core
     ///     Component added to the worker entity immediately after establishing a connection to a SpatialOS deployment
     ///     Removed at the end of the tick it was added
     /// </summary>
-    [RemoveAtEndOfTick]
+    [RemoveAtEndOfTickAttribute]
     public struct OnConnected : IComponentData
     {
     }
@@ -30,7 +30,7 @@ namespace Improbable.Gdk.Core
     ///     Component added to the worker entity immediately after disconnecting from SpatialOS
     ///     Removed at the end of the tick it was added
     /// </summary>
-    [RemoveAtEndOfTick]
+    [RemoveAtEndOfTickAttribute]
     public struct OnDisconnected : ISharedComponentData
     {
         /// <summary>

--- a/workers/unity/Packages/com.improbable.gdk.core/Components/WorkerEntityComponents.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Components/WorkerEntityComponents.cs
@@ -24,10 +24,6 @@ namespace Improbable.Gdk.Core
     [RemoveAtEndOfTick]
     public struct OnConnected : IComponentData
     {
-        public void RemoveComponent(EntityCommandBuffer commands, Entity entity)
-        {
-            commands.RemoveComponent<OnConnected>(entity);
-        }
     }
 
     /// <summary>
@@ -41,9 +37,5 @@ namespace Improbable.Gdk.Core
         ///     The reported reason for disconnecting
         /// </summary>
         public string ReasonForDisconnect;
-        public void RemoveComponent(EntityCommandBuffer commands, Entity entity)
-        {
-            commands.RemoveComponent<OnDisconnected>(entity);
-        }
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.core/Systems/CleanReactiveComponentsSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Systems/CleanReactiveComponentsSystem.cs
@@ -26,7 +26,7 @@ namespace Improbable.Gdk.Core
 
             GenerateComponentGroups();
         }
-
+        
         private void GenerateComponentGroups()
         {
             foreach (var translationUnit in view.TranslationUnits.Values)
@@ -37,7 +37,7 @@ namespace Improbable.Gdk.Core
                     translationUnit.CleanUpComponentGroups.Add(GetComponentGroup(componentType));
                 }
             }
-            
+
             // Find all components with the RemoveAtEndOfTick attribute
             foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
             {
@@ -74,7 +74,7 @@ namespace Improbable.Gdk.Core
                 {
                     continue;
                 }
-                
+
                 var entityArray = componentGroup.GetEntityArray();
                 for (var i = 0; i < entityArray.Length; ++i)
                 {

--- a/workers/unity/Packages/com.improbable.gdk.core/Systems/CleanReactiveComponentsSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Systems/CleanReactiveComponentsSystem.cs
@@ -48,6 +48,7 @@ namespace Improbable.Gdk.Core
                     {
                         continue;
                     }
+
                     if (!typeof(IComponentData).IsAssignableFrom(type)
                         && !typeof(ISharedComponentData).IsAssignableFrom(type))
                     {
@@ -66,20 +67,20 @@ namespace Improbable.Gdk.Core
 
         private void RemoveComponents()
         {
-            var componentToRemove = new List<Tuple<Entity,Type>>();
+            var componentToRemove = new List<(Entity, Type)>();
             foreach (Type type in typesToRemove)
             {
                 var componentGroup = GetComponentGroup(ComponentType.ReadOnly(type));
                 var entityArray = componentGroup.GetEntityArray();
                 for (var i = 0; i < entityArray.Length; ++i)
                 {
-                    componentToRemove.Add(Tuple.Create<Entity, Type>(entityArray[i], type));
+                    componentToRemove.Add((entityArray[i], type));
                 }
             }
 
-            foreach (Tuple<Entity, Type> entity in componentToRemove)
+            foreach ((Entity entity, Type type) in componentToRemove)
             {
-                EntityManager.RemoveComponent(entity.Item1, entity.Item2);
+                EntityManager.RemoveComponent(entity, type);
             }
         }
 

--- a/workers/unity/Packages/com.improbable.gdk.core/Systems/CleanReactiveComponentsSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Systems/CleanReactiveComponentsSystem.cs
@@ -6,7 +6,7 @@ using Unity.Entities;
 namespace Improbable.Gdk.Core
 {
     /// <summary>
-    ///     Removes GDK reactive components and components with attribute RemoveAtEndOfTickAttribute from all entities
+    ///     Removes GDK reactive components and components with attribute RemoveAtEndOfTick from all entities
     /// </summary>
     [UpdateInGroup(typeof(SpatialOSSendGroup.InternalSpatialOSCleanGroup))]
     public class CleanReactiveComponentsSystem : ComponentSystem
@@ -38,12 +38,12 @@ namespace Improbable.Gdk.Core
                 }
             }
             
-            // Find all components with the RemoveAtEndOfTickAttribute attribute
+            // Find all components with the RemoveAtEndOfTick attribute
             foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
             {
                 foreach (var type in assembly.GetTypes())
                 {
-                    if (type.GetCustomAttribute<RemoveAtEndOfTickAttribute>(false) == null)
+                    if (type.GetCustomAttribute<RemoveAtEndOfTick>(false) == null)
                     {
                         continue;
                     }

--- a/workers/unity/Packages/com.improbable.gdk.core/Systems/CleanReactiveComponentsSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Systems/CleanReactiveComponentsSystem.cs
@@ -93,6 +93,18 @@ namespace Improbable.Gdk.Core
                 }
             });
         }
+        
+        private void UsedOnlyForAotCodeGeneration()
+        {
+            // IL2CPP needs those lines for AOT instantiation of methods
+            AddRemoveComponentAction<OnConnected>();
+            AddRemoveComponentAction<OnDisconnected>();
+            AddRemoveComponentAction<NewlyAddedSpatialOSEntity>();
+
+            // Include an exception so we can be sure to know if this method is ever called.
+            throw new InvalidOperationException(
+                "This method is used for AOT code generation only. Do not call it at runtime.");
+        }
 
         protected override void OnUpdate()
         {

--- a/workers/unity/Packages/com.improbable.gdk.core/Systems/CleanReactiveComponentsSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Systems/CleanReactiveComponentsSystem.cs
@@ -44,10 +44,12 @@ namespace Improbable.Gdk.Core
             {
                 foreach (var type in assembly.GetTypes())
                 {
-                    if (type.IsAbstract ||
-                        !typeof(IRemoveableComponent).IsAssignableFrom(type) ||
-                        (!typeof(IComponentData).IsAssignableFrom(type)
-                         && !typeof(ISharedComponentData).IsAssignableFrom(type)))
+                    if (type.GetCustomAttribute<RemoveAtEndOfTick>(false) == null)
+                    {
+                        continue;
+                    }
+                    if (!typeof(IComponentData).IsAssignableFrom(type)
+                        && !typeof(ISharedComponentData).IsAssignableFrom(type))
                     {
                         continue;
                     }
@@ -59,7 +61,7 @@ namespace Improbable.Gdk.Core
 
                     typesToRemove.Add(type);
                 }
-            }            
+            }
         }
 
         private void RemoveComponents()
@@ -90,7 +92,7 @@ namespace Improbable.Gdk.Core
             {
                 translationUnit.CleanUpComponents(ref commandBuffer);
             }
-            
+
             // Clean components with RemoveAtEndOfTick attribute
             foreach (var removeComponentAction in removeComponentActions)
             {

--- a/workers/unity/Packages/com.improbable.gdk.core/Systems/CleanReactiveComponentsSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Systems/CleanReactiveComponentsSystem.cs
@@ -6,7 +6,7 @@ using Unity.Entities;
 namespace Improbable.Gdk.Core
 {
     /// <summary>
-    ///     Removes GDK reactive components and components with attribute RemoveAtEndOfTick from all entities
+    ///     Removes GDK reactive components and components with attribute RemoveAtEndOfTickAttribute from all entities
     /// </summary>
     [UpdateInGroup(typeof(SpatialOSSendGroup.InternalSpatialOSCleanGroup))]
     public class CleanReactiveComponentsSystem : ComponentSystem
@@ -37,12 +37,12 @@ namespace Improbable.Gdk.Core
                 }
             }
             
-            // Find all components with the RemoveAtEndOfTick attribute
+            // Find all components with the RemoveAtEndOfTickAttribute attribute
             foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
             {
                 foreach (var type in assembly.GetTypes())
                 {
-                    if (type.GetCustomAttribute<RemoveAtEndOfTick>(false) == null)
+                    if (type.GetCustomAttribute<RemoveAtEndOfTickAttribute>(false) == null)
                     {
                         continue;
                     }

--- a/workers/unity/Packages/com.improbable.gdk.core/Systems/CleanReactiveComponentsSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Systems/CleanReactiveComponentsSystem.cs
@@ -6,7 +6,7 @@ using Unity.Entities;
 namespace Improbable.Gdk.Core
 {
     /// <summary>
-    ///     Removes GDK reactive components and components with attribute RemoveAtEndOfTick from all entities
+    ///     Removes GDK reactive components and components with attribute RemoveAtEndOfTickAtrribute from all entities
     /// </summary>
     [UpdateInGroup(typeof(SpatialOSSendGroup.InternalSpatialOSCleanGroup))]
     public class CleanReactiveComponentsSystem : ComponentSystem
@@ -26,7 +26,7 @@ namespace Improbable.Gdk.Core
 
             GenerateComponentGroups();
         }
-        
+
         private void GenerateComponentGroups()
         {
             foreach (var translationUnit in view.TranslationUnits.Values)
@@ -38,12 +38,12 @@ namespace Improbable.Gdk.Core
                 }
             }
 
-            // Find all components with the RemoveAtEndOfTick attribute
+            // Find all components with the RemoveAtEndOfTickAtrribute attribute
             foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
             {
                 foreach (var type in assembly.GetTypes())
                 {
-                    if (type.GetCustomAttribute<RemoveAtEndOfTick>(false) == null)
+                    if (type.GetCustomAttribute<RemoveAtEndOfTickAtrribute>(false) == null)
                     {
                         continue;
                     }
@@ -98,7 +98,7 @@ namespace Improbable.Gdk.Core
                 translationUnit.CleanUpComponents(ref commandBuffer);
             }
 
-            // Clean components with RemoveAtEndOfTick attribute
+            // Clean components with RemoveAtEndOfTickAtrribute attribute
             RemoveComponents();
         }
     }

--- a/workers/unity/Packages/com.improbable.gdk.core/Systems/CleanReactiveComponentsSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Systems/CleanReactiveComponentsSystem.cs
@@ -64,19 +64,20 @@ namespace Improbable.Gdk.Core
 
         private void RemoveComponents()
         {
-            var componentGroups = new List<ComponentGroup>();
+            var componentToRemove = new List<Tuple<Entity,Type>>();
             foreach (Type type in typesToRemove)
             {
-                componentGroups.Add(GetComponentGroup(ComponentType.ReadOnly(type)));
-            }
-
-            foreach (var componentGroup in componentGroups)
-            {
+                var componentGroup = GetComponentGroup(ComponentType.ReadOnly(type));
                 var entityArray = componentGroup.GetEntityArray();
                 for (var i = 0; i < entityArray.Length; ++i)
                 {
-                    EntityManager.RemoveComponent(entityArray[i], componentGroup.Types[0]);
+                    componentToRemove.Add(Tuple.Create<Entity, Type>(entityArray[i], type));
                 }
+            }
+
+            foreach (Tuple<Entity, Type> entity in componentToRemove)
+            {
+                EntityManager.RemoveComponent(entity.Item1, entity.Item2);
             }
         }
 

--- a/workers/unity/Packages/com.improbable.gdk.core/Systems/CleanReactiveComponentsSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Systems/CleanReactiveComponentsSystem.cs
@@ -13,8 +13,6 @@ namespace Improbable.Gdk.Core
     {
         private MutableView view;
 
-        private readonly List<Action> removeComponentActions = new List<Action>();
-
         // Here to prevent adding an action for the same type multiple times
         private readonly HashSet<Type> typesToRemove = new HashSet<Type>();
 
@@ -95,10 +93,7 @@ namespace Improbable.Gdk.Core
             }
 
             // Clean components with RemoveAtEndOfTick attribute
-            foreach (var removeComponentAction in removeComponentActions)
-            {
-                RemoveComponents();
-            }
+            RemoveComponents();
         }
     }
 }


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
This adds assembly linker instructions to not strip classes needed for AOT and instantiation calls to methods that should be declared for AOT.
Original discussion in https://github.com/spatialos/UnityGDK/pull/143
#### Tests
Ensure iOS is built with these changes, performance doesn't regress and builds are done correctly
#### Documentation
https://brevi.link/il2cpp
#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.