### PR TITLE
Correct ComponentType access tags

### DIFF
--- a/code_generator/GdkCodeGenerator/Templates/UnityComponentConversionGenerator.tt
+++ b/code_generator/GdkCodeGenerator/Templates/UnityComponentConversionGenerator.tt
@@ -618,13 +618,13 @@ for (var i = 0; i < commandDetailsList.Count; i++) {
         public class ComponentCleanup : ComponentCleanupHandler
         {
             public override ComponentType[] CleanUpComponentTypes => new ComponentType[] {
-                typeof(ComponentAdded<<#= componentDetails.TypeName #>>),
-                typeof(ComponentRemoved<<#= componentDetails.TypeName #>>),
+                ComponentType.ReadOnly<ComponentAdded<<#= componentDetails.TypeName #>>>(),
+                ComponentType.ReadOnly<ComponentRemoved<<#= componentDetails.TypeName #>>>(),
             };
 
             public override ComponentType[] EventComponentTypes => new ComponentType[] {
 <# foreach (var eventDetails in eventDetailsList) { #>
-                typeof(ReceivedEvents.<#= eventDetails.EventName #>),
+                ComponentType.ReadOnly<ReceivedEvents.<#= eventDetails.EventName #>>(),
 <# } #>
             };
 

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveBlittableSingularTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveBlittableSingularTranslation.cs
@@ -323,8 +323,8 @@ namespace Generated.Improbable.Gdk.Tests
         public class ComponentCleanup : ComponentCleanupHandler
         {
             public override ComponentType[] CleanUpComponentTypes => new ComponentType[] {
-                typeof(ComponentAdded<SpatialOSExhaustiveBlittableSingular>),
-                typeof(ComponentRemoved<SpatialOSExhaustiveBlittableSingular>),
+                ComponentType.ReadOnly<ComponentAdded<SpatialOSExhaustiveBlittableSingular>>(),
+                ComponentType.ReadOnly<ComponentRemoved<SpatialOSExhaustiveBlittableSingular>>(),
             };
 
             public override ComponentType[] EventComponentTypes => new ComponentType[] {

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKeyTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKeyTranslation.cs
@@ -359,8 +359,8 @@ namespace Generated.Improbable.Gdk.Tests
         public class ComponentCleanup : ComponentCleanupHandler
         {
             public override ComponentType[] CleanUpComponentTypes => new ComponentType[] {
-                typeof(ComponentAdded<SpatialOSExhaustiveMapKey>),
-                typeof(ComponentRemoved<SpatialOSExhaustiveMapKey>),
+                ComponentType.ReadOnly<ComponentAdded<SpatialOSExhaustiveMapKey>>(),
+                ComponentType.ReadOnly<ComponentRemoved<SpatialOSExhaustiveMapKey>>(),
             };
 
             public override ComponentType[] EventComponentTypes => new ComponentType[] {

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValueTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValueTranslation.cs
@@ -359,8 +359,8 @@ namespace Generated.Improbable.Gdk.Tests
         public class ComponentCleanup : ComponentCleanupHandler
         {
             public override ComponentType[] CleanUpComponentTypes => new ComponentType[] {
-                typeof(ComponentAdded<SpatialOSExhaustiveMapValue>),
-                typeof(ComponentRemoved<SpatialOSExhaustiveMapValue>),
+                ComponentType.ReadOnly<ComponentAdded<SpatialOSExhaustiveMapValue>>(),
+                ComponentType.ReadOnly<ComponentRemoved<SpatialOSExhaustiveMapValue>>(),
             };
 
             public override ComponentType[] EventComponentTypes => new ComponentType[] {

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptionalTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptionalTranslation.cs
@@ -359,8 +359,8 @@ namespace Generated.Improbable.Gdk.Tests
         public class ComponentCleanup : ComponentCleanupHandler
         {
             public override ComponentType[] CleanUpComponentTypes => new ComponentType[] {
-                typeof(ComponentAdded<SpatialOSExhaustiveOptional>),
-                typeof(ComponentRemoved<SpatialOSExhaustiveOptional>),
+                ComponentType.ReadOnly<ComponentAdded<SpatialOSExhaustiveOptional>>(),
+                ComponentType.ReadOnly<ComponentRemoved<SpatialOSExhaustiveOptional>>(),
             };
 
             public override ComponentType[] EventComponentTypes => new ComponentType[] {

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeatedTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeatedTranslation.cs
@@ -359,8 +359,8 @@ namespace Generated.Improbable.Gdk.Tests
         public class ComponentCleanup : ComponentCleanupHandler
         {
             public override ComponentType[] CleanUpComponentTypes => new ComponentType[] {
-                typeof(ComponentAdded<SpatialOSExhaustiveRepeated>),
-                typeof(ComponentRemoved<SpatialOSExhaustiveRepeated>),
+                ComponentType.ReadOnly<ComponentAdded<SpatialOSExhaustiveRepeated>>(),
+                ComponentType.ReadOnly<ComponentRemoved<SpatialOSExhaustiveRepeated>>(),
             };
 
             public override ComponentType[] EventComponentTypes => new ComponentType[] {

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingularTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingularTranslation.cs
@@ -329,8 +329,8 @@ namespace Generated.Improbable.Gdk.Tests
         public class ComponentCleanup : ComponentCleanupHandler
         {
             public override ComponentType[] CleanUpComponentTypes => new ComponentType[] {
-                typeof(ComponentAdded<SpatialOSExhaustiveSingular>),
-                typeof(ComponentRemoved<SpatialOSExhaustiveSingular>),
+                ComponentType.ReadOnly<ComponentAdded<SpatialOSExhaustiveSingular>>(),
+                ComponentType.ReadOnly<ComponentRemoved<SpatialOSExhaustiveSingular>>(),
             };
 
             public override ComponentType[] EventComponentTypes => new ComponentType[] {

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/NestedComponentTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/NestedComponentTranslation.cs
@@ -323,8 +323,8 @@ namespace Generated.Improbable.Gdk.Tests
         public class ComponentCleanup : ComponentCleanupHandler
         {
             public override ComponentType[] CleanUpComponentTypes => new ComponentType[] {
-                typeof(ComponentAdded<SpatialOSNestedComponent>),
-                typeof(ComponentRemoved<SpatialOSNestedComponent>),
+                ComponentType.ReadOnly<ComponentAdded<SpatialOSNestedComponent>>(),
+                ComponentType.ReadOnly<ComponentRemoved<SpatialOSNestedComponent>>(),
             };
 
             public override ComponentType[] EventComponentTypes => new ComponentType[] {

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/ConnectionTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/ConnectionTranslation.cs
@@ -386,12 +386,12 @@ namespace Generated.Improbable.Gdk.Tests.AlternateSchemaSyntax
         public class ComponentCleanup : ComponentCleanupHandler
         {
             public override ComponentType[] CleanUpComponentTypes => new ComponentType[] {
-                typeof(ComponentAdded<SpatialOSConnection>),
-                typeof(ComponentRemoved<SpatialOSConnection>),
+                ComponentType.ReadOnly<ComponentAdded<SpatialOSConnection>>(),
+                ComponentType.ReadOnly<ComponentRemoved<SpatialOSConnection>>(),
             };
 
             public override ComponentType[] EventComponentTypes => new ComponentType[] {
-                typeof(ReceivedEvents.MyEvent),
+                ComponentType.ReadOnly<ReceivedEvents.MyEvent>(),
             };
 
             public override ComponentType ComponentUpdateType => ComponentType.ReadOnly<SpatialOSConnection.ReceivedUpdates>();

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentTranslation.cs
@@ -762,13 +762,13 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
         public class ComponentCleanup : ComponentCleanupHandler
         {
             public override ComponentType[] CleanUpComponentTypes => new ComponentType[] {
-                typeof(ComponentAdded<SpatialOSBlittableComponent>),
-                typeof(ComponentRemoved<SpatialOSBlittableComponent>),
+                ComponentType.ReadOnly<ComponentAdded<SpatialOSBlittableComponent>>(),
+                ComponentType.ReadOnly<ComponentRemoved<SpatialOSBlittableComponent>>(),
             };
 
             public override ComponentType[] EventComponentTypes => new ComponentType[] {
-                typeof(ReceivedEvents.FirstEvent),
-                typeof(ReceivedEvents.SecondEvent),
+                ComponentType.ReadOnly<ReceivedEvents.FirstEvent>(),
+                ComponentType.ReadOnly<ReceivedEvents.SecondEvent>(),
             };
 
             public override ComponentType ComponentUpdateType => ComponentType.ReadOnly<SpatialOSBlittableComponent.ReceivedUpdates>();

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsTranslation.cs
@@ -323,8 +323,8 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
         public class ComponentCleanup : ComponentCleanupHandler
         {
             public override ComponentType[] CleanUpComponentTypes => new ComponentType[] {
-                typeof(ComponentAdded<SpatialOSComponentWithNoFields>),
-                typeof(ComponentRemoved<SpatialOSComponentWithNoFields>),
+                ComponentType.ReadOnly<ComponentAdded<SpatialOSComponentWithNoFields>>(),
+                ComponentType.ReadOnly<ComponentRemoved<SpatialOSComponentWithNoFields>>(),
             };
 
             public override ComponentType[] EventComponentTypes => new ComponentType[] {

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsTranslation.cs
@@ -481,8 +481,8 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
         public class ComponentCleanup : ComponentCleanupHandler
         {
             public override ComponentType[] CleanUpComponentTypes => new ComponentType[] {
-                typeof(ComponentAdded<SpatialOSComponentWithNoFieldsWithCommands>),
-                typeof(ComponentRemoved<SpatialOSComponentWithNoFieldsWithCommands>),
+                ComponentType.ReadOnly<ComponentAdded<SpatialOSComponentWithNoFieldsWithCommands>>(),
+                ComponentType.ReadOnly<ComponentRemoved<SpatialOSComponentWithNoFieldsWithCommands>>(),
             };
 
             public override ComponentType[] EventComponentTypes => new ComponentType[] {

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEventsTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEventsTranslation.cs
@@ -386,12 +386,12 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
         public class ComponentCleanup : ComponentCleanupHandler
         {
             public override ComponentType[] CleanUpComponentTypes => new ComponentType[] {
-                typeof(ComponentAdded<SpatialOSComponentWithNoFieldsWithEvents>),
-                typeof(ComponentRemoved<SpatialOSComponentWithNoFieldsWithEvents>),
+                ComponentType.ReadOnly<ComponentAdded<SpatialOSComponentWithNoFieldsWithEvents>>(),
+                ComponentType.ReadOnly<ComponentRemoved<SpatialOSComponentWithNoFieldsWithEvents>>(),
             };
 
             public override ComponentType[] EventComponentTypes => new ComponentType[] {
-                typeof(ReceivedEvents.Evt),
+                ComponentType.ReadOnly<ReceivedEvents.Evt>(),
             };
 
             public override ComponentType ComponentUpdateType => ComponentType.ReadOnly<SpatialOSComponentWithNoFieldsWithEvents.ReceivedUpdates>();

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentTranslation.cs
@@ -772,13 +772,13 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
         public class ComponentCleanup : ComponentCleanupHandler
         {
             public override ComponentType[] CleanUpComponentTypes => new ComponentType[] {
-                typeof(ComponentAdded<SpatialOSNonBlittableComponent>),
-                typeof(ComponentRemoved<SpatialOSNonBlittableComponent>),
+                ComponentType.ReadOnly<ComponentAdded<SpatialOSNonBlittableComponent>>(),
+                ComponentType.ReadOnly<ComponentRemoved<SpatialOSNonBlittableComponent>>(),
             };
 
             public override ComponentType[] EventComponentTypes => new ComponentType[] {
-                typeof(ReceivedEvents.FirstEvent),
-                typeof(ReceivedEvents.SecondEvent),
+                ComponentType.ReadOnly<ReceivedEvents.FirstEvent>(),
+                ComponentType.ReadOnly<ReceivedEvents.SecondEvent>(),
             };
 
             public override ComponentType ComponentUpdateType => ComponentType.ReadOnly<SpatialOSNonBlittableComponent.ReceivedUpdates>();

--- a/workers/unity/Assets/Playground/Scripts/Player/MoveLocalPlayerSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/Player/MoveLocalPlayerSystem.cs
@@ -1,6 +1,7 @@
 using Generated.Improbable.Transform;
 using Generated.Playground;
 using Improbable.Gdk.Core;
+using Unity.Collections;
 using Unity.Entities;
 using UnityEngine;
 
@@ -23,22 +24,22 @@ namespace Playground
             public float SpeedSmoothVelocity;
         }
 
-        public struct NewPlayerData
+        private struct NewPlayerData
         {
             public readonly int Length;
             public EntityArray Entity;
-            public ComponentDataArray<SpatialOSPlayerInput> PlayerInput;
-            public ComponentDataArray<Authoritative<SpatialOSTransform>> TransformAuthority;
+            [ReadOnly] public ComponentDataArray<SpatialOSPlayerInput> PlayerInput;
+            [ReadOnly] public ComponentDataArray<Authoritative<SpatialOSTransform>> TransformAuthority;
             public SubtractiveComponent<Speed> NoSpeed;
         }
 
-        public struct PlayerInputData
+        private struct PlayerInputData
         {
             public readonly int Length;
             public ComponentArray<Rigidbody> Rigidbody;
-            public ComponentDataArray<SpatialOSPlayerInput> PlayerInput;
-            public ComponentDataArray<Authoritative<SpatialOSTransform>> TransformAuthority;
             public ComponentDataArray<Speed> SpeedData;
+            [ReadOnly] public ComponentDataArray<SpatialOSPlayerInput> PlayerInput;
+            [ReadOnly] public ComponentDataArray<Authoritative<SpatialOSTransform>> TransformAuthority;
         }
 
         [Inject] private NewPlayerData newPlayerData;
@@ -69,9 +70,9 @@ namespace Playground
             for (var i = 0; i < playerInputData.Length; i++)
             {
                 var rigidBody = playerInputData.Rigidbody[i];
+                var playerInput = playerInputData.PlayerInput[i];
 
-                var input = new Vector2(playerInputData.PlayerInput[i].Horizontal,
-                    playerInputData.PlayerInput[i].Vertical);
+                var input = new Vector2(playerInput.Horizontal, playerInput.Vertical);
                 var inputDir = input.normalized;
 
                 if (inputDir != Vector2.zero)
@@ -82,8 +83,7 @@ namespace Playground
                         ref turnSmoothVelocity, TurnSmoothTime);
                 }
 
-                var running = playerInputData.PlayerInput[i].Running;
-                var targetSpeed = (running ? RunSpeed : WalkSpeed) * inputDir.magnitude;
+                var targetSpeed = (playerInput.Running ? RunSpeed : WalkSpeed) * inputDir.magnitude;
                 var speed = playerInputData.SpeedData[i];
                 var currentSpeed = speed.CurrentSpeed;
                 var speedSmoothVelocity = speed.SpeedSmoothVelocity;

--- a/workers/unity/Assets/Playground/Scripts/Player/ProcessLaunchCommandSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/Player/ProcessLaunchCommandSystem.cs
@@ -23,19 +23,19 @@ namespace Playground
         private struct LaunchCommandData
         {
             public readonly int Length;
-            [ReadOnly] public EntityArray Entity;
+            public EntityArray Entity;
             public ComponentDataArray<SpatialOSLauncher> Launcher;
-            [ReadOnly] public ComponentDataArray<Launcher.CommandRequests.LaunchEntity> Requests;
             public ComponentDataArray<Launchable.CommandSenders.LaunchMe> Senders;
+            [ReadOnly] public ComponentDataArray<Launcher.CommandRequests.LaunchEntity> Requests;
         }
 
         private struct LaunchableData
         {
             public readonly int Length;
             public ComponentDataArray<SpatialOSLaunchable> Launchable;
-            [ReadOnly] public ComponentDataArray<Launchable.CommandRequests.LaunchMe> Requests;
-            [ReadOnly] public ComponentArray<Rigidbody> Rigidbody;
+            public ComponentArray<Rigidbody> Rigidbody;
             public ComponentDataArray<Launcher.CommandSenders.IncreaseScore> Sender;
+            [ReadOnly] public ComponentDataArray<Launchable.CommandRequests.LaunchMe> Requests;
         }
 
         [Inject] private LaunchCommandData launchCommandData;

--- a/workers/unity/Assets/Playground/Scripts/Player/ProcessRechargeSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/Player/ProcessRechargeSystem.cs
@@ -1,5 +1,6 @@
 using Generated.Playground;
 using Improbable.Gdk.Core;
+using Unity.Collections;
 using Unity.Entities;
 using UnityEngine;
 
@@ -24,8 +25,8 @@ namespace Playground
         {
             public readonly int Length;
             public EntityArray Entity;
-            public ComponentDataArray<Recharging> Reloading;
             public ComponentDataArray<SpatialOSLauncher> Launcher;
+            [ReadOnly] public ComponentDataArray<Recharging> Reloading;
         }
 
         [Inject] private Data data;

--- a/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerCreation/HandleCreatePlayerRequestSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerCreation/HandleCreatePlayerRequestSystem.cs
@@ -14,8 +14,8 @@ namespace Improbable.Gdk.PlayerLifecycle
         {
             public readonly int Length;
             [ReadOnly] public ComponentDataArray<PlayerCreator.CommandRequests.CreatePlayer> CreatePlayerRequests;
-            [ReadOnly] public ComponentDataArray<PlayerCreator.CommandResponders.CreatePlayer> CreatePlayerResponders;
-            [ReadOnly] public ComponentDataArray<WorldCommands.CreateEntity.CommandSender> CreateEntitySender;
+            public ComponentDataArray<PlayerCreator.CommandResponders.CreatePlayer> CreatePlayerResponders;
+            public ComponentDataArray<WorldCommands.CreateEntity.CommandSender> CreateEntitySender;
         }
 
         [Inject] private CreatePlayerData createPlayerData;
@@ -25,7 +25,9 @@ namespace Improbable.Gdk.PlayerLifecycle
             for (var i = 0; i < createPlayerData.Length; i++)
             {
                 var requests = createPlayerData.CreatePlayerRequests[i].Requests;
-                var responders = createPlayerData.CreatePlayerResponders[i].ResponsesToSend;
+                var responder = createPlayerData.CreatePlayerResponders[i];
+
+                var createEntitySender = createPlayerData.CreateEntitySender[i];
 
                 foreach (var request in requests)
                 {
@@ -36,14 +38,17 @@ namespace Improbable.Gdk.PlayerLifecycle
 
                     var playerEntity = PlayerLifecycleConfig.CreatePlayerEntityTemplate(request.CallerAttributeSet,
                         request.Payload.Position);
-                    createPlayerData.CreateEntitySender[i].RequestsToSend.Add(new WorldCommands.CreateEntity.Request
+                    createEntitySender.RequestsToSend.Add(new WorldCommands.CreateEntity.Request
                     {
                         Entity = playerEntity
                     });
 
-                    responders.Add(
+                    responder.ResponsesToSend.Add(
                         PlayerCreator.CreatePlayer.Response.CreateResponse(request, new CreatePlayerResponseType()));
                 }
+
+                createPlayerData.CreatePlayerResponders[i] = responder;
+                createPlayerData.CreateEntitySender[i] = createEntitySender;
             }
         }
 

--- a/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerHeartbeat/HandlePlayerHeartbeatResponseSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerHeartbeat/HandlePlayerHeartbeatResponseSystem.cs
@@ -18,7 +18,7 @@ namespace Improbable.Gdk.PlayerLifecycle
             [ReadOnly] public ComponentDataArray<PlayerHeartbeatClient.CommandResponses.PlayerHeartbeat>
                 PlayerHeartbeatResponses;
 
-            [ReadOnly] public ComponentDataArray<WorldCommands.DeleteEntity.CommandSender> WorldCommandSenders;
+            public ComponentDataArray<WorldCommands.DeleteEntity.CommandSender> WorldCommandSenders;
             [ReadOnly] public ComponentDataArray<SpatialEntityId> SpatialEntityIds;
             [ReadOnly] public ComponentDataArray<AwaitingHeartbeatResponseTag> AwaitingHeartbeatResponses;
             public EntityArray Entities;
@@ -33,6 +33,7 @@ namespace Improbable.Gdk.PlayerLifecycle
                 var entityId = data.SpatialEntityIds[i].EntityId;
                 var responses = data.PlayerHeartbeatResponses[i].Responses;
                 var entity = data.Entities[i];
+                var entityDeleteSender = data.WorldCommandSenders[i];
 
                 foreach (var response in responses)
                 {
@@ -59,10 +60,11 @@ namespace Improbable.Gdk.PlayerLifecycle
                             PlayerLifecycleConfig.MaxNumFailedPlayerHeartbeats)
                         {
                             Debug.LogFormat(Messages.DeletingPlayer, entityId);
-                            data.WorldCommandSenders[i].RequestsToSend.Add(new WorldCommands.DeleteEntity.Request
+                            entityDeleteSender.RequestsToSend.Add(new WorldCommands.DeleteEntity.Request
                             {
                                 EntityId = entityId,
                             });
+                            data.WorldCommandSenders[i] = entityDeleteSender;
                         }
                     }
                     else

--- a/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/InterpolateTransformSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/InterpolateTransformSystem.cs
@@ -1,5 +1,6 @@
 using Generated.Improbable.Transform;
 using Improbable.Gdk.Core;
+using Unity.Collections;
 using Unity.Entities;
 using UnityEngine;
 
@@ -17,12 +18,12 @@ namespace Improbable.Gdk.TransformSynchronization
 
         private Vector3 origin;
 
-        public struct TransformData
+        private struct TransformData
         {
             public readonly int Length;
             public ComponentArray<BufferedTransform> BufferedTransform;
             public ComponentArray<Rigidbody> Rigidbody;
-            public ComponentDataArray<NotAuthoritative<SpatialOSTransform>> transformAuthority;
+            [ReadOnly] public ComponentDataArray<NotAuthoritative<SpatialOSTransform>> transformAuthority;
         }
 
         [Inject] private TransformData transformData;

--- a/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/LocalTransformSyncSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/LocalTransformSyncSystem.cs
@@ -1,6 +1,7 @@
 using Generated.Improbable;
 using Generated.Improbable.Transform;
 using Improbable.Gdk.Core;
+using Unity.Collections;
 using Unity.Entities;
 using UnityEngine;
 using Quaternion = Generated.Improbable.Transform.Quaternion;
@@ -10,15 +11,15 @@ namespace Improbable.Gdk.TransformSynchronization
     [UpdateInGroup(typeof(TransformSynchronizationGroup))]
     public class LocalTransformSyncSystem : ComponentSystem
     {
-        public struct TransformData
+        private struct TransformData
         {
             public readonly int Length;
             public ComponentDataArray<SpatialOSTransform> Transform;
             public ComponentDataArray<SpatialOSPosition> Position;
-            public ComponentArray<Rigidbody> GameObjectRigidBody;
+            [ReadOnly] public ComponentArray<Rigidbody> GameObjectRigidBody;
 
-            public ComponentDataArray<Authoritative<SpatialOSTransform>> TransformAuthority;
-            public ComponentDataArray<Authoritative<SpatialOSPosition>> PositionAuthority;
+            [ReadOnly] public ComponentDataArray<Authoritative<SpatialOSTransform>> TransformAuthority;
+            [ReadOnly] public ComponentDataArray<Authoritative<SpatialOSPosition>> PositionAuthority;
         }
 
         [Inject] private TransformData transformData;
@@ -88,7 +89,7 @@ namespace Improbable.Gdk.TransformSynchronization
 
                 var newPosition = new SpatialOSPosition
                 {
-                    Coords = new global::Generated.Improbable.Coordinates
+                    Coords = new Coordinates
                     {
                         X = newTransform.Location.X,
                         Y = newTransform.Location.Y,


### PR DESCRIPTION
This updates all systems to have the correct [ReadOnly] tags and readonly component types where needed.

Some slight reordering was also done for readability