### PR TITLE
UTY-375: Always have a ReceivedUpdates on ComponentAdded

### DIFF
--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveBlittableSingularTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveBlittableSingularTranslation.cs
@@ -48,6 +48,38 @@ namespace Generated.Improbable.Gdk.Tests
                 entityManager.AddComponentData(entity, data);
                 entityManager.AddComponentData(entity, new NotAuthoritative<SpatialOSExhaustiveBlittableSingular>());
 
+                var update = new SpatialOSExhaustiveBlittableSingular.Update 
+                {
+                    Field1 = data.Field1,
+                    Field2 = data.Field2,
+                    Field4 = data.Field4,
+                    Field5 = data.Field5,
+                    Field6 = data.Field6,
+                    Field8 = data.Field8,
+                    Field9 = data.Field9,
+                    Field10 = data.Field10,
+                    Field11 = data.Field11,
+                    Field12 = data.Field12,
+                    Field13 = data.Field13,
+                    Field14 = data.Field14,
+                    Field15 = data.Field15,
+                    Field16 = data.Field16,
+                    Field17 = data.Field17,
+                };
+                
+                var updates = new List<SpatialOSExhaustiveBlittableSingular.Update>
+                {
+                    update
+                };
+                
+                var updatesComponent = new SpatialOSExhaustiveBlittableSingular.ReceivedUpdates
+                {
+                    handle = ReferenceTypeProviders.UpdatesProvider.Allocate(World)
+                };
+                
+                ReferenceTypeProviders.UpdatesProvider.Set(updatesComponent.handle, updates);
+                entityManager.AddComponentData(entity, updatesComponent);
+                
                 if (entityManager.HasComponent<ComponentRemoved<SpatialOSExhaustiveBlittableSingular>>(entity))
                 {
                     entityManager.RemoveComponent<ComponentRemoved<SpatialOSExhaustiveBlittableSingular>>(entity);

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKeyTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKeyTranslation.cs
@@ -65,6 +65,40 @@ namespace Generated.Improbable.Gdk.Tests
                 entityManager.AddComponentData(entity, data);
                 entityManager.AddComponentData(entity, new NotAuthoritative<SpatialOSExhaustiveMapKey>());
 
+                var update = new SpatialOSExhaustiveMapKey.Update 
+                {
+                    Field1 = data.Field1,
+                    Field2 = data.Field2,
+                    Field3 = data.Field3,
+                    Field4 = data.Field4,
+                    Field5 = data.Field5,
+                    Field6 = data.Field6,
+                    Field7 = data.Field7,
+                    Field8 = data.Field8,
+                    Field9 = data.Field9,
+                    Field10 = data.Field10,
+                    Field11 = data.Field11,
+                    Field12 = data.Field12,
+                    Field13 = data.Field13,
+                    Field14 = data.Field14,
+                    Field15 = data.Field15,
+                    Field16 = data.Field16,
+                    Field17 = data.Field17,
+                };
+                
+                var updates = new List<SpatialOSExhaustiveMapKey.Update>
+                {
+                    update
+                };
+                
+                var updatesComponent = new SpatialOSExhaustiveMapKey.ReceivedUpdates
+                {
+                    handle = ReferenceTypeProviders.UpdatesProvider.Allocate(World)
+                };
+                
+                ReferenceTypeProviders.UpdatesProvider.Set(updatesComponent.handle, updates);
+                entityManager.AddComponentData(entity, updatesComponent);
+                
                 if (entityManager.HasComponent<ComponentRemoved<SpatialOSExhaustiveMapKey>>(entity))
                 {
                     entityManager.RemoveComponent<ComponentRemoved<SpatialOSExhaustiveMapKey>>(entity);

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValueTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValueTranslation.cs
@@ -65,6 +65,40 @@ namespace Generated.Improbable.Gdk.Tests
                 entityManager.AddComponentData(entity, data);
                 entityManager.AddComponentData(entity, new NotAuthoritative<SpatialOSExhaustiveMapValue>());
 
+                var update = new SpatialOSExhaustiveMapValue.Update 
+                {
+                    Field1 = data.Field1,
+                    Field2 = data.Field2,
+                    Field3 = data.Field3,
+                    Field4 = data.Field4,
+                    Field5 = data.Field5,
+                    Field6 = data.Field6,
+                    Field7 = data.Field7,
+                    Field8 = data.Field8,
+                    Field9 = data.Field9,
+                    Field10 = data.Field10,
+                    Field11 = data.Field11,
+                    Field12 = data.Field12,
+                    Field13 = data.Field13,
+                    Field14 = data.Field14,
+                    Field15 = data.Field15,
+                    Field16 = data.Field16,
+                    Field17 = data.Field17,
+                };
+                
+                var updates = new List<SpatialOSExhaustiveMapValue.Update>
+                {
+                    update
+                };
+                
+                var updatesComponent = new SpatialOSExhaustiveMapValue.ReceivedUpdates
+                {
+                    handle = ReferenceTypeProviders.UpdatesProvider.Allocate(World)
+                };
+                
+                ReferenceTypeProviders.UpdatesProvider.Set(updatesComponent.handle, updates);
+                entityManager.AddComponentData(entity, updatesComponent);
+                
                 if (entityManager.HasComponent<ComponentRemoved<SpatialOSExhaustiveMapValue>>(entity))
                 {
                     entityManager.RemoveComponent<ComponentRemoved<SpatialOSExhaustiveMapValue>>(entity);

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptionalTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptionalTranslation.cs
@@ -65,6 +65,40 @@ namespace Generated.Improbable.Gdk.Tests
                 entityManager.AddComponentData(entity, data);
                 entityManager.AddComponentData(entity, new NotAuthoritative<SpatialOSExhaustiveOptional>());
 
+                var update = new SpatialOSExhaustiveOptional.Update 
+                {
+                    Field1 = data.Field1,
+                    Field2 = data.Field2,
+                    Field3 = data.Field3,
+                    Field4 = data.Field4,
+                    Field5 = data.Field5,
+                    Field6 = data.Field6,
+                    Field7 = data.Field7,
+                    Field8 = data.Field8,
+                    Field9 = data.Field9,
+                    Field10 = data.Field10,
+                    Field11 = data.Field11,
+                    Field12 = data.Field12,
+                    Field13 = data.Field13,
+                    Field14 = data.Field14,
+                    Field15 = data.Field15,
+                    Field16 = data.Field16,
+                    Field17 = data.Field17,
+                };
+                
+                var updates = new List<SpatialOSExhaustiveOptional.Update>
+                {
+                    update
+                };
+                
+                var updatesComponent = new SpatialOSExhaustiveOptional.ReceivedUpdates
+                {
+                    handle = ReferenceTypeProviders.UpdatesProvider.Allocate(World)
+                };
+                
+                ReferenceTypeProviders.UpdatesProvider.Set(updatesComponent.handle, updates);
+                entityManager.AddComponentData(entity, updatesComponent);
+                
                 if (entityManager.HasComponent<ComponentRemoved<SpatialOSExhaustiveOptional>>(entity))
                 {
                     entityManager.RemoveComponent<ComponentRemoved<SpatialOSExhaustiveOptional>>(entity);

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeatedTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeatedTranslation.cs
@@ -65,6 +65,40 @@ namespace Generated.Improbable.Gdk.Tests
                 entityManager.AddComponentData(entity, data);
                 entityManager.AddComponentData(entity, new NotAuthoritative<SpatialOSExhaustiveRepeated>());
 
+                var update = new SpatialOSExhaustiveRepeated.Update 
+                {
+                    Field1 = data.Field1,
+                    Field2 = data.Field2,
+                    Field3 = data.Field3,
+                    Field4 = data.Field4,
+                    Field5 = data.Field5,
+                    Field6 = data.Field6,
+                    Field7 = data.Field7,
+                    Field8 = data.Field8,
+                    Field9 = data.Field9,
+                    Field10 = data.Field10,
+                    Field11 = data.Field11,
+                    Field12 = data.Field12,
+                    Field13 = data.Field13,
+                    Field14 = data.Field14,
+                    Field15 = data.Field15,
+                    Field16 = data.Field16,
+                    Field17 = data.Field17,
+                };
+                
+                var updates = new List<SpatialOSExhaustiveRepeated.Update>
+                {
+                    update
+                };
+                
+                var updatesComponent = new SpatialOSExhaustiveRepeated.ReceivedUpdates
+                {
+                    handle = ReferenceTypeProviders.UpdatesProvider.Allocate(World)
+                };
+                
+                ReferenceTypeProviders.UpdatesProvider.Set(updatesComponent.handle, updates);
+                entityManager.AddComponentData(entity, updatesComponent);
+                
                 if (entityManager.HasComponent<ComponentRemoved<SpatialOSExhaustiveRepeated>>(entity))
                 {
                     entityManager.RemoveComponent<ComponentRemoved<SpatialOSExhaustiveRepeated>>(entity);

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingularTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingularTranslation.cs
@@ -50,6 +50,40 @@ namespace Generated.Improbable.Gdk.Tests
                 entityManager.AddComponentData(entity, data);
                 entityManager.AddComponentData(entity, new NotAuthoritative<SpatialOSExhaustiveSingular>());
 
+                var update = new SpatialOSExhaustiveSingular.Update 
+                {
+                    Field1 = data.Field1,
+                    Field2 = data.Field2,
+                    Field3 = data.Field3,
+                    Field4 = data.Field4,
+                    Field5 = data.Field5,
+                    Field6 = data.Field6,
+                    Field7 = data.Field7,
+                    Field8 = data.Field8,
+                    Field9 = data.Field9,
+                    Field10 = data.Field10,
+                    Field11 = data.Field11,
+                    Field12 = data.Field12,
+                    Field13 = data.Field13,
+                    Field14 = data.Field14,
+                    Field15 = data.Field15,
+                    Field16 = data.Field16,
+                    Field17 = data.Field17,
+                };
+                
+                var updates = new List<SpatialOSExhaustiveSingular.Update>
+                {
+                    update
+                };
+                
+                var updatesComponent = new SpatialOSExhaustiveSingular.ReceivedUpdates
+                {
+                    handle = ReferenceTypeProviders.UpdatesProvider.Allocate(World)
+                };
+                
+                ReferenceTypeProviders.UpdatesProvider.Set(updatesComponent.handle, updates);
+                entityManager.AddComponentData(entity, updatesComponent);
+                
                 if (entityManager.HasComponent<ComponentRemoved<SpatialOSExhaustiveSingular>>(entity))
                 {
                     entityManager.RemoveComponent<ComponentRemoved<SpatialOSExhaustiveSingular>>(entity);

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/NestedComponentTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/NestedComponentTranslation.cs
@@ -48,6 +48,24 @@ namespace Generated.Improbable.Gdk.Tests
                 entityManager.AddComponentData(entity, data);
                 entityManager.AddComponentData(entity, new NotAuthoritative<SpatialOSNestedComponent>());
 
+                var update = new SpatialOSNestedComponent.Update 
+                {
+                    NestedType = data.NestedType,
+                };
+                
+                var updates = new List<SpatialOSNestedComponent.Update>
+                {
+                    update
+                };
+                
+                var updatesComponent = new SpatialOSNestedComponent.ReceivedUpdates
+                {
+                    handle = ReferenceTypeProviders.UpdatesProvider.Allocate(World)
+                };
+                
+                ReferenceTypeProviders.UpdatesProvider.Set(updatesComponent.handle, updates);
+                entityManager.AddComponentData(entity, updatesComponent);
+                
                 if (entityManager.HasComponent<ComponentRemoved<SpatialOSNestedComponent>>(entity))
                 {
                     entityManager.RemoveComponent<ComponentRemoved<SpatialOSNestedComponent>>(entity);

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/ConnectionTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/ConnectionTranslation.cs
@@ -49,6 +49,23 @@ namespace Generated.Improbable.Gdk.Tests.AlternateSchemaSyntax
                 entityManager.AddComponentData(entity, data);
                 entityManager.AddComponentData(entity, new NotAuthoritative<SpatialOSConnection>());
 
+                var update = new SpatialOSConnection.Update 
+                {
+                };
+                
+                var updates = new List<SpatialOSConnection.Update>
+                {
+                    update
+                };
+                
+                var updatesComponent = new SpatialOSConnection.ReceivedUpdates
+                {
+                    handle = ReferenceTypeProviders.UpdatesProvider.Allocate(World)
+                };
+                
+                ReferenceTypeProviders.UpdatesProvider.Set(updatesComponent.handle, updates);
+                entityManager.AddComponentData(entity, updatesComponent);
+                
                 if (entityManager.HasComponent<ComponentRemoved<SpatialOSConnection>>(entity))
                 {
                     entityManager.RemoveComponent<ComponentRemoved<SpatialOSConnection>>(entity);

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentTranslation.cs
@@ -54,6 +54,28 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
                 entityManager.AddComponentData(entity, data);
                 entityManager.AddComponentData(entity, new NotAuthoritative<SpatialOSBlittableComponent>());
 
+                var update = new SpatialOSBlittableComponent.Update 
+                {
+                    BoolField = data.BoolField,
+                    IntField = data.IntField,
+                    LongField = data.LongField,
+                    FloatField = data.FloatField,
+                    DoubleField = data.DoubleField,
+                };
+                
+                var updates = new List<SpatialOSBlittableComponent.Update>
+                {
+                    update
+                };
+                
+                var updatesComponent = new SpatialOSBlittableComponent.ReceivedUpdates
+                {
+                    handle = ReferenceTypeProviders.UpdatesProvider.Allocate(World)
+                };
+                
+                ReferenceTypeProviders.UpdatesProvider.Set(updatesComponent.handle, updates);
+                entityManager.AddComponentData(entity, updatesComponent);
+                
                 if (entityManager.HasComponent<ComponentRemoved<SpatialOSBlittableComponent>>(entity))
                 {
                     entityManager.RemoveComponent<ComponentRemoved<SpatialOSBlittableComponent>>(entity);

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsTranslation.cs
@@ -48,6 +48,23 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 entityManager.AddComponentData(entity, data);
                 entityManager.AddComponentData(entity, new NotAuthoritative<SpatialOSComponentWithNoFields>());
 
+                var update = new SpatialOSComponentWithNoFields.Update 
+                {
+                };
+                
+                var updates = new List<SpatialOSComponentWithNoFields.Update>
+                {
+                    update
+                };
+                
+                var updatesComponent = new SpatialOSComponentWithNoFields.ReceivedUpdates
+                {
+                    handle = ReferenceTypeProviders.UpdatesProvider.Allocate(World)
+                };
+                
+                ReferenceTypeProviders.UpdatesProvider.Set(updatesComponent.handle, updates);
+                entityManager.AddComponentData(entity, updatesComponent);
+                
                 if (entityManager.HasComponent<ComponentRemoved<SpatialOSComponentWithNoFields>>(entity))
                 {
                     entityManager.RemoveComponent<ComponentRemoved<SpatialOSComponentWithNoFields>>(entity);

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsTranslation.cs
@@ -50,6 +50,23 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 entityManager.AddComponentData(entity, data);
                 entityManager.AddComponentData(entity, new NotAuthoritative<SpatialOSComponentWithNoFieldsWithCommands>());
 
+                var update = new SpatialOSComponentWithNoFieldsWithCommands.Update 
+                {
+                };
+                
+                var updates = new List<SpatialOSComponentWithNoFieldsWithCommands.Update>
+                {
+                    update
+                };
+                
+                var updatesComponent = new SpatialOSComponentWithNoFieldsWithCommands.ReceivedUpdates
+                {
+                    handle = ReferenceTypeProviders.UpdatesProvider.Allocate(World)
+                };
+                
+                ReferenceTypeProviders.UpdatesProvider.Set(updatesComponent.handle, updates);
+                entityManager.AddComponentData(entity, updatesComponent);
+                
                 if (entityManager.HasComponent<ComponentRemoved<SpatialOSComponentWithNoFieldsWithCommands>>(entity))
                 {
                     entityManager.RemoveComponent<ComponentRemoved<SpatialOSComponentWithNoFieldsWithCommands>>(entity);

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEventsTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEventsTranslation.cs
@@ -49,6 +49,23 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 entityManager.AddComponentData(entity, data);
                 entityManager.AddComponentData(entity, new NotAuthoritative<SpatialOSComponentWithNoFieldsWithEvents>());
 
+                var update = new SpatialOSComponentWithNoFieldsWithEvents.Update 
+                {
+                };
+                
+                var updates = new List<SpatialOSComponentWithNoFieldsWithEvents.Update>
+                {
+                    update
+                };
+                
+                var updatesComponent = new SpatialOSComponentWithNoFieldsWithEvents.ReceivedUpdates
+                {
+                    handle = ReferenceTypeProviders.UpdatesProvider.Allocate(World)
+                };
+                
+                ReferenceTypeProviders.UpdatesProvider.Set(updatesComponent.handle, updates);
+                entityManager.AddComponentData(entity, updatesComponent);
+                
                 if (entityManager.HasComponent<ComponentRemoved<SpatialOSComponentWithNoFieldsWithEvents>>(entity))
                 {
                     entityManager.RemoveComponent<ComponentRemoved<SpatialOSComponentWithNoFieldsWithEvents>>(entity);

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentTranslation.cs
@@ -58,6 +58,32 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                 entityManager.AddComponentData(entity, data);
                 entityManager.AddComponentData(entity, new NotAuthoritative<SpatialOSNonBlittableComponent>());
 
+                var update = new SpatialOSNonBlittableComponent.Update 
+                {
+                    BoolField = data.BoolField,
+                    IntField = data.IntField,
+                    LongField = data.LongField,
+                    FloatField = data.FloatField,
+                    DoubleField = data.DoubleField,
+                    StringField = data.StringField,
+                    OptionalField = data.OptionalField,
+                    ListField = data.ListField,
+                    MapField = data.MapField,
+                };
+                
+                var updates = new List<SpatialOSNonBlittableComponent.Update>
+                {
+                    update
+                };
+                
+                var updatesComponent = new SpatialOSNonBlittableComponent.ReceivedUpdates
+                {
+                    handle = ReferenceTypeProviders.UpdatesProvider.Allocate(World)
+                };
+                
+                ReferenceTypeProviders.UpdatesProvider.Set(updatesComponent.handle, updates);
+                entityManager.AddComponentData(entity, updatesComponent);
+                
                 if (entityManager.HasComponent<ComponentRemoved<SpatialOSNonBlittableComponent>>(entity))
                 {
                     entityManager.RemoveComponent<ComponentRemoved<SpatialOSNonBlittableComponent>>(entity);

--- a/workers/unity/Packages/com.improbable.gdk.core/CoreSystemHelper.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/CoreSystemHelper.cs
@@ -14,12 +14,8 @@ namespace Improbable.Gdk.TransformSynchronization
             world.GetOrCreateManager<WorldCommandsCleanSystem>();
             world.GetOrCreateManager<WorldCommandsSendSystem>();
             world.GetOrCreateManager<CommandRequestTrackerSystem>();
-<<<<<<< HEAD
             world.GetOrCreateManager<GameObjectDispatcherSystem>();
             world.GetOrCreateManager<MonoBehaviourActivationManagerInitializationSystem>();
-            world.GetOrCreateManager<ReactiveComponentAdditionSystem>();
-=======
->>>>>>> 6ed01da8... Revert "Add ComponentUpdated when a component is added."
         }
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.core/CoreSystemHelper.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/CoreSystemHelper.cs
@@ -14,9 +14,12 @@ namespace Improbable.Gdk.TransformSynchronization
             world.GetOrCreateManager<WorldCommandsCleanSystem>();
             world.GetOrCreateManager<WorldCommandsSendSystem>();
             world.GetOrCreateManager<CommandRequestTrackerSystem>();
-
+<<<<<<< HEAD
             world.GetOrCreateManager<GameObjectDispatcherSystem>();
             world.GetOrCreateManager<MonoBehaviourActivationManagerInitializationSystem>();
+            world.GetOrCreateManager<ReactiveComponentAdditionSystem>();
+=======
+>>>>>>> 6ed01da8... Revert "Add ComponentUpdated when a component is added."
         }
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityComponentConversionGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityComponentConversionGenerator.tt
@@ -69,6 +69,26 @@ namespace <#= qualifiedNamespace #>
                 entityManager.AddComponentData(entity, data);
                 entityManager.AddComponentData(entity, new NotAuthoritative<<#= componentDetails.TypeName #>>());
 
+                var update = new <#= componentDetails.TypeName #>.Update 
+                {
+<# foreach (var fieldDetails in fieldDetailsList) { #>
+                    <#= fieldDetails.PascalCaseName #> = data.<#= fieldDetails.PascalCaseName #>,
+<# } #>
+                };
+                
+                var updates = new List<<#= componentDetails.TypeName #>.Update>
+                {
+                    update
+                };
+                
+                var updatesComponent = new <#= componentDetails.TypeName #>.ReceivedUpdates
+                {
+                    handle = ReferenceTypeProviders.UpdatesProvider.Allocate(World)
+                };
+                
+                ReferenceTypeProviders.UpdatesProvider.Set(updatesComponent.handle, updates);
+                entityManager.AddComponentData(entity, updatesComponent);
+                
                 if (entityManager.HasComponent<ComponentRemoved<<#= componentDetails.TypeName #>>>(entity))
                 {
                     entityManager.RemoveComponent<ComponentRemoved<<#= componentDetails.TypeName #>>>(entity);


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Currently you only receive ReceivedUpdates when you are authoritative over a component when its added. This isn't intuitive and instead we should always be added.

Best to read in commit order to avoid a lot of generated code.
Previous PR that implemented this on the previous core: #142

#### Tests
Checked that an update actually got added when not authoritative.

#### Documentation
Will be added.

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.