### PR TITLE
changing which library we download for mac

### DIFF
--- a/ci/download-core-sdk.sh
+++ b/ci/download-core-sdk.sh
@@ -39,7 +39,7 @@ mkdir -p "${CORE_SDK_DIR}/worker_sdk"
 
 spatial package retrieve "worker_sdk" "c-dynamic-x86_64-msvc_mt-win32"        "${PINNED_CORE_SDK_VERSION}" "${CORE_SDK_DIR}/worker_sdk/c-dynamic-x86_64-msvc_mt-win32"
 spatial package retrieve "worker_sdk" "c-dynamic-x86_64-gcc_libstdcpp-linux"  "${PINNED_CORE_SDK_VERSION}" "${CORE_SDK_DIR}/worker_sdk/c-dynamic-x86_64-gcc_libstdcpp-linux"
-spatial package retrieve "worker_sdk" "c-dynamic-x86_64-clang_libcpp-macos"   "${PINNED_CORE_SDK_VERSION}" "${CORE_SDK_DIR}/worker_sdk/c-dynamic-x86_64-clang_libcpp-macos"
+spatial package retrieve "worker_sdk" "c-bundle-x86_64-clang_libcpp-macos"   "${PINNED_CORE_SDK_VERSION}" "${CORE_SDK_DIR}/worker_sdk/c-dynamic-x86_64-clang_libcpp-macos"
 spatial package retrieve "worker_sdk" "csharp_core"                           "${PINNED_CORE_SDK_VERSION}" "${CORE_SDK_DIR}/worker_sdk/csharp"
 spatial package retrieve "tools"      "schema_compiler-x86_64-win32"          "${PINNED_CORE_SDK_VERSION}" "${CORE_SDK_DIR}/tools/schema_compiler-x86_64-win32"
 spatial package retrieve "tools"      "schema_compiler-x86_64-macos"          "${PINNED_CORE_SDK_VERSION}" "${CORE_SDK_DIR}/tools/schema_compiler-x86_64-macos"

--- a/workers/unity/Assets/Plugins/Improbable/Core/OSX/libworker.dylib.meta
+++ b/workers/unity/Assets/Plugins/Improbable/Core/OSX/libworker.dylib.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: eecba350983eadc4fb7d331684c7344f
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/workers/unity/Assets/Plugins/Improbable/Core/OSX/worker.bundle.meta
+++ b/workers/unity/Assets/Plugins/Improbable/Core/OSX/worker.bundle.meta
@@ -1,0 +1,40 @@
+fileFormatVersion: 2
+guid: 8275c09bd45ed44588044219e7332e67
+folderAsset: yes
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  isPreloaded: 0
+  isOverridable: 0
+  platformData:
+  - first:
+      '': OSXIntel
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      '': OSXIntel64
+    second:
+      enabled: 1
+      settings: {}
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 1
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 1
+      settings: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Assets/Plugins/Improbable/Core/OSX/worker.bundle/Contents.meta
+++ b/workers/unity/Assets/Plugins/Improbable/Core/OSX/worker.bundle/Contents.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3a5f0505461f544b680be442ce2302e9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Assets/Plugins/Improbable/Core/OSX/worker.bundle/Contents/Info.plist
+++ b/workers/unity/Assets/Plugins/Improbable/Core/OSX/worker.bundle/Contents/Info.plist
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>English</string>
+	<key>CFBundleExecutable</key>
+	<string>worker</string>
+	<key>CFBundleGetInfoString</key>
+	<string></string>
+	<key>CFBundleIconFile</key>
+	<string></string>
+	<key>CFBundleIdentifier</key>
+	<string></string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleLongVersionString</key>
+	<string></string>
+	<key>CFBundleName</key>
+	<string></string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string></string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string></string>
+	<key>CSResourcesFileMapped</key>
+	<true/>
+	<key>NSHumanReadableCopyright</key>
+	<string></string>
+	<key>NSPrincipalClass</key>
+	<string>NSApplication</string>
+	<key>NSHighResolutionCapable</key>
+	<string>True</string>
+</dict>
+</plist>

--- a/workers/unity/Assets/Plugins/Improbable/Core/OSX/worker.bundle/Contents/Info.plist.meta
+++ b/workers/unity/Assets/Plugins/Improbable/Core/OSX/worker.bundle/Contents/Info.plist.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f6086041ce6e8476d8d8ab615f3cebed
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Assets/Plugins/Improbable/Core/OSX/worker.bundle/Contents/MacOS.meta
+++ b/workers/unity/Assets/Plugins/Improbable/Core/OSX/worker.bundle/Contents/MacOS.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bfe3b2bb837c84718840a2b42a416f18
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Assets/Plugins/Improbable/Core/OSX/worker.bundle/Contents/MacOS/worker.meta
+++ b/workers/unity/Assets/Plugins/Improbable/Core/OSX/worker.bundle/Contents/MacOS/worker.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4f20bdb9c4e7e41d0a3a8a9cadc253bc
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/manifest.json
+++ b/workers/unity/Packages/manifest.json
@@ -6,8 +6,8 @@
     "com.improbable.gdk.testutils": "file:com.improbable.gdk.testutils",
     "com.improbable.gdk.transformsynchronization": "file:com.improbable.gdk.transformsynchronization",
     "com.unity.burst": "0.2.4-preview.18",
-    "com.unity.entities": "0.0.12-preview.8",
-    "com.unity.incrementalcompiler": "0.0.42-preview.14",
+    "com.unity.entities": "0.0.12-preview.10",
+    "com.unity.incrementalcompiler": "0.0.42-preview.18",
     "com.unity.package-manager-ui": "1.9.9",
     "com.unity.modules.physics": "1.0.0",
     "com.unity.modules.ui": "1.0.0"


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Because the dylib didn't seem to load correctly for Mac.
Switched it to download the bundle instead.

#### Tests
ran it locally and the error that it can't download the worker library went away.

#### Documentation
no docs needed

#### Primary reviewers
@jamiebrynes7 