### PR TITLE
Adding support for IL2CPP to GDK

### DIFF
--- a/workers/unity/Assets/link.xml
+++ b/workers/unity/Assets/link.xml
@@ -1,0 +1,5 @@
+<linker>
+	<assembly fullname="Improbable.Gdk.Core" preserve="all"/>
+	<assembly fullname="Improbable.Gdk.TransformSynchronization" preserve="all"/>
+	<assembly fullname="Improbable.Gdk.PlayerLifecycle" preserve="all"/>
+</linker>

--- a/workers/unity/Assets/link.xml.meta
+++ b/workers/unity/Assets/link.xml.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 1bb255a5e77934b52997e18fed43b44c
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/com.improbable.gdk.core/Systems/CleanReactiveComponentsSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Systems/CleanReactiveComponentsSystem.cs
@@ -17,7 +17,9 @@ namespace Improbable.Gdk.Core
 
         // Here to prevent adding an action for the same type multiple times
         private readonly HashSet<Type> typesToRemove = new HashSet<Type>();
-        private readonly List<(ComponentGroup, Type)> componentGroupsToRemove = new List<(ComponentGroup, Type)>();
+        
+        private readonly List<(ComponentGroup, ComponentType)> componentGroupsToRemove = new List<(ComponentGroup, ComponentType)>();
+        private readonly List<(Entity, ComponentType)> componentsToRemove = new List<(Entity, ComponentType)>();
 
         protected override void OnCreateManager(int capacity)
         {
@@ -58,7 +60,7 @@ namespace Improbable.Gdk.Core
                         foreach (var componentType in componentCleanupHandler.CleanUpComponentTypes)
                         {
                             typesToRemove.Add(componentType.GetManagedType());
-                            componentGroupsToRemove.Add((GetComponentGroup(componentType), componentType.GetManagedType()));
+                            componentGroupsToRemove.Add((GetComponentGroup(componentType), componentType));
                         }
 
                         // Updates group
@@ -104,8 +106,8 @@ namespace Improbable.Gdk.Core
 
         private void RemoveComponents()
         {
-            var componentsToRemove = new List<(Entity, Type)>();
-            foreach ((ComponentGroup componentGroup, Type type) in componentGroupsToRemove)
+            componentsToRemove.Clear();
+            foreach ((ComponentGroup componentGroup, ComponentType type) in componentGroupsToRemove)
             {
                 if (componentGroup.IsEmptyIgnoreFilter)
                 {
@@ -119,7 +121,7 @@ namespace Improbable.Gdk.Core
                 }
             }
 
-            foreach ((Entity entity, Type type) in componentsToRemove)
+            foreach ((Entity entity, ComponentType type) in componentsToRemove)
             {
                 EntityManager.RemoveComponent(entity, type);
             }

--- a/workers/unity/Packages/com.improbable.gdk.core/Systems/CleanReactiveComponentsSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Systems/CleanReactiveComponentsSystem.cs
@@ -13,12 +13,11 @@ namespace Improbable.Gdk.Core
     [UpdateInGroup(typeof(SpatialOSSendGroup.InternalSpatialOSCleanGroup))]
     public class CleanReactiveComponentsSystem : ComponentSystem
     {
-        private readonly List<Action> removeComponentActions = new List<Action>();
-
         private readonly List<ComponentCleanup> componentCleanups = new List<ComponentCleanup>();
 
         // Here to prevent adding an action for the same type multiple times
         private readonly HashSet<Type> typesToRemove = new HashSet<Type>();
+        private readonly List<(ComponentGroup, Type)> componentGroupsToRemove = new List<(ComponentGroup, Type)>();
 
         protected override void OnCreateManager(int capacity)
         {
@@ -28,17 +27,6 @@ namespace Improbable.Gdk.Core
 
         private void GenerateComponentGroups()
         {
-            // TODO: Remove workaround when UTY-936 is fixed
-            var addRemoveComponentActionMethod =
-                typeof(CleanReactiveComponentsSystem).GetMethod(nameof(AddRemoveComponentAction),
-                    BindingFlags.NonPublic | BindingFlags.Instance);
-
-            if (addRemoveComponentActionMethod == null)
-            {
-                throw new MissingMethodException(nameof(CleanReactiveComponentsSystem),
-                    nameof(AddRemoveComponentAction));
-            }
-
             foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
             {
                 // Find all components with the RemoveAtEndOfTick attribute
@@ -57,7 +45,7 @@ namespace Improbable.Gdk.Core
 
                     if (typesToRemove.Add(type))
                     {
-                        addRemoveComponentActionMethod.MakeGenericMethod(type).Invoke(this, null);
+                        componentGroupsToRemove.Add((GetComponentGroup(ComponentType.ReadOnly(type)), type));
                     }
                 }
 
@@ -70,8 +58,7 @@ namespace Improbable.Gdk.Core
                         foreach (var componentType in componentCleanupHandler.CleanUpComponentTypes)
                         {
                             typesToRemove.Add(componentType.GetManagedType());
-                            addRemoveComponentActionMethod.MakeGenericMethod(componentType.GetManagedType())
-                                .Invoke(this, null);
+                            componentGroupsToRemove.Add((GetComponentGroup(componentType), componentType.GetManagedType()));
                         }
 
                         // Updates group
@@ -91,31 +78,8 @@ namespace Improbable.Gdk.Core
             }
         }
 
-        private void AddRemoveComponentAction<T>()
-        {
-            var componentGroup = GetComponentGroup(ComponentType.ReadOnly<T>());
-            removeComponentActions.Add(() =>
-            {
-                if (componentGroup.IsEmptyIgnoreFilter)
-                {
-                    return;
-                }
-
-                var entityArray = componentGroup.GetEntityArray();
-                for (var i = 0; i < entityArray.Length; ++i)
-                {
-                    PostUpdateCommands.RemoveComponent<T>(entityArray[i]);
-                }
-            });
-        }
-
         protected override void OnUpdate()
         {
-            foreach (var removeComponentAction in removeComponentActions)
-            {
-                removeComponentAction();
-            }
-
             var buffer = PostUpdateCommands;
             foreach (var cleanup in componentCleanups)
             {
@@ -124,6 +88,9 @@ namespace Improbable.Gdk.Core
                 cleanup.Handler.CleanupAuthChanges(cleanup.AuthorityChangesGroup, ref buffer);
                 cleanup.Handler.CleanupCommands(cleanup.CommandsGroups, ref buffer);
             }
+
+            // Clean components with RemoveAtEndOfTick attribute
+            RemoveComponents();
         }
 
         private struct ComponentCleanup
@@ -133,6 +100,29 @@ namespace Improbable.Gdk.Core
             public ComponentGroup AuthorityChangesGroup;
             public ComponentGroup[] EventGroups;
             public ComponentGroup[] CommandsGroups;
+        }
+
+        private void RemoveComponents()
+        {
+            var componentsToRemove = new List<(Entity, Type)>();
+            foreach ((ComponentGroup componentGroup, Type type) in componentGroupsToRemove)
+            {
+                if (componentGroup.IsEmptyIgnoreFilter)
+                {
+                    continue;
+                }
+
+                var entityArray = componentGroup.GetEntityArray();
+                for (var i = 0; i < entityArray.Length; ++i)
+                {
+                    componentsToRemove.Add((entityArray[i], type));
+                }
+            }
+
+            foreach ((Entity entity, Type type) in componentsToRemove)
+            {
+                EntityManager.RemoveComponent(entity, type);
+            }
         }
     }
 }


### PR DESCRIPTION
Contributions: We are not currently taking public contributions - see our contributions policy. However, we are accepting issues and we do want your feedback.

Description
This adds assembly linker instructions to not strip classes needed for AOT and instantiation calls to methods that should be declared for AOT.
Original discussion in #143

Tests
Ensure iOS is built with these changes, performance doesn't regress and builds are done correctly

Documentation
https://brevi.link/il2cpp

Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.