### PR TITLE
UTY-1050: Minor Optimisation - Deserialise Data Directly Into Backings

### DIFF
--- a/code_generator/GdkCodeGenerator/Templates/UnityComponentConversionGenerator.tt
+++ b/code_generator/GdkCodeGenerator/Templates/UnityComponentConversionGenerator.tt
@@ -65,7 +65,6 @@ namespace <#= qualifiedNamespace #>
                 }
 
                 var data = global::<#= qualifiedNamespace #>.<#= componentDetails.TypeName #>.Serialization.Deserialize(op.Data.SchemaData.Value.GetFields(), World);
-                data.DirtyBit = false;
                 entityManager.AddComponentData(entity, data);
                 entityManager.AddComponentData(entity, new NotAuthoritative<<#= componentDetails.TypeName #>>());
 

--- a/code_generator/GdkCodeGenerator/Templates/UnityComponentDataGenerator.tt
+++ b/code_generator/GdkCodeGenerator/Templates/UnityComponentDataGenerator.tt
@@ -193,7 +193,7 @@ namespace <#= qualifiedNamespace #>
 <# if (fieldDetails.SchemaTypeInfo.SingularTypeInfo.HasValue) { #>
 <# var singularTypeInfo = fieldDetails.SchemaTypeInfo.SingularTypeInfo.Value; #>
 <# if (singularTypeInfo.IsEnum) { #>
-                component.<#= fieldDetails.PascalCaseName #> = (<#= fieldDetails.Type #>) obj.GetEnum(<#= fieldDetails.FieldNumber #>);
+                component.<#= fieldDetails.CamelCaseName #> = (<#= fieldDetails.Type #>) obj.GetEnum(<#= fieldDetails.FieldNumber #>);
 <# } else if (singularTypeInfo.IsPrimitive) { #>
 <# if (fieldDetails.IsBlittable) { #>
                 component.<#= fieldDetails.CamelCaseName #> = obj.<#= singularTypeInfo.SerializationFunctions.Deserialize #>(<#= fieldDetails.FieldNumber #>);
@@ -233,17 +233,25 @@ namespace <#= qualifiedNamespace #>
 <# if (optionTypeInfo.IsEnum) { #>
                 if (obj.GetEnumCount(<#= fieldDetails.FieldNumber #>) == 1)
                 {
-                    component.<#= fieldDetails.PascalCaseName #> = (<#= optionTypeInfo.Type #>) obj.GetEnum(<#= fieldDetails.FieldNumber #>);
+                    component.<#= fieldDetails.CamelCaseName #> = (<#= optionTypeInfo.Type #>) obj.GetEnum(<#= fieldDetails.FieldNumber #>);
                 }
 <# } else if (optionTypeInfo.IsPrimitive) { #>
                 if (obj.<#= optionTypeInfo.SerializationFunctions.GetCount #>(<#= fieldDetails.FieldNumber #>) == 1)
                 {
-                    component.<#= fieldDetails.PascalCaseName #> = obj.<#= optionTypeInfo.SerializationFunctions.Deserialize #>(<#= fieldDetails.FieldNumber #>);
+<# if (fieldDetails.IsBlittable) { #>
+                    component.<#= fieldDetails.CamelCaseName #> = obj.<#= optionTypeInfo.SerializationFunctions.Deserialize #>(<#= fieldDetails.FieldNumber #>);
+<# } else { #>
+                    <#= qualifiedNamespace #>.<#= componentDetails.ComponentName #>.ReferenceTypeProviders.<#= fieldDetails.PascalCaseName #>Provider.Set(component.<#= fieldDetails.CamelCaseName#>Handle, obj.<#= optionTypeInfo.SerializationFunctions.Deserialize #>(<#= fieldDetails.FieldNumber #>));                
+<# } #>
                 }
 <# } else { #>
                 if (obj.GetObjectCount(<#= fieldDetails.FieldNumber #>) == 1)
                 {
-                    component.<#= fieldDetails.PascalCaseName #> = <#= optionTypeInfo.SerializationFunctions.Deserialize #>(obj.GetObject(<#= fieldDetails.FieldNumber #>));
+<# if (fieldDetails.IsBlittable) { #>
+                    component.<#= fieldDetails.CamelCaseName #> = <#= optionTypeInfo.SerializationFunctions.Deserialize #>(obj.GetObject(<#= fieldDetails.FieldNumber #>));
+<# } else { #>
+                    <#= qualifiedNamespace #>.<#= componentDetails.ComponentName #>.ReferenceTypeProviders.<#= fieldDetails.PascalCaseName #>Provider.Set(component.<#= fieldDetails.CamelCaseName#>Handle, <#= optionTypeInfo.SerializationFunctions.Deserialize #>(obj.GetObject(<#= fieldDetails.FieldNumber #>)));                
+<# } #>
                 }
 <# } #>
 <# } else { #>
@@ -354,21 +362,29 @@ namespace <#= qualifiedNamespace #>
                 {
                     var value = (<#= optionTypeInfo.Type #>) obj.GetEnum(<#= fieldDetails.FieldNumber #>);
                     update.<#= fieldDetails.PascalCaseName #> = new Option<<#= fieldDetails.Type #>>(value);
-                    component.<#= fieldDetails.PascalCaseName #> = value;
+                    component.<#= fieldDetails.CamelCaseName #> = value;
                 }
 <# } else if (optionTypeInfo.IsPrimitive) { #>
                 if (obj.<#= optionTypeInfo.SerializationFunctions.GetCount #>(<#= fieldDetails.FieldNumber #>) == 1)
                 {
                     var value = obj.<#= optionTypeInfo.SerializationFunctions.Deserialize #>(<#= fieldDetails.FieldNumber #>);
                     update.<#= fieldDetails.PascalCaseName #> = new Option<<#= fieldDetails.Type #>>(value);
-                    component.<#= fieldDetails.PascalCaseName #> = value;
+<# if (fieldDetails.IsBlittable) { #>
+                    component.<#= fieldDetails.CamelCaseName #> = value;
+<# } else { #>
+                    <#= qualifiedNamespace #>.<#= componentDetails.ComponentName #>.ReferenceTypeProviders.<#= fieldDetails.PascalCaseName #>Provider.Set(component.<#= fieldDetails.CamelCaseName#>Handle, value);                
+<# } #>
                 }
 <# } else { #>
                 if (obj.GetObjectCount(<#= fieldDetails.FieldNumber #>) == 1)
                 {
                     var value = <#= optionTypeInfo.SerializationFunctions.Deserialize #>(obj.GetObject(<#= fieldDetails.FieldNumber #>));
-                    update.<#= fieldDetails.PascalCaseName #> = value;
-                    component.<#= fieldDetails.PascalCaseName #> = new Option<<#= fieldDetails.Type #>>(value);
+                    update.<#= fieldDetails.PascalCaseName #> = new Option<<#= fieldDetails.Type #>>(value);
+<# if (fieldDetails.IsBlittable) { #>
+                    component.<#= fieldDetails.CamelCaseName #> = value;
+<# } else { #>
+                    <#= qualifiedNamespace #>.<#= componentDetails.ComponentName #>.ReferenceTypeProviders.<#= fieldDetails.PascalCaseName #>Provider.Set(component.<#= fieldDetails.CamelCaseName#>Handle, value);                
+<# } #>
                 }
 <# } #>
 <# } else { #>

--- a/code_generator/GdkCodeGenerator/Templates/UnityComponentDataGenerator.tt
+++ b/code_generator/GdkCodeGenerator/Templates/UnityComponentDataGenerator.tt
@@ -202,7 +202,8 @@ namespace <#= qualifiedNamespace #>
 <# } #>
 <# } else if (fieldDetails.SchemaTypeInfo.ListTypeInfo.HasValue) { #>
 <# var listTypeInfo = fieldDetails.SchemaTypeInfo.ListTypeInfo.Value; #>
-                var <#= fieldDetails.CamelCaseName #> = component.<#= fieldDetails.PascalCaseName #> = new global::System.Collections.Generic.List<<#= listTypeInfo.Type #>>();
+                var <#= fieldDetails.CamelCaseName #> = new global::System.Collections.Generic.List<<#= listTypeInfo.Type #>>();
+                <#= qualifiedNamespace #>.<#= componentDetails.ComponentName #>.ReferenceTypeProviders.<#= fieldDetails.PascalCaseName #>Provider.Set(component.<#= fieldDetails.CamelCaseName #>Handle, <#= fieldDetails.CamelCaseName #>);
 <# if (listTypeInfo.IsEnum) { #>
                 for (var i = 0; i < obj.GetEnumCount(<#= fieldDetails.FieldNumber #>); i++)
                 {
@@ -241,7 +242,8 @@ namespace <#= qualifiedNamespace #>
 <# } else { #>
 <# var mapTypeInfo = fieldDetails.SchemaTypeInfo.MapTypeInfo; #>
                 {
-                    var <#= fieldDetails.CamelCaseName #> = component.<#= fieldDetails.PascalCaseName #> = new global::System.Collections.Generic.Dictionary<<#= mapTypeInfo.Key.Type #>,<#= mapTypeInfo.Value.Type #>>();
+                    var <#= fieldDetails.CamelCaseName #> = new global::System.Collections.Generic.Dictionary<<#= mapTypeInfo.Key.Type #>,<#= mapTypeInfo.Value.Type #>>();
+                    <#= qualifiedNamespace #>.<#= componentDetails.ComponentName #>.ReferenceTypeProviders.<#= fieldDetails.PascalCaseName #>Provider.Set(component.<#= fieldDetails.CamelCaseName #>Handle, <#= fieldDetails.CamelCaseName #>);
                     var mapSize = obj.GetObjectCount(<#= fieldDetails.FieldNumber #>);
                     for (var i = 0; i < mapSize; i++)
                     {

--- a/code_generator/GdkCodeGenerator/Templates/UnityComponentDataGenerator.tt
+++ b/code_generator/GdkCodeGenerator/Templates/UnityComponentDataGenerator.tt
@@ -19,7 +19,7 @@ namespace <#= qualifiedNamespace #>
         public BlittableBool DirtyBit { get; set; }
 <# foreach(var fieldDetails in fieldDetailsList) { #>
 <# if (fieldDetails.IsBlittable) { #>
-        private <#= fieldDetails.Type #> <#= fieldDetails.CamelCaseName #>;
+        internal <#= fieldDetails.Type #> <#= fieldDetails.CamelCaseName #>;
 
         public <#= fieldDetails.Type #> <#= fieldDetails.PascalCaseName #>
         {

--- a/code_generator/GdkCodeGenerator/Templates/UnityComponentDataGenerator.tt
+++ b/code_generator/GdkCodeGenerator/Templates/UnityComponentDataGenerator.tt
@@ -190,15 +190,22 @@ namespace <#= qualifiedNamespace #>
 <# if (!fieldDetails.IsBlittable) { #>
                 component.<#= fieldDetails.CamelCaseName#>Handle = <#= qualifiedNamespace #>.<#= componentDetails.ComponentName #>.ReferenceTypeProviders.<#= fieldDetails.PascalCaseName #>Provider.Allocate(world);
 <# } #>
-
 <# if (fieldDetails.SchemaTypeInfo.SingularTypeInfo.HasValue) { #>
 <# var singularTypeInfo = fieldDetails.SchemaTypeInfo.SingularTypeInfo.Value; #>
 <# if (singularTypeInfo.IsEnum) { #>
                 component.<#= fieldDetails.PascalCaseName #> = (<#= fieldDetails.Type #>) obj.GetEnum(<#= fieldDetails.FieldNumber #>);
 <# } else if (singularTypeInfo.IsPrimitive) { #>
-                component.<#= fieldDetails.PascalCaseName #> = obj.<#= singularTypeInfo.SerializationFunctions.Deserialize #>(<#= fieldDetails.FieldNumber #>);
+<# if (fieldDetails.IsBlittable) { #>
+                component.<#= fieldDetails.CamelCaseName #> = obj.<#= singularTypeInfo.SerializationFunctions.Deserialize #>(<#= fieldDetails.FieldNumber #>);
 <# } else { #>
-                component.<#= fieldDetails.PascalCaseName #> = <#= singularTypeInfo.SerializationFunctions.Deserialize #>(obj.GetObject(<#= fieldDetails.FieldNumber #>));
+                <#= qualifiedNamespace #>.<#= componentDetails.ComponentName #>.ReferenceTypeProviders.<#= fieldDetails.PascalCaseName #>Provider.Set(component.<#= fieldDetails.CamelCaseName#>Handle, obj.<#= singularTypeInfo.SerializationFunctions.Deserialize #>(<#= fieldDetails.FieldNumber #>));                
+<# } #>
+<# } else { #>
+<# if (fieldDetails.IsBlittable) { #>
+                component.<#= fieldDetails.CamelCaseName #> = <#= singularTypeInfo.SerializationFunctions.Deserialize #>(obj.GetObject(<#= fieldDetails.FieldNumber #>));
+<# } else { #>
+                <#= qualifiedNamespace #>.<#= componentDetails.ComponentName #>.ReferenceTypeProviders.<#= fieldDetails.PascalCaseName #>Provider.Set(component.<#= fieldDetails.CamelCaseName#>Handle, <#= singularTypeInfo.SerializationFunctions.Deserialize #>(obj.GetObject(<#= fieldDetails.FieldNumber #>)));                
+<# } #>
 <# } #>
 <# } else if (fieldDetails.SchemaTypeInfo.ListTypeInfo.HasValue) { #>
 <# var listTypeInfo = fieldDetails.SchemaTypeInfo.ListTypeInfo.Value; #>
@@ -266,6 +273,7 @@ namespace <#= qualifiedNamespace #>
                     }
                 }
 <# } #>
+
 <# } #>
                 return component;
             }
@@ -286,7 +294,11 @@ namespace <#= qualifiedNamespace #>
                     var value = <#= singularTypeInfo.SerializationFunctions.Deserialize #>(obj.GetObject(<#= fieldDetails.FieldNumber #>));
 <# } #>
                     update.<#= fieldDetails.PascalCaseName #> = new Option<<#= fieldDetails.Type #>>(value);
-                    component.<#= fieldDetails.PascalCaseName #> = value;
+<# if (fieldDetails.IsBlittable) { #>
+                    component.<#= fieldDetails.CamelCaseName #> = value;
+<# } else { #>
+                    <#= qualifiedNamespace #>.<#= componentDetails.ComponentName #>.ReferenceTypeProviders.<#= fieldDetails.PascalCaseName #>Provider.Set(component.<#= fieldDetails.CamelCaseName#>Handle, value);                
+<# } #>
                 }
 <# } else if (fieldDetails.SchemaTypeInfo.ListTypeInfo.HasValue) { #>
 <# var listTypeInfo = fieldDetails.SchemaTypeInfo.ListTypeInfo.Value; #>

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveBlittableSingular.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveBlittableSingular.cs
@@ -12,7 +12,7 @@ namespace Generated.Improbable.Gdk.Tests
         public uint ComponentId => 197720;
 
         public BlittableBool DirtyBit { get; set; }
-        private BlittableBool field1;
+        internal BlittableBool field1;
 
         public BlittableBool Field1
         {
@@ -23,7 +23,7 @@ namespace Generated.Improbable.Gdk.Tests
                 field1 = value;
             }
         }
-        private float field2;
+        internal float field2;
 
         public float Field2
         {
@@ -34,7 +34,7 @@ namespace Generated.Improbable.Gdk.Tests
                 field2 = value;
             }
         }
-        private int field4;
+        internal int field4;
 
         public int Field4
         {
@@ -45,7 +45,7 @@ namespace Generated.Improbable.Gdk.Tests
                 field4 = value;
             }
         }
-        private long field5;
+        internal long field5;
 
         public long Field5
         {
@@ -56,7 +56,7 @@ namespace Generated.Improbable.Gdk.Tests
                 field5 = value;
             }
         }
-        private double field6;
+        internal double field6;
 
         public double Field6
         {
@@ -67,7 +67,7 @@ namespace Generated.Improbable.Gdk.Tests
                 field6 = value;
             }
         }
-        private uint field8;
+        internal uint field8;
 
         public uint Field8
         {
@@ -78,7 +78,7 @@ namespace Generated.Improbable.Gdk.Tests
                 field8 = value;
             }
         }
-        private ulong field9;
+        internal ulong field9;
 
         public ulong Field9
         {
@@ -89,7 +89,7 @@ namespace Generated.Improbable.Gdk.Tests
                 field9 = value;
             }
         }
-        private int field10;
+        internal int field10;
 
         public int Field10
         {
@@ -100,7 +100,7 @@ namespace Generated.Improbable.Gdk.Tests
                 field10 = value;
             }
         }
-        private long field11;
+        internal long field11;
 
         public long Field11
         {
@@ -111,7 +111,7 @@ namespace Generated.Improbable.Gdk.Tests
                 field11 = value;
             }
         }
-        private uint field12;
+        internal uint field12;
 
         public uint Field12
         {
@@ -122,7 +122,7 @@ namespace Generated.Improbable.Gdk.Tests
                 field12 = value;
             }
         }
-        private ulong field13;
+        internal ulong field13;
 
         public ulong Field13
         {
@@ -133,7 +133,7 @@ namespace Generated.Improbable.Gdk.Tests
                 field13 = value;
             }
         }
-        private int field14;
+        internal int field14;
 
         public int Field14
         {
@@ -144,7 +144,7 @@ namespace Generated.Improbable.Gdk.Tests
                 field14 = value;
             }
         }
-        private long field15;
+        internal long field15;
 
         public long Field15
         {
@@ -155,7 +155,7 @@ namespace Generated.Improbable.Gdk.Tests
                 field15 = value;
             }
         }
-        private global::Improbable.Worker.EntityId field16;
+        internal global::Improbable.Worker.EntityId field16;
 
         public global::Improbable.Worker.EntityId Field16
         {
@@ -166,7 +166,7 @@ namespace Generated.Improbable.Gdk.Tests
                 field16 = value;
             }
         }
-        private global::Generated.Improbable.Gdk.Tests.SomeType field17;
+        internal global::Generated.Improbable.Gdk.Tests.SomeType field17;
 
         public global::Generated.Improbable.Gdk.Tests.SomeType Field17
         {

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveBlittableSingular.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveBlittableSingular.cs
@@ -244,36 +244,36 @@ namespace Generated.Improbable.Gdk.Tests
             {
                 var component = new SpatialOSExhaustiveBlittableSingular();
 
+                component.field1 = obj.GetBool(1);
 
-                component.Field1 = obj.GetBool(1);
+                component.field2 = obj.GetFloat(2);
 
-                component.Field2 = obj.GetFloat(2);
+                component.field4 = obj.GetInt32(4);
 
-                component.Field4 = obj.GetInt32(4);
+                component.field5 = obj.GetInt64(5);
 
-                component.Field5 = obj.GetInt64(5);
+                component.field6 = obj.GetDouble(6);
 
-                component.Field6 = obj.GetDouble(6);
+                component.field8 = obj.GetUint32(8);
 
-                component.Field8 = obj.GetUint32(8);
+                component.field9 = obj.GetUint64(9);
 
-                component.Field9 = obj.GetUint64(9);
+                component.field10 = obj.GetSint32(10);
 
-                component.Field10 = obj.GetSint32(10);
+                component.field11 = obj.GetSint64(11);
 
-                component.Field11 = obj.GetSint64(11);
+                component.field12 = obj.GetFixed32(12);
 
-                component.Field12 = obj.GetFixed32(12);
+                component.field13 = obj.GetFixed64(13);
 
-                component.Field13 = obj.GetFixed64(13);
+                component.field14 = obj.GetSfixed32(14);
 
-                component.Field14 = obj.GetSfixed32(14);
+                component.field15 = obj.GetSfixed64(15);
 
-                component.Field15 = obj.GetSfixed64(15);
+                component.field16 = obj.GetEntityId(16);
 
-                component.Field16 = obj.GetEntityId(16);
+                component.field17 = global::Generated.Improbable.Gdk.Tests.SomeType.Serialization.Deserialize(obj.GetObject(17));
 
-                component.Field17 = global::Generated.Improbable.Gdk.Tests.SomeType.Serialization.Deserialize(obj.GetObject(17));
                 return component;
             }
 
@@ -284,91 +284,91 @@ namespace Generated.Improbable.Gdk.Tests
                 {
                     var value = obj.GetBool(1);
                     update.Field1 = new Option<BlittableBool>(value);
-                    component.Field1 = value;
+                    component.field1 = value;
                 }
                 if (obj.GetFloatCount(2) == 1)
                 {
                     var value = obj.GetFloat(2);
                     update.Field2 = new Option<float>(value);
-                    component.Field2 = value;
+                    component.field2 = value;
                 }
                 if (obj.GetInt32Count(4) == 1)
                 {
                     var value = obj.GetInt32(4);
                     update.Field4 = new Option<int>(value);
-                    component.Field4 = value;
+                    component.field4 = value;
                 }
                 if (obj.GetInt64Count(5) == 1)
                 {
                     var value = obj.GetInt64(5);
                     update.Field5 = new Option<long>(value);
-                    component.Field5 = value;
+                    component.field5 = value;
                 }
                 if (obj.GetDoubleCount(6) == 1)
                 {
                     var value = obj.GetDouble(6);
                     update.Field6 = new Option<double>(value);
-                    component.Field6 = value;
+                    component.field6 = value;
                 }
                 if (obj.GetUint32Count(8) == 1)
                 {
                     var value = obj.GetUint32(8);
                     update.Field8 = new Option<uint>(value);
-                    component.Field8 = value;
+                    component.field8 = value;
                 }
                 if (obj.GetUint64Count(9) == 1)
                 {
                     var value = obj.GetUint64(9);
                     update.Field9 = new Option<ulong>(value);
-                    component.Field9 = value;
+                    component.field9 = value;
                 }
                 if (obj.GetSint32Count(10) == 1)
                 {
                     var value = obj.GetSint32(10);
                     update.Field10 = new Option<int>(value);
-                    component.Field10 = value;
+                    component.field10 = value;
                 }
                 if (obj.GetSint64Count(11) == 1)
                 {
                     var value = obj.GetSint64(11);
                     update.Field11 = new Option<long>(value);
-                    component.Field11 = value;
+                    component.field11 = value;
                 }
                 if (obj.GetFixed32Count(12) == 1)
                 {
                     var value = obj.GetFixed32(12);
                     update.Field12 = new Option<uint>(value);
-                    component.Field12 = value;
+                    component.field12 = value;
                 }
                 if (obj.GetFixed64Count(13) == 1)
                 {
                     var value = obj.GetFixed64(13);
                     update.Field13 = new Option<ulong>(value);
-                    component.Field13 = value;
+                    component.field13 = value;
                 }
                 if (obj.GetSfixed32Count(14) == 1)
                 {
                     var value = obj.GetSfixed32(14);
                     update.Field14 = new Option<int>(value);
-                    component.Field14 = value;
+                    component.field14 = value;
                 }
                 if (obj.GetSfixed64Count(15) == 1)
                 {
                     var value = obj.GetSfixed64(15);
                     update.Field15 = new Option<long>(value);
-                    component.Field15 = value;
+                    component.field15 = value;
                 }
                 if (obj.GetEntityIdCount(16) == 1)
                 {
                     var value = obj.GetEntityId(16);
                     update.Field16 = new Option<global::Improbable.Worker.EntityId>(value);
-                    component.Field16 = value;
+                    component.field16 = value;
                 }
                 if (obj.GetObjectCount(17) == 1)
                 {
                     var value = global::Generated.Improbable.Gdk.Tests.SomeType.Serialization.Deserialize(obj.GetObject(17));
                     update.Field17 = new Option<global::Generated.Improbable.Gdk.Tests.SomeType>(value);
-                    component.Field17 = value;
+                    component.field17 = value;
                 }
                 return update;
             }

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveBlittableSingularTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveBlittableSingularTranslation.cs
@@ -44,7 +44,6 @@ namespace Generated.Improbable.Gdk.Tests
                 }
 
                 var data = global::Generated.Improbable.Gdk.Tests.SpatialOSExhaustiveBlittableSingular.Serialization.Deserialize(op.Data.SchemaData.Value.GetFields(), World);
-                data.DirtyBit = false;
                 entityManager.AddComponentData(entity, data);
                 entityManager.AddComponentData(entity, new NotAuthoritative<SpatialOSExhaustiveBlittableSingular>());
 

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKey.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKey.cs
@@ -460,7 +460,6 @@ namespace Generated.Improbable.Gdk.Tests
                 var component = new SpatialOSExhaustiveMapKey();
 
                 component.field1Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field1Provider.Allocate(world);
-
                 {
                     var field1 = new global::System.Collections.Generic.Dictionary<BlittableBool,string>();
                     Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field1Provider.Set(component.field1Handle, field1);
@@ -473,8 +472,8 @@ namespace Generated.Improbable.Gdk.Tests
                         field1.Add(key, value);
                     }
                 }
-                component.field2Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field2Provider.Allocate(world);
 
+                component.field2Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field2Provider.Allocate(world);
                 {
                     var field2 = new global::System.Collections.Generic.Dictionary<float,string>();
                     Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field2Provider.Set(component.field2Handle, field2);
@@ -487,8 +486,8 @@ namespace Generated.Improbable.Gdk.Tests
                         field2.Add(key, value);
                     }
                 }
-                component.field3Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field3Provider.Allocate(world);
 
+                component.field3Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field3Provider.Allocate(world);
                 {
                     var field3 = new global::System.Collections.Generic.Dictionary<byte[],string>();
                     Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field3Provider.Set(component.field3Handle, field3);
@@ -501,8 +500,8 @@ namespace Generated.Improbable.Gdk.Tests
                         field3.Add(key, value);
                     }
                 }
-                component.field4Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field4Provider.Allocate(world);
 
+                component.field4Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field4Provider.Allocate(world);
                 {
                     var field4 = new global::System.Collections.Generic.Dictionary<int,string>();
                     Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field4Provider.Set(component.field4Handle, field4);
@@ -515,8 +514,8 @@ namespace Generated.Improbable.Gdk.Tests
                         field4.Add(key, value);
                     }
                 }
-                component.field5Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field5Provider.Allocate(world);
 
+                component.field5Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field5Provider.Allocate(world);
                 {
                     var field5 = new global::System.Collections.Generic.Dictionary<long,string>();
                     Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field5Provider.Set(component.field5Handle, field5);
@@ -529,8 +528,8 @@ namespace Generated.Improbable.Gdk.Tests
                         field5.Add(key, value);
                     }
                 }
-                component.field6Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field6Provider.Allocate(world);
 
+                component.field6Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field6Provider.Allocate(world);
                 {
                     var field6 = new global::System.Collections.Generic.Dictionary<double,string>();
                     Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field6Provider.Set(component.field6Handle, field6);
@@ -543,8 +542,8 @@ namespace Generated.Improbable.Gdk.Tests
                         field6.Add(key, value);
                     }
                 }
-                component.field7Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field7Provider.Allocate(world);
 
+                component.field7Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field7Provider.Allocate(world);
                 {
                     var field7 = new global::System.Collections.Generic.Dictionary<string,string>();
                     Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field7Provider.Set(component.field7Handle, field7);
@@ -557,8 +556,8 @@ namespace Generated.Improbable.Gdk.Tests
                         field7.Add(key, value);
                     }
                 }
-                component.field8Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field8Provider.Allocate(world);
 
+                component.field8Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field8Provider.Allocate(world);
                 {
                     var field8 = new global::System.Collections.Generic.Dictionary<uint,string>();
                     Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field8Provider.Set(component.field8Handle, field8);
@@ -571,8 +570,8 @@ namespace Generated.Improbable.Gdk.Tests
                         field8.Add(key, value);
                     }
                 }
-                component.field9Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field9Provider.Allocate(world);
 
+                component.field9Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field9Provider.Allocate(world);
                 {
                     var field9 = new global::System.Collections.Generic.Dictionary<ulong,string>();
                     Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field9Provider.Set(component.field9Handle, field9);
@@ -585,8 +584,8 @@ namespace Generated.Improbable.Gdk.Tests
                         field9.Add(key, value);
                     }
                 }
-                component.field10Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field10Provider.Allocate(world);
 
+                component.field10Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field10Provider.Allocate(world);
                 {
                     var field10 = new global::System.Collections.Generic.Dictionary<int,string>();
                     Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field10Provider.Set(component.field10Handle, field10);
@@ -599,8 +598,8 @@ namespace Generated.Improbable.Gdk.Tests
                         field10.Add(key, value);
                     }
                 }
-                component.field11Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field11Provider.Allocate(world);
 
+                component.field11Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field11Provider.Allocate(world);
                 {
                     var field11 = new global::System.Collections.Generic.Dictionary<long,string>();
                     Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field11Provider.Set(component.field11Handle, field11);
@@ -613,8 +612,8 @@ namespace Generated.Improbable.Gdk.Tests
                         field11.Add(key, value);
                     }
                 }
-                component.field12Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field12Provider.Allocate(world);
 
+                component.field12Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field12Provider.Allocate(world);
                 {
                     var field12 = new global::System.Collections.Generic.Dictionary<uint,string>();
                     Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field12Provider.Set(component.field12Handle, field12);
@@ -627,8 +626,8 @@ namespace Generated.Improbable.Gdk.Tests
                         field12.Add(key, value);
                     }
                 }
-                component.field13Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field13Provider.Allocate(world);
 
+                component.field13Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field13Provider.Allocate(world);
                 {
                     var field13 = new global::System.Collections.Generic.Dictionary<ulong,string>();
                     Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field13Provider.Set(component.field13Handle, field13);
@@ -641,8 +640,8 @@ namespace Generated.Improbable.Gdk.Tests
                         field13.Add(key, value);
                     }
                 }
-                component.field14Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field14Provider.Allocate(world);
 
+                component.field14Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field14Provider.Allocate(world);
                 {
                     var field14 = new global::System.Collections.Generic.Dictionary<int,string>();
                     Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field14Provider.Set(component.field14Handle, field14);
@@ -655,8 +654,8 @@ namespace Generated.Improbable.Gdk.Tests
                         field14.Add(key, value);
                     }
                 }
-                component.field15Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field15Provider.Allocate(world);
 
+                component.field15Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field15Provider.Allocate(world);
                 {
                     var field15 = new global::System.Collections.Generic.Dictionary<long,string>();
                     Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field15Provider.Set(component.field15Handle, field15);
@@ -669,8 +668,8 @@ namespace Generated.Improbable.Gdk.Tests
                         field15.Add(key, value);
                     }
                 }
-                component.field16Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field16Provider.Allocate(world);
 
+                component.field16Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field16Provider.Allocate(world);
                 {
                     var field16 = new global::System.Collections.Generic.Dictionary<global::Improbable.Worker.EntityId,string>();
                     Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field16Provider.Set(component.field16Handle, field16);
@@ -683,8 +682,8 @@ namespace Generated.Improbable.Gdk.Tests
                         field16.Add(key, value);
                     }
                 }
-                component.field17Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field17Provider.Allocate(world);
 
+                component.field17Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field17Provider.Allocate(world);
                 {
                     var field17 = new global::System.Collections.Generic.Dictionary<global::Generated.Improbable.Gdk.Tests.SomeType,string>();
                     Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field17Provider.Set(component.field17Handle, field17);
@@ -697,6 +696,7 @@ namespace Generated.Improbable.Gdk.Tests
                         field17.Add(key, value);
                     }
                 }
+
                 return component;
             }
 

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKey.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKey.cs
@@ -462,7 +462,8 @@ namespace Generated.Improbable.Gdk.Tests
                 component.field1Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field1Provider.Allocate(world);
 
                 {
-                    var field1 = component.Field1 = new global::System.Collections.Generic.Dictionary<BlittableBool,string>();
+                    var field1 = new global::System.Collections.Generic.Dictionary<BlittableBool,string>();
+                    Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field1Provider.Set(component.field1Handle, field1);
                     var mapSize = obj.GetObjectCount(1);
                     for (var i = 0; i < mapSize; i++)
                     {
@@ -475,7 +476,8 @@ namespace Generated.Improbable.Gdk.Tests
                 component.field2Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field2Provider.Allocate(world);
 
                 {
-                    var field2 = component.Field2 = new global::System.Collections.Generic.Dictionary<float,string>();
+                    var field2 = new global::System.Collections.Generic.Dictionary<float,string>();
+                    Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field2Provider.Set(component.field2Handle, field2);
                     var mapSize = obj.GetObjectCount(2);
                     for (var i = 0; i < mapSize; i++)
                     {
@@ -488,7 +490,8 @@ namespace Generated.Improbable.Gdk.Tests
                 component.field3Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field3Provider.Allocate(world);
 
                 {
-                    var field3 = component.Field3 = new global::System.Collections.Generic.Dictionary<byte[],string>();
+                    var field3 = new global::System.Collections.Generic.Dictionary<byte[],string>();
+                    Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field3Provider.Set(component.field3Handle, field3);
                     var mapSize = obj.GetObjectCount(3);
                     for (var i = 0; i < mapSize; i++)
                     {
@@ -501,7 +504,8 @@ namespace Generated.Improbable.Gdk.Tests
                 component.field4Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field4Provider.Allocate(world);
 
                 {
-                    var field4 = component.Field4 = new global::System.Collections.Generic.Dictionary<int,string>();
+                    var field4 = new global::System.Collections.Generic.Dictionary<int,string>();
+                    Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field4Provider.Set(component.field4Handle, field4);
                     var mapSize = obj.GetObjectCount(4);
                     for (var i = 0; i < mapSize; i++)
                     {
@@ -514,7 +518,8 @@ namespace Generated.Improbable.Gdk.Tests
                 component.field5Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field5Provider.Allocate(world);
 
                 {
-                    var field5 = component.Field5 = new global::System.Collections.Generic.Dictionary<long,string>();
+                    var field5 = new global::System.Collections.Generic.Dictionary<long,string>();
+                    Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field5Provider.Set(component.field5Handle, field5);
                     var mapSize = obj.GetObjectCount(5);
                     for (var i = 0; i < mapSize; i++)
                     {
@@ -527,7 +532,8 @@ namespace Generated.Improbable.Gdk.Tests
                 component.field6Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field6Provider.Allocate(world);
 
                 {
-                    var field6 = component.Field6 = new global::System.Collections.Generic.Dictionary<double,string>();
+                    var field6 = new global::System.Collections.Generic.Dictionary<double,string>();
+                    Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field6Provider.Set(component.field6Handle, field6);
                     var mapSize = obj.GetObjectCount(6);
                     for (var i = 0; i < mapSize; i++)
                     {
@@ -540,7 +546,8 @@ namespace Generated.Improbable.Gdk.Tests
                 component.field7Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field7Provider.Allocate(world);
 
                 {
-                    var field7 = component.Field7 = new global::System.Collections.Generic.Dictionary<string,string>();
+                    var field7 = new global::System.Collections.Generic.Dictionary<string,string>();
+                    Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field7Provider.Set(component.field7Handle, field7);
                     var mapSize = obj.GetObjectCount(7);
                     for (var i = 0; i < mapSize; i++)
                     {
@@ -553,7 +560,8 @@ namespace Generated.Improbable.Gdk.Tests
                 component.field8Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field8Provider.Allocate(world);
 
                 {
-                    var field8 = component.Field8 = new global::System.Collections.Generic.Dictionary<uint,string>();
+                    var field8 = new global::System.Collections.Generic.Dictionary<uint,string>();
+                    Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field8Provider.Set(component.field8Handle, field8);
                     var mapSize = obj.GetObjectCount(8);
                     for (var i = 0; i < mapSize; i++)
                     {
@@ -566,7 +574,8 @@ namespace Generated.Improbable.Gdk.Tests
                 component.field9Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field9Provider.Allocate(world);
 
                 {
-                    var field9 = component.Field9 = new global::System.Collections.Generic.Dictionary<ulong,string>();
+                    var field9 = new global::System.Collections.Generic.Dictionary<ulong,string>();
+                    Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field9Provider.Set(component.field9Handle, field9);
                     var mapSize = obj.GetObjectCount(9);
                     for (var i = 0; i < mapSize; i++)
                     {
@@ -579,7 +588,8 @@ namespace Generated.Improbable.Gdk.Tests
                 component.field10Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field10Provider.Allocate(world);
 
                 {
-                    var field10 = component.Field10 = new global::System.Collections.Generic.Dictionary<int,string>();
+                    var field10 = new global::System.Collections.Generic.Dictionary<int,string>();
+                    Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field10Provider.Set(component.field10Handle, field10);
                     var mapSize = obj.GetObjectCount(10);
                     for (var i = 0; i < mapSize; i++)
                     {
@@ -592,7 +602,8 @@ namespace Generated.Improbable.Gdk.Tests
                 component.field11Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field11Provider.Allocate(world);
 
                 {
-                    var field11 = component.Field11 = new global::System.Collections.Generic.Dictionary<long,string>();
+                    var field11 = new global::System.Collections.Generic.Dictionary<long,string>();
+                    Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field11Provider.Set(component.field11Handle, field11);
                     var mapSize = obj.GetObjectCount(11);
                     for (var i = 0; i < mapSize; i++)
                     {
@@ -605,7 +616,8 @@ namespace Generated.Improbable.Gdk.Tests
                 component.field12Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field12Provider.Allocate(world);
 
                 {
-                    var field12 = component.Field12 = new global::System.Collections.Generic.Dictionary<uint,string>();
+                    var field12 = new global::System.Collections.Generic.Dictionary<uint,string>();
+                    Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field12Provider.Set(component.field12Handle, field12);
                     var mapSize = obj.GetObjectCount(12);
                     for (var i = 0; i < mapSize; i++)
                     {
@@ -618,7 +630,8 @@ namespace Generated.Improbable.Gdk.Tests
                 component.field13Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field13Provider.Allocate(world);
 
                 {
-                    var field13 = component.Field13 = new global::System.Collections.Generic.Dictionary<ulong,string>();
+                    var field13 = new global::System.Collections.Generic.Dictionary<ulong,string>();
+                    Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field13Provider.Set(component.field13Handle, field13);
                     var mapSize = obj.GetObjectCount(13);
                     for (var i = 0; i < mapSize; i++)
                     {
@@ -631,7 +644,8 @@ namespace Generated.Improbable.Gdk.Tests
                 component.field14Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field14Provider.Allocate(world);
 
                 {
-                    var field14 = component.Field14 = new global::System.Collections.Generic.Dictionary<int,string>();
+                    var field14 = new global::System.Collections.Generic.Dictionary<int,string>();
+                    Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field14Provider.Set(component.field14Handle, field14);
                     var mapSize = obj.GetObjectCount(14);
                     for (var i = 0; i < mapSize; i++)
                     {
@@ -644,7 +658,8 @@ namespace Generated.Improbable.Gdk.Tests
                 component.field15Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field15Provider.Allocate(world);
 
                 {
-                    var field15 = component.Field15 = new global::System.Collections.Generic.Dictionary<long,string>();
+                    var field15 = new global::System.Collections.Generic.Dictionary<long,string>();
+                    Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field15Provider.Set(component.field15Handle, field15);
                     var mapSize = obj.GetObjectCount(15);
                     for (var i = 0; i < mapSize; i++)
                     {
@@ -657,7 +672,8 @@ namespace Generated.Improbable.Gdk.Tests
                 component.field16Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field16Provider.Allocate(world);
 
                 {
-                    var field16 = component.Field16 = new global::System.Collections.Generic.Dictionary<global::Improbable.Worker.EntityId,string>();
+                    var field16 = new global::System.Collections.Generic.Dictionary<global::Improbable.Worker.EntityId,string>();
+                    Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field16Provider.Set(component.field16Handle, field16);
                     var mapSize = obj.GetObjectCount(16);
                     for (var i = 0; i < mapSize; i++)
                     {
@@ -670,7 +686,8 @@ namespace Generated.Improbable.Gdk.Tests
                 component.field17Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field17Provider.Allocate(world);
 
                 {
-                    var field17 = component.Field17 = new global::System.Collections.Generic.Dictionary<global::Generated.Improbable.Gdk.Tests.SomeType,string>();
+                    var field17 = new global::System.Collections.Generic.Dictionary<global::Generated.Improbable.Gdk.Tests.SomeType,string>();
+                    Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReferenceTypeProviders.Field17Provider.Set(component.field17Handle, field17);
                     var mapSize = obj.GetObjectCount(17);
                     for (var i = 0; i < mapSize; i++)
                     {

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKeyTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKeyTranslation.cs
@@ -61,7 +61,6 @@ namespace Generated.Improbable.Gdk.Tests
                 }
 
                 var data = global::Generated.Improbable.Gdk.Tests.SpatialOSExhaustiveMapKey.Serialization.Deserialize(op.Data.SchemaData.Value.GetFields(), World);
-                data.DirtyBit = false;
                 entityManager.AddComponentData(entity, data);
                 entityManager.AddComponentData(entity, new NotAuthoritative<SpatialOSExhaustiveMapKey>());
 

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValue.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValue.cs
@@ -460,7 +460,6 @@ namespace Generated.Improbable.Gdk.Tests
                 var component = new SpatialOSExhaustiveMapValue();
 
                 component.field1Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field1Provider.Allocate(world);
-
                 {
                     var field1 = new global::System.Collections.Generic.Dictionary<string,BlittableBool>();
                     Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field1Provider.Set(component.field1Handle, field1);
@@ -473,8 +472,8 @@ namespace Generated.Improbable.Gdk.Tests
                         field1.Add(key, value);
                     }
                 }
-                component.field2Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field2Provider.Allocate(world);
 
+                component.field2Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field2Provider.Allocate(world);
                 {
                     var field2 = new global::System.Collections.Generic.Dictionary<string,float>();
                     Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field2Provider.Set(component.field2Handle, field2);
@@ -487,8 +486,8 @@ namespace Generated.Improbable.Gdk.Tests
                         field2.Add(key, value);
                     }
                 }
-                component.field3Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field3Provider.Allocate(world);
 
+                component.field3Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field3Provider.Allocate(world);
                 {
                     var field3 = new global::System.Collections.Generic.Dictionary<string,byte[]>();
                     Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field3Provider.Set(component.field3Handle, field3);
@@ -501,8 +500,8 @@ namespace Generated.Improbable.Gdk.Tests
                         field3.Add(key, value);
                     }
                 }
-                component.field4Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field4Provider.Allocate(world);
 
+                component.field4Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field4Provider.Allocate(world);
                 {
                     var field4 = new global::System.Collections.Generic.Dictionary<string,int>();
                     Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field4Provider.Set(component.field4Handle, field4);
@@ -515,8 +514,8 @@ namespace Generated.Improbable.Gdk.Tests
                         field4.Add(key, value);
                     }
                 }
-                component.field5Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field5Provider.Allocate(world);
 
+                component.field5Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field5Provider.Allocate(world);
                 {
                     var field5 = new global::System.Collections.Generic.Dictionary<string,long>();
                     Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field5Provider.Set(component.field5Handle, field5);
@@ -529,8 +528,8 @@ namespace Generated.Improbable.Gdk.Tests
                         field5.Add(key, value);
                     }
                 }
-                component.field6Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field6Provider.Allocate(world);
 
+                component.field6Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field6Provider.Allocate(world);
                 {
                     var field6 = new global::System.Collections.Generic.Dictionary<string,double>();
                     Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field6Provider.Set(component.field6Handle, field6);
@@ -543,8 +542,8 @@ namespace Generated.Improbable.Gdk.Tests
                         field6.Add(key, value);
                     }
                 }
-                component.field7Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field7Provider.Allocate(world);
 
+                component.field7Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field7Provider.Allocate(world);
                 {
                     var field7 = new global::System.Collections.Generic.Dictionary<string,string>();
                     Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field7Provider.Set(component.field7Handle, field7);
@@ -557,8 +556,8 @@ namespace Generated.Improbable.Gdk.Tests
                         field7.Add(key, value);
                     }
                 }
-                component.field8Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field8Provider.Allocate(world);
 
+                component.field8Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field8Provider.Allocate(world);
                 {
                     var field8 = new global::System.Collections.Generic.Dictionary<string,uint>();
                     Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field8Provider.Set(component.field8Handle, field8);
@@ -571,8 +570,8 @@ namespace Generated.Improbable.Gdk.Tests
                         field8.Add(key, value);
                     }
                 }
-                component.field9Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field9Provider.Allocate(world);
 
+                component.field9Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field9Provider.Allocate(world);
                 {
                     var field9 = new global::System.Collections.Generic.Dictionary<string,ulong>();
                     Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field9Provider.Set(component.field9Handle, field9);
@@ -585,8 +584,8 @@ namespace Generated.Improbable.Gdk.Tests
                         field9.Add(key, value);
                     }
                 }
-                component.field10Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field10Provider.Allocate(world);
 
+                component.field10Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field10Provider.Allocate(world);
                 {
                     var field10 = new global::System.Collections.Generic.Dictionary<string,int>();
                     Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field10Provider.Set(component.field10Handle, field10);
@@ -599,8 +598,8 @@ namespace Generated.Improbable.Gdk.Tests
                         field10.Add(key, value);
                     }
                 }
-                component.field11Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field11Provider.Allocate(world);
 
+                component.field11Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field11Provider.Allocate(world);
                 {
                     var field11 = new global::System.Collections.Generic.Dictionary<string,long>();
                     Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field11Provider.Set(component.field11Handle, field11);
@@ -613,8 +612,8 @@ namespace Generated.Improbable.Gdk.Tests
                         field11.Add(key, value);
                     }
                 }
-                component.field12Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field12Provider.Allocate(world);
 
+                component.field12Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field12Provider.Allocate(world);
                 {
                     var field12 = new global::System.Collections.Generic.Dictionary<string,uint>();
                     Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field12Provider.Set(component.field12Handle, field12);
@@ -627,8 +626,8 @@ namespace Generated.Improbable.Gdk.Tests
                         field12.Add(key, value);
                     }
                 }
-                component.field13Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field13Provider.Allocate(world);
 
+                component.field13Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field13Provider.Allocate(world);
                 {
                     var field13 = new global::System.Collections.Generic.Dictionary<string,ulong>();
                     Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field13Provider.Set(component.field13Handle, field13);
@@ -641,8 +640,8 @@ namespace Generated.Improbable.Gdk.Tests
                         field13.Add(key, value);
                     }
                 }
-                component.field14Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field14Provider.Allocate(world);
 
+                component.field14Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field14Provider.Allocate(world);
                 {
                     var field14 = new global::System.Collections.Generic.Dictionary<string,int>();
                     Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field14Provider.Set(component.field14Handle, field14);
@@ -655,8 +654,8 @@ namespace Generated.Improbable.Gdk.Tests
                         field14.Add(key, value);
                     }
                 }
-                component.field15Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field15Provider.Allocate(world);
 
+                component.field15Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field15Provider.Allocate(world);
                 {
                     var field15 = new global::System.Collections.Generic.Dictionary<string,long>();
                     Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field15Provider.Set(component.field15Handle, field15);
@@ -669,8 +668,8 @@ namespace Generated.Improbable.Gdk.Tests
                         field15.Add(key, value);
                     }
                 }
-                component.field16Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field16Provider.Allocate(world);
 
+                component.field16Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field16Provider.Allocate(world);
                 {
                     var field16 = new global::System.Collections.Generic.Dictionary<string,global::Improbable.Worker.EntityId>();
                     Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field16Provider.Set(component.field16Handle, field16);
@@ -683,8 +682,8 @@ namespace Generated.Improbable.Gdk.Tests
                         field16.Add(key, value);
                     }
                 }
-                component.field17Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field17Provider.Allocate(world);
 
+                component.field17Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field17Provider.Allocate(world);
                 {
                     var field17 = new global::System.Collections.Generic.Dictionary<string,global::Generated.Improbable.Gdk.Tests.SomeType>();
                     Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field17Provider.Set(component.field17Handle, field17);
@@ -697,6 +696,7 @@ namespace Generated.Improbable.Gdk.Tests
                         field17.Add(key, value);
                     }
                 }
+
                 return component;
             }
 

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValue.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValue.cs
@@ -462,7 +462,8 @@ namespace Generated.Improbable.Gdk.Tests
                 component.field1Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field1Provider.Allocate(world);
 
                 {
-                    var field1 = component.Field1 = new global::System.Collections.Generic.Dictionary<string,BlittableBool>();
+                    var field1 = new global::System.Collections.Generic.Dictionary<string,BlittableBool>();
+                    Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field1Provider.Set(component.field1Handle, field1);
                     var mapSize = obj.GetObjectCount(1);
                     for (var i = 0; i < mapSize; i++)
                     {
@@ -475,7 +476,8 @@ namespace Generated.Improbable.Gdk.Tests
                 component.field2Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field2Provider.Allocate(world);
 
                 {
-                    var field2 = component.Field2 = new global::System.Collections.Generic.Dictionary<string,float>();
+                    var field2 = new global::System.Collections.Generic.Dictionary<string,float>();
+                    Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field2Provider.Set(component.field2Handle, field2);
                     var mapSize = obj.GetObjectCount(2);
                     for (var i = 0; i < mapSize; i++)
                     {
@@ -488,7 +490,8 @@ namespace Generated.Improbable.Gdk.Tests
                 component.field3Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field3Provider.Allocate(world);
 
                 {
-                    var field3 = component.Field3 = new global::System.Collections.Generic.Dictionary<string,byte[]>();
+                    var field3 = new global::System.Collections.Generic.Dictionary<string,byte[]>();
+                    Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field3Provider.Set(component.field3Handle, field3);
                     var mapSize = obj.GetObjectCount(3);
                     for (var i = 0; i < mapSize; i++)
                     {
@@ -501,7 +504,8 @@ namespace Generated.Improbable.Gdk.Tests
                 component.field4Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field4Provider.Allocate(world);
 
                 {
-                    var field4 = component.Field4 = new global::System.Collections.Generic.Dictionary<string,int>();
+                    var field4 = new global::System.Collections.Generic.Dictionary<string,int>();
+                    Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field4Provider.Set(component.field4Handle, field4);
                     var mapSize = obj.GetObjectCount(4);
                     for (var i = 0; i < mapSize; i++)
                     {
@@ -514,7 +518,8 @@ namespace Generated.Improbable.Gdk.Tests
                 component.field5Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field5Provider.Allocate(world);
 
                 {
-                    var field5 = component.Field5 = new global::System.Collections.Generic.Dictionary<string,long>();
+                    var field5 = new global::System.Collections.Generic.Dictionary<string,long>();
+                    Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field5Provider.Set(component.field5Handle, field5);
                     var mapSize = obj.GetObjectCount(5);
                     for (var i = 0; i < mapSize; i++)
                     {
@@ -527,7 +532,8 @@ namespace Generated.Improbable.Gdk.Tests
                 component.field6Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field6Provider.Allocate(world);
 
                 {
-                    var field6 = component.Field6 = new global::System.Collections.Generic.Dictionary<string,double>();
+                    var field6 = new global::System.Collections.Generic.Dictionary<string,double>();
+                    Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field6Provider.Set(component.field6Handle, field6);
                     var mapSize = obj.GetObjectCount(6);
                     for (var i = 0; i < mapSize; i++)
                     {
@@ -540,7 +546,8 @@ namespace Generated.Improbable.Gdk.Tests
                 component.field7Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field7Provider.Allocate(world);
 
                 {
-                    var field7 = component.Field7 = new global::System.Collections.Generic.Dictionary<string,string>();
+                    var field7 = new global::System.Collections.Generic.Dictionary<string,string>();
+                    Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field7Provider.Set(component.field7Handle, field7);
                     var mapSize = obj.GetObjectCount(7);
                     for (var i = 0; i < mapSize; i++)
                     {
@@ -553,7 +560,8 @@ namespace Generated.Improbable.Gdk.Tests
                 component.field8Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field8Provider.Allocate(world);
 
                 {
-                    var field8 = component.Field8 = new global::System.Collections.Generic.Dictionary<string,uint>();
+                    var field8 = new global::System.Collections.Generic.Dictionary<string,uint>();
+                    Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field8Provider.Set(component.field8Handle, field8);
                     var mapSize = obj.GetObjectCount(8);
                     for (var i = 0; i < mapSize; i++)
                     {
@@ -566,7 +574,8 @@ namespace Generated.Improbable.Gdk.Tests
                 component.field9Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field9Provider.Allocate(world);
 
                 {
-                    var field9 = component.Field9 = new global::System.Collections.Generic.Dictionary<string,ulong>();
+                    var field9 = new global::System.Collections.Generic.Dictionary<string,ulong>();
+                    Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field9Provider.Set(component.field9Handle, field9);
                     var mapSize = obj.GetObjectCount(9);
                     for (var i = 0; i < mapSize; i++)
                     {
@@ -579,7 +588,8 @@ namespace Generated.Improbable.Gdk.Tests
                 component.field10Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field10Provider.Allocate(world);
 
                 {
-                    var field10 = component.Field10 = new global::System.Collections.Generic.Dictionary<string,int>();
+                    var field10 = new global::System.Collections.Generic.Dictionary<string,int>();
+                    Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field10Provider.Set(component.field10Handle, field10);
                     var mapSize = obj.GetObjectCount(10);
                     for (var i = 0; i < mapSize; i++)
                     {
@@ -592,7 +602,8 @@ namespace Generated.Improbable.Gdk.Tests
                 component.field11Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field11Provider.Allocate(world);
 
                 {
-                    var field11 = component.Field11 = new global::System.Collections.Generic.Dictionary<string,long>();
+                    var field11 = new global::System.Collections.Generic.Dictionary<string,long>();
+                    Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field11Provider.Set(component.field11Handle, field11);
                     var mapSize = obj.GetObjectCount(11);
                     for (var i = 0; i < mapSize; i++)
                     {
@@ -605,7 +616,8 @@ namespace Generated.Improbable.Gdk.Tests
                 component.field12Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field12Provider.Allocate(world);
 
                 {
-                    var field12 = component.Field12 = new global::System.Collections.Generic.Dictionary<string,uint>();
+                    var field12 = new global::System.Collections.Generic.Dictionary<string,uint>();
+                    Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field12Provider.Set(component.field12Handle, field12);
                     var mapSize = obj.GetObjectCount(12);
                     for (var i = 0; i < mapSize; i++)
                     {
@@ -618,7 +630,8 @@ namespace Generated.Improbable.Gdk.Tests
                 component.field13Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field13Provider.Allocate(world);
 
                 {
-                    var field13 = component.Field13 = new global::System.Collections.Generic.Dictionary<string,ulong>();
+                    var field13 = new global::System.Collections.Generic.Dictionary<string,ulong>();
+                    Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field13Provider.Set(component.field13Handle, field13);
                     var mapSize = obj.GetObjectCount(13);
                     for (var i = 0; i < mapSize; i++)
                     {
@@ -631,7 +644,8 @@ namespace Generated.Improbable.Gdk.Tests
                 component.field14Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field14Provider.Allocate(world);
 
                 {
-                    var field14 = component.Field14 = new global::System.Collections.Generic.Dictionary<string,int>();
+                    var field14 = new global::System.Collections.Generic.Dictionary<string,int>();
+                    Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field14Provider.Set(component.field14Handle, field14);
                     var mapSize = obj.GetObjectCount(14);
                     for (var i = 0; i < mapSize; i++)
                     {
@@ -644,7 +658,8 @@ namespace Generated.Improbable.Gdk.Tests
                 component.field15Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field15Provider.Allocate(world);
 
                 {
-                    var field15 = component.Field15 = new global::System.Collections.Generic.Dictionary<string,long>();
+                    var field15 = new global::System.Collections.Generic.Dictionary<string,long>();
+                    Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field15Provider.Set(component.field15Handle, field15);
                     var mapSize = obj.GetObjectCount(15);
                     for (var i = 0; i < mapSize; i++)
                     {
@@ -657,7 +672,8 @@ namespace Generated.Improbable.Gdk.Tests
                 component.field16Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field16Provider.Allocate(world);
 
                 {
-                    var field16 = component.Field16 = new global::System.Collections.Generic.Dictionary<string,global::Improbable.Worker.EntityId>();
+                    var field16 = new global::System.Collections.Generic.Dictionary<string,global::Improbable.Worker.EntityId>();
+                    Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field16Provider.Set(component.field16Handle, field16);
                     var mapSize = obj.GetObjectCount(16);
                     for (var i = 0; i < mapSize; i++)
                     {
@@ -670,7 +686,8 @@ namespace Generated.Improbable.Gdk.Tests
                 component.field17Handle = Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field17Provider.Allocate(world);
 
                 {
-                    var field17 = component.Field17 = new global::System.Collections.Generic.Dictionary<string,global::Generated.Improbable.Gdk.Tests.SomeType>();
+                    var field17 = new global::System.Collections.Generic.Dictionary<string,global::Generated.Improbable.Gdk.Tests.SomeType>();
+                    Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReferenceTypeProviders.Field17Provider.Set(component.field17Handle, field17);
                     var mapSize = obj.GetObjectCount(17);
                     for (var i = 0; i < mapSize; i++)
                     {

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValueTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValueTranslation.cs
@@ -61,7 +61,6 @@ namespace Generated.Improbable.Gdk.Tests
                 }
 
                 var data = global::Generated.Improbable.Gdk.Tests.SpatialOSExhaustiveMapValue.Serialization.Deserialize(op.Data.SchemaData.Value.GetFields(), World);
-                data.DirtyBit = false;
                 entityManager.AddComponentData(entity, data);
                 entityManager.AddComponentData(entity, new NotAuthoritative<SpatialOSExhaustiveMapValue>());
 

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptional.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptional.cs
@@ -394,103 +394,103 @@ namespace Generated.Improbable.Gdk.Tests
                 component.field1Handle = Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field1Provider.Allocate(world);
                 if (obj.GetBoolCount(1) == 1)
                 {
-                    component.Field1 = obj.GetBool(1);
+                    Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field1Provider.Set(component.field1Handle, obj.GetBool(1));                
                 }
 
                 component.field2Handle = Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field2Provider.Allocate(world);
                 if (obj.GetFloatCount(2) == 1)
                 {
-                    component.Field2 = obj.GetFloat(2);
+                    Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field2Provider.Set(component.field2Handle, obj.GetFloat(2));                
                 }
 
                 component.field3Handle = Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field3Provider.Allocate(world);
                 if (obj.GetBytesCount(3) == 1)
                 {
-                    component.Field3 = obj.GetBytes(3);
+                    Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field3Provider.Set(component.field3Handle, obj.GetBytes(3));                
                 }
 
                 component.field4Handle = Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field4Provider.Allocate(world);
                 if (obj.GetInt32Count(4) == 1)
                 {
-                    component.Field4 = obj.GetInt32(4);
+                    Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field4Provider.Set(component.field4Handle, obj.GetInt32(4));                
                 }
 
                 component.field5Handle = Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field5Provider.Allocate(world);
                 if (obj.GetInt64Count(5) == 1)
                 {
-                    component.Field5 = obj.GetInt64(5);
+                    Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field5Provider.Set(component.field5Handle, obj.GetInt64(5));                
                 }
 
                 component.field6Handle = Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field6Provider.Allocate(world);
                 if (obj.GetDoubleCount(6) == 1)
                 {
-                    component.Field6 = obj.GetDouble(6);
+                    Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field6Provider.Set(component.field6Handle, obj.GetDouble(6));                
                 }
 
                 component.field7Handle = Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field7Provider.Allocate(world);
                 if (obj.GetStringCount(7) == 1)
                 {
-                    component.Field7 = obj.GetString(7);
+                    Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field7Provider.Set(component.field7Handle, obj.GetString(7));                
                 }
 
                 component.field8Handle = Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field8Provider.Allocate(world);
                 if (obj.GetUint32Count(8) == 1)
                 {
-                    component.Field8 = obj.GetUint32(8);
+                    Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field8Provider.Set(component.field8Handle, obj.GetUint32(8));                
                 }
 
                 component.field9Handle = Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field9Provider.Allocate(world);
                 if (obj.GetUint64Count(9) == 1)
                 {
-                    component.Field9 = obj.GetUint64(9);
+                    Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field9Provider.Set(component.field9Handle, obj.GetUint64(9));                
                 }
 
                 component.field10Handle = Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field10Provider.Allocate(world);
                 if (obj.GetSint32Count(10) == 1)
                 {
-                    component.Field10 = obj.GetSint32(10);
+                    Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field10Provider.Set(component.field10Handle, obj.GetSint32(10));                
                 }
 
                 component.field11Handle = Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field11Provider.Allocate(world);
                 if (obj.GetSint64Count(11) == 1)
                 {
-                    component.Field11 = obj.GetSint64(11);
+                    Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field11Provider.Set(component.field11Handle, obj.GetSint64(11));                
                 }
 
                 component.field12Handle = Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field12Provider.Allocate(world);
                 if (obj.GetFixed32Count(12) == 1)
                 {
-                    component.Field12 = obj.GetFixed32(12);
+                    Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field12Provider.Set(component.field12Handle, obj.GetFixed32(12));                
                 }
 
                 component.field13Handle = Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field13Provider.Allocate(world);
                 if (obj.GetFixed64Count(13) == 1)
                 {
-                    component.Field13 = obj.GetFixed64(13);
+                    Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field13Provider.Set(component.field13Handle, obj.GetFixed64(13));                
                 }
 
                 component.field14Handle = Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field14Provider.Allocate(world);
                 if (obj.GetSfixed32Count(14) == 1)
                 {
-                    component.Field14 = obj.GetSfixed32(14);
+                    Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field14Provider.Set(component.field14Handle, obj.GetSfixed32(14));                
                 }
 
                 component.field15Handle = Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field15Provider.Allocate(world);
                 if (obj.GetSfixed64Count(15) == 1)
                 {
-                    component.Field15 = obj.GetSfixed64(15);
+                    Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field15Provider.Set(component.field15Handle, obj.GetSfixed64(15));                
                 }
 
                 component.field16Handle = Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field16Provider.Allocate(world);
                 if (obj.GetEntityIdCount(16) == 1)
                 {
-                    component.Field16 = obj.GetEntityId(16);
+                    Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field16Provider.Set(component.field16Handle, obj.GetEntityId(16));                
                 }
 
                 component.field17Handle = Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field17Provider.Allocate(world);
                 if (obj.GetObjectCount(17) == 1)
                 {
-                    component.Field17 = global::Generated.Improbable.Gdk.Tests.SomeType.Serialization.Deserialize(obj.GetObject(17));
+                    Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field17Provider.Set(component.field17Handle, global::Generated.Improbable.Gdk.Tests.SomeType.Serialization.Deserialize(obj.GetObject(17)));                
                 }
 
                 return component;
@@ -503,103 +503,103 @@ namespace Generated.Improbable.Gdk.Tests
                 {
                     var value = obj.GetBool(1);
                     update.Field1 = new Option<global::System.Nullable<BlittableBool>>(value);
-                    component.Field1 = value;
+                    Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field1Provider.Set(component.field1Handle, value);                
                 }
                 if (obj.GetFloatCount(2) == 1)
                 {
                     var value = obj.GetFloat(2);
                     update.Field2 = new Option<global::System.Nullable<float>>(value);
-                    component.Field2 = value;
+                    Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field2Provider.Set(component.field2Handle, value);                
                 }
                 if (obj.GetBytesCount(3) == 1)
                 {
                     var value = obj.GetBytes(3);
                     update.Field3 = new Option<global::Improbable.Gdk.Core.Option<byte[]>>(value);
-                    component.Field3 = value;
+                    Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field3Provider.Set(component.field3Handle, value);                
                 }
                 if (obj.GetInt32Count(4) == 1)
                 {
                     var value = obj.GetInt32(4);
                     update.Field4 = new Option<global::System.Nullable<int>>(value);
-                    component.Field4 = value;
+                    Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field4Provider.Set(component.field4Handle, value);                
                 }
                 if (obj.GetInt64Count(5) == 1)
                 {
                     var value = obj.GetInt64(5);
                     update.Field5 = new Option<global::System.Nullable<long>>(value);
-                    component.Field5 = value;
+                    Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field5Provider.Set(component.field5Handle, value);                
                 }
                 if (obj.GetDoubleCount(6) == 1)
                 {
                     var value = obj.GetDouble(6);
                     update.Field6 = new Option<global::System.Nullable<double>>(value);
-                    component.Field6 = value;
+                    Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field6Provider.Set(component.field6Handle, value);                
                 }
                 if (obj.GetStringCount(7) == 1)
                 {
                     var value = obj.GetString(7);
                     update.Field7 = new Option<global::Improbable.Gdk.Core.Option<string>>(value);
-                    component.Field7 = value;
+                    Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field7Provider.Set(component.field7Handle, value);                
                 }
                 if (obj.GetUint32Count(8) == 1)
                 {
                     var value = obj.GetUint32(8);
                     update.Field8 = new Option<global::System.Nullable<uint>>(value);
-                    component.Field8 = value;
+                    Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field8Provider.Set(component.field8Handle, value);                
                 }
                 if (obj.GetUint64Count(9) == 1)
                 {
                     var value = obj.GetUint64(9);
                     update.Field9 = new Option<global::System.Nullable<ulong>>(value);
-                    component.Field9 = value;
+                    Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field9Provider.Set(component.field9Handle, value);                
                 }
                 if (obj.GetSint32Count(10) == 1)
                 {
                     var value = obj.GetSint32(10);
                     update.Field10 = new Option<global::System.Nullable<int>>(value);
-                    component.Field10 = value;
+                    Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field10Provider.Set(component.field10Handle, value);                
                 }
                 if (obj.GetSint64Count(11) == 1)
                 {
                     var value = obj.GetSint64(11);
                     update.Field11 = new Option<global::System.Nullable<long>>(value);
-                    component.Field11 = value;
+                    Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field11Provider.Set(component.field11Handle, value);                
                 }
                 if (obj.GetFixed32Count(12) == 1)
                 {
                     var value = obj.GetFixed32(12);
                     update.Field12 = new Option<global::System.Nullable<uint>>(value);
-                    component.Field12 = value;
+                    Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field12Provider.Set(component.field12Handle, value);                
                 }
                 if (obj.GetFixed64Count(13) == 1)
                 {
                     var value = obj.GetFixed64(13);
                     update.Field13 = new Option<global::System.Nullable<ulong>>(value);
-                    component.Field13 = value;
+                    Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field13Provider.Set(component.field13Handle, value);                
                 }
                 if (obj.GetSfixed32Count(14) == 1)
                 {
                     var value = obj.GetSfixed32(14);
                     update.Field14 = new Option<global::System.Nullable<int>>(value);
-                    component.Field14 = value;
+                    Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field14Provider.Set(component.field14Handle, value);                
                 }
                 if (obj.GetSfixed64Count(15) == 1)
                 {
                     var value = obj.GetSfixed64(15);
                     update.Field15 = new Option<global::System.Nullable<long>>(value);
-                    component.Field15 = value;
+                    Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field15Provider.Set(component.field15Handle, value);                
                 }
                 if (obj.GetEntityIdCount(16) == 1)
                 {
                     var value = obj.GetEntityId(16);
                     update.Field16 = new Option<global::System.Nullable<global::Improbable.Worker.EntityId>>(value);
-                    component.Field16 = value;
+                    Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field16Provider.Set(component.field16Handle, value);                
                 }
                 if (obj.GetObjectCount(17) == 1)
                 {
                     var value = global::Generated.Improbable.Gdk.Tests.SomeType.Serialization.Deserialize(obj.GetObject(17));
-                    update.Field17 = value;
-                    component.Field17 = new Option<global::System.Nullable<global::Generated.Improbable.Gdk.Tests.SomeType>>(value);
+                    update.Field17 = new Option<global::System.Nullable<global::Generated.Improbable.Gdk.Tests.SomeType>>(value);
+                    Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field17Provider.Set(component.field17Handle, value);                
                 }
                 return update;
             }

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptional.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptional.cs
@@ -392,107 +392,107 @@ namespace Generated.Improbable.Gdk.Tests
                 var component = new SpatialOSExhaustiveOptional();
 
                 component.field1Handle = Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field1Provider.Allocate(world);
-
                 if (obj.GetBoolCount(1) == 1)
                 {
                     component.Field1 = obj.GetBool(1);
                 }
-                component.field2Handle = Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field2Provider.Allocate(world);
 
+                component.field2Handle = Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field2Provider.Allocate(world);
                 if (obj.GetFloatCount(2) == 1)
                 {
                     component.Field2 = obj.GetFloat(2);
                 }
-                component.field3Handle = Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field3Provider.Allocate(world);
 
+                component.field3Handle = Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field3Provider.Allocate(world);
                 if (obj.GetBytesCount(3) == 1)
                 {
                     component.Field3 = obj.GetBytes(3);
                 }
-                component.field4Handle = Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field4Provider.Allocate(world);
 
+                component.field4Handle = Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field4Provider.Allocate(world);
                 if (obj.GetInt32Count(4) == 1)
                 {
                     component.Field4 = obj.GetInt32(4);
                 }
-                component.field5Handle = Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field5Provider.Allocate(world);
 
+                component.field5Handle = Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field5Provider.Allocate(world);
                 if (obj.GetInt64Count(5) == 1)
                 {
                     component.Field5 = obj.GetInt64(5);
                 }
-                component.field6Handle = Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field6Provider.Allocate(world);
 
+                component.field6Handle = Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field6Provider.Allocate(world);
                 if (obj.GetDoubleCount(6) == 1)
                 {
                     component.Field6 = obj.GetDouble(6);
                 }
-                component.field7Handle = Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field7Provider.Allocate(world);
 
+                component.field7Handle = Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field7Provider.Allocate(world);
                 if (obj.GetStringCount(7) == 1)
                 {
                     component.Field7 = obj.GetString(7);
                 }
-                component.field8Handle = Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field8Provider.Allocate(world);
 
+                component.field8Handle = Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field8Provider.Allocate(world);
                 if (obj.GetUint32Count(8) == 1)
                 {
                     component.Field8 = obj.GetUint32(8);
                 }
-                component.field9Handle = Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field9Provider.Allocate(world);
 
+                component.field9Handle = Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field9Provider.Allocate(world);
                 if (obj.GetUint64Count(9) == 1)
                 {
                     component.Field9 = obj.GetUint64(9);
                 }
-                component.field10Handle = Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field10Provider.Allocate(world);
 
+                component.field10Handle = Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field10Provider.Allocate(world);
                 if (obj.GetSint32Count(10) == 1)
                 {
                     component.Field10 = obj.GetSint32(10);
                 }
-                component.field11Handle = Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field11Provider.Allocate(world);
 
+                component.field11Handle = Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field11Provider.Allocate(world);
                 if (obj.GetSint64Count(11) == 1)
                 {
                     component.Field11 = obj.GetSint64(11);
                 }
-                component.field12Handle = Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field12Provider.Allocate(world);
 
+                component.field12Handle = Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field12Provider.Allocate(world);
                 if (obj.GetFixed32Count(12) == 1)
                 {
                     component.Field12 = obj.GetFixed32(12);
                 }
-                component.field13Handle = Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field13Provider.Allocate(world);
 
+                component.field13Handle = Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field13Provider.Allocate(world);
                 if (obj.GetFixed64Count(13) == 1)
                 {
                     component.Field13 = obj.GetFixed64(13);
                 }
-                component.field14Handle = Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field14Provider.Allocate(world);
 
+                component.field14Handle = Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field14Provider.Allocate(world);
                 if (obj.GetSfixed32Count(14) == 1)
                 {
                     component.Field14 = obj.GetSfixed32(14);
                 }
-                component.field15Handle = Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field15Provider.Allocate(world);
 
+                component.field15Handle = Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field15Provider.Allocate(world);
                 if (obj.GetSfixed64Count(15) == 1)
                 {
                     component.Field15 = obj.GetSfixed64(15);
                 }
-                component.field16Handle = Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field16Provider.Allocate(world);
 
+                component.field16Handle = Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field16Provider.Allocate(world);
                 if (obj.GetEntityIdCount(16) == 1)
                 {
                     component.Field16 = obj.GetEntityId(16);
                 }
-                component.field17Handle = Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field17Provider.Allocate(world);
 
+                component.field17Handle = Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReferenceTypeProviders.Field17Provider.Allocate(world);
                 if (obj.GetObjectCount(17) == 1)
                 {
                     component.Field17 = global::Generated.Improbable.Gdk.Tests.SomeType.Serialization.Deserialize(obj.GetObject(17));
                 }
+
                 return component;
             }
 

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptionalTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptionalTranslation.cs
@@ -61,7 +61,6 @@ namespace Generated.Improbable.Gdk.Tests
                 }
 
                 var data = global::Generated.Improbable.Gdk.Tests.SpatialOSExhaustiveOptional.Serialization.Deserialize(op.Data.SchemaData.Value.GetFields(), World);
-                data.DirtyBit = false;
                 entityManager.AddComponentData(entity, data);
                 entityManager.AddComponentData(entity, new NotAuthoritative<SpatialOSExhaustiveOptional>());
 

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeated.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeated.cs
@@ -392,7 +392,6 @@ namespace Generated.Improbable.Gdk.Tests
                 var component = new SpatialOSExhaustiveRepeated();
 
                 component.field1Handle = Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field1Provider.Allocate(world);
-
                 var field1 = new global::System.Collections.Generic.List<BlittableBool>();
                 Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field1Provider.Set(component.field1Handle, field1);
                 for (var i = 0; i < obj.GetBoolCount(1); i++)
@@ -400,8 +399,8 @@ namespace Generated.Improbable.Gdk.Tests
                     field1.Add(obj.IndexBool(1, (uint) i));
                 }
 
-                component.field2Handle = Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field2Provider.Allocate(world);
 
+                component.field2Handle = Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field2Provider.Allocate(world);
                 var field2 = new global::System.Collections.Generic.List<float>();
                 Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field2Provider.Set(component.field2Handle, field2);
                 for (var i = 0; i < obj.GetFloatCount(2); i++)
@@ -409,8 +408,8 @@ namespace Generated.Improbable.Gdk.Tests
                     field2.Add(obj.IndexFloat(2, (uint) i));
                 }
 
-                component.field3Handle = Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field3Provider.Allocate(world);
 
+                component.field3Handle = Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field3Provider.Allocate(world);
                 var field3 = new global::System.Collections.Generic.List<byte[]>();
                 Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field3Provider.Set(component.field3Handle, field3);
                 for (var i = 0; i < obj.GetBytesCount(3); i++)
@@ -418,8 +417,8 @@ namespace Generated.Improbable.Gdk.Tests
                     field3.Add(obj.IndexBytes(3, (uint) i));
                 }
 
-                component.field4Handle = Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field4Provider.Allocate(world);
 
+                component.field4Handle = Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field4Provider.Allocate(world);
                 var field4 = new global::System.Collections.Generic.List<int>();
                 Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field4Provider.Set(component.field4Handle, field4);
                 for (var i = 0; i < obj.GetInt32Count(4); i++)
@@ -427,8 +426,8 @@ namespace Generated.Improbable.Gdk.Tests
                     field4.Add(obj.IndexInt32(4, (uint) i));
                 }
 
-                component.field5Handle = Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field5Provider.Allocate(world);
 
+                component.field5Handle = Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field5Provider.Allocate(world);
                 var field5 = new global::System.Collections.Generic.List<long>();
                 Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field5Provider.Set(component.field5Handle, field5);
                 for (var i = 0; i < obj.GetInt64Count(5); i++)
@@ -436,8 +435,8 @@ namespace Generated.Improbable.Gdk.Tests
                     field5.Add(obj.IndexInt64(5, (uint) i));
                 }
 
-                component.field6Handle = Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field6Provider.Allocate(world);
 
+                component.field6Handle = Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field6Provider.Allocate(world);
                 var field6 = new global::System.Collections.Generic.List<double>();
                 Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field6Provider.Set(component.field6Handle, field6);
                 for (var i = 0; i < obj.GetDoubleCount(6); i++)
@@ -445,8 +444,8 @@ namespace Generated.Improbable.Gdk.Tests
                     field6.Add(obj.IndexDouble(6, (uint) i));
                 }
 
-                component.field7Handle = Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field7Provider.Allocate(world);
 
+                component.field7Handle = Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field7Provider.Allocate(world);
                 var field7 = new global::System.Collections.Generic.List<string>();
                 Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field7Provider.Set(component.field7Handle, field7);
                 for (var i = 0; i < obj.GetStringCount(7); i++)
@@ -454,8 +453,8 @@ namespace Generated.Improbable.Gdk.Tests
                     field7.Add(obj.IndexString(7, (uint) i));
                 }
 
-                component.field8Handle = Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field8Provider.Allocate(world);
 
+                component.field8Handle = Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field8Provider.Allocate(world);
                 var field8 = new global::System.Collections.Generic.List<uint>();
                 Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field8Provider.Set(component.field8Handle, field8);
                 for (var i = 0; i < obj.GetUint32Count(8); i++)
@@ -463,8 +462,8 @@ namespace Generated.Improbable.Gdk.Tests
                     field8.Add(obj.IndexUint32(8, (uint) i));
                 }
 
-                component.field9Handle = Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field9Provider.Allocate(world);
 
+                component.field9Handle = Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field9Provider.Allocate(world);
                 var field9 = new global::System.Collections.Generic.List<ulong>();
                 Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field9Provider.Set(component.field9Handle, field9);
                 for (var i = 0; i < obj.GetUint64Count(9); i++)
@@ -472,8 +471,8 @@ namespace Generated.Improbable.Gdk.Tests
                     field9.Add(obj.IndexUint64(9, (uint) i));
                 }
 
-                component.field10Handle = Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field10Provider.Allocate(world);
 
+                component.field10Handle = Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field10Provider.Allocate(world);
                 var field10 = new global::System.Collections.Generic.List<int>();
                 Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field10Provider.Set(component.field10Handle, field10);
                 for (var i = 0; i < obj.GetSint32Count(10); i++)
@@ -481,8 +480,8 @@ namespace Generated.Improbable.Gdk.Tests
                     field10.Add(obj.IndexSint32(10, (uint) i));
                 }
 
-                component.field11Handle = Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field11Provider.Allocate(world);
 
+                component.field11Handle = Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field11Provider.Allocate(world);
                 var field11 = new global::System.Collections.Generic.List<long>();
                 Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field11Provider.Set(component.field11Handle, field11);
                 for (var i = 0; i < obj.GetSint64Count(11); i++)
@@ -490,8 +489,8 @@ namespace Generated.Improbable.Gdk.Tests
                     field11.Add(obj.IndexSint64(11, (uint) i));
                 }
 
-                component.field12Handle = Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field12Provider.Allocate(world);
 
+                component.field12Handle = Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field12Provider.Allocate(world);
                 var field12 = new global::System.Collections.Generic.List<uint>();
                 Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field12Provider.Set(component.field12Handle, field12);
                 for (var i = 0; i < obj.GetFixed32Count(12); i++)
@@ -499,8 +498,8 @@ namespace Generated.Improbable.Gdk.Tests
                     field12.Add(obj.IndexFixed32(12, (uint) i));
                 }
 
-                component.field13Handle = Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field13Provider.Allocate(world);
 
+                component.field13Handle = Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field13Provider.Allocate(world);
                 var field13 = new global::System.Collections.Generic.List<ulong>();
                 Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field13Provider.Set(component.field13Handle, field13);
                 for (var i = 0; i < obj.GetFixed64Count(13); i++)
@@ -508,8 +507,8 @@ namespace Generated.Improbable.Gdk.Tests
                     field13.Add(obj.IndexFixed64(13, (uint) i));
                 }
 
-                component.field14Handle = Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field14Provider.Allocate(world);
 
+                component.field14Handle = Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field14Provider.Allocate(world);
                 var field14 = new global::System.Collections.Generic.List<int>();
                 Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field14Provider.Set(component.field14Handle, field14);
                 for (var i = 0; i < obj.GetSfixed32Count(14); i++)
@@ -517,8 +516,8 @@ namespace Generated.Improbable.Gdk.Tests
                     field14.Add(obj.IndexSfixed32(14, (uint) i));
                 }
 
-                component.field15Handle = Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field15Provider.Allocate(world);
 
+                component.field15Handle = Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field15Provider.Allocate(world);
                 var field15 = new global::System.Collections.Generic.List<long>();
                 Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field15Provider.Set(component.field15Handle, field15);
                 for (var i = 0; i < obj.GetSfixed64Count(15); i++)
@@ -526,8 +525,8 @@ namespace Generated.Improbable.Gdk.Tests
                     field15.Add(obj.IndexSfixed64(15, (uint) i));
                 }
 
-                component.field16Handle = Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field16Provider.Allocate(world);
 
+                component.field16Handle = Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field16Provider.Allocate(world);
                 var field16 = new global::System.Collections.Generic.List<global::Improbable.Worker.EntityId>();
                 Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field16Provider.Set(component.field16Handle, field16);
                 for (var i = 0; i < obj.GetEntityIdCount(16); i++)
@@ -535,14 +534,15 @@ namespace Generated.Improbable.Gdk.Tests
                     field16.Add(obj.IndexEntityId(16, (uint) i));
                 }
 
-                component.field17Handle = Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field17Provider.Allocate(world);
 
+                component.field17Handle = Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field17Provider.Allocate(world);
                 var field17 = new global::System.Collections.Generic.List<global::Generated.Improbable.Gdk.Tests.SomeType>();
                 Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field17Provider.Set(component.field17Handle, field17);
                 for (var i = 0; i < obj.GetObjectCount(17); i++)
                 {
                     field17.Add(global::Generated.Improbable.Gdk.Tests.SomeType.Serialization.Deserialize(obj.IndexObject(17, (uint) i)));
                 }
+
 
                 return component;
             }

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeated.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeated.cs
@@ -393,7 +393,8 @@ namespace Generated.Improbable.Gdk.Tests
 
                 component.field1Handle = Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field1Provider.Allocate(world);
 
-                var field1 = component.Field1 = new global::System.Collections.Generic.List<BlittableBool>();
+                var field1 = new global::System.Collections.Generic.List<BlittableBool>();
+                Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field1Provider.Set(component.field1Handle, field1);
                 for (var i = 0; i < obj.GetBoolCount(1); i++)
                 {
                     field1.Add(obj.IndexBool(1, (uint) i));
@@ -401,7 +402,8 @@ namespace Generated.Improbable.Gdk.Tests
 
                 component.field2Handle = Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field2Provider.Allocate(world);
 
-                var field2 = component.Field2 = new global::System.Collections.Generic.List<float>();
+                var field2 = new global::System.Collections.Generic.List<float>();
+                Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field2Provider.Set(component.field2Handle, field2);
                 for (var i = 0; i < obj.GetFloatCount(2); i++)
                 {
                     field2.Add(obj.IndexFloat(2, (uint) i));
@@ -409,7 +411,8 @@ namespace Generated.Improbable.Gdk.Tests
 
                 component.field3Handle = Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field3Provider.Allocate(world);
 
-                var field3 = component.Field3 = new global::System.Collections.Generic.List<byte[]>();
+                var field3 = new global::System.Collections.Generic.List<byte[]>();
+                Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field3Provider.Set(component.field3Handle, field3);
                 for (var i = 0; i < obj.GetBytesCount(3); i++)
                 {
                     field3.Add(obj.IndexBytes(3, (uint) i));
@@ -417,7 +420,8 @@ namespace Generated.Improbable.Gdk.Tests
 
                 component.field4Handle = Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field4Provider.Allocate(world);
 
-                var field4 = component.Field4 = new global::System.Collections.Generic.List<int>();
+                var field4 = new global::System.Collections.Generic.List<int>();
+                Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field4Provider.Set(component.field4Handle, field4);
                 for (var i = 0; i < obj.GetInt32Count(4); i++)
                 {
                     field4.Add(obj.IndexInt32(4, (uint) i));
@@ -425,7 +429,8 @@ namespace Generated.Improbable.Gdk.Tests
 
                 component.field5Handle = Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field5Provider.Allocate(world);
 
-                var field5 = component.Field5 = new global::System.Collections.Generic.List<long>();
+                var field5 = new global::System.Collections.Generic.List<long>();
+                Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field5Provider.Set(component.field5Handle, field5);
                 for (var i = 0; i < obj.GetInt64Count(5); i++)
                 {
                     field5.Add(obj.IndexInt64(5, (uint) i));
@@ -433,7 +438,8 @@ namespace Generated.Improbable.Gdk.Tests
 
                 component.field6Handle = Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field6Provider.Allocate(world);
 
-                var field6 = component.Field6 = new global::System.Collections.Generic.List<double>();
+                var field6 = new global::System.Collections.Generic.List<double>();
+                Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field6Provider.Set(component.field6Handle, field6);
                 for (var i = 0; i < obj.GetDoubleCount(6); i++)
                 {
                     field6.Add(obj.IndexDouble(6, (uint) i));
@@ -441,7 +447,8 @@ namespace Generated.Improbable.Gdk.Tests
 
                 component.field7Handle = Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field7Provider.Allocate(world);
 
-                var field7 = component.Field7 = new global::System.Collections.Generic.List<string>();
+                var field7 = new global::System.Collections.Generic.List<string>();
+                Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field7Provider.Set(component.field7Handle, field7);
                 for (var i = 0; i < obj.GetStringCount(7); i++)
                 {
                     field7.Add(obj.IndexString(7, (uint) i));
@@ -449,7 +456,8 @@ namespace Generated.Improbable.Gdk.Tests
 
                 component.field8Handle = Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field8Provider.Allocate(world);
 
-                var field8 = component.Field8 = new global::System.Collections.Generic.List<uint>();
+                var field8 = new global::System.Collections.Generic.List<uint>();
+                Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field8Provider.Set(component.field8Handle, field8);
                 for (var i = 0; i < obj.GetUint32Count(8); i++)
                 {
                     field8.Add(obj.IndexUint32(8, (uint) i));
@@ -457,7 +465,8 @@ namespace Generated.Improbable.Gdk.Tests
 
                 component.field9Handle = Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field9Provider.Allocate(world);
 
-                var field9 = component.Field9 = new global::System.Collections.Generic.List<ulong>();
+                var field9 = new global::System.Collections.Generic.List<ulong>();
+                Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field9Provider.Set(component.field9Handle, field9);
                 for (var i = 0; i < obj.GetUint64Count(9); i++)
                 {
                     field9.Add(obj.IndexUint64(9, (uint) i));
@@ -465,7 +474,8 @@ namespace Generated.Improbable.Gdk.Tests
 
                 component.field10Handle = Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field10Provider.Allocate(world);
 
-                var field10 = component.Field10 = new global::System.Collections.Generic.List<int>();
+                var field10 = new global::System.Collections.Generic.List<int>();
+                Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field10Provider.Set(component.field10Handle, field10);
                 for (var i = 0; i < obj.GetSint32Count(10); i++)
                 {
                     field10.Add(obj.IndexSint32(10, (uint) i));
@@ -473,7 +483,8 @@ namespace Generated.Improbable.Gdk.Tests
 
                 component.field11Handle = Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field11Provider.Allocate(world);
 
-                var field11 = component.Field11 = new global::System.Collections.Generic.List<long>();
+                var field11 = new global::System.Collections.Generic.List<long>();
+                Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field11Provider.Set(component.field11Handle, field11);
                 for (var i = 0; i < obj.GetSint64Count(11); i++)
                 {
                     field11.Add(obj.IndexSint64(11, (uint) i));
@@ -481,7 +492,8 @@ namespace Generated.Improbable.Gdk.Tests
 
                 component.field12Handle = Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field12Provider.Allocate(world);
 
-                var field12 = component.Field12 = new global::System.Collections.Generic.List<uint>();
+                var field12 = new global::System.Collections.Generic.List<uint>();
+                Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field12Provider.Set(component.field12Handle, field12);
                 for (var i = 0; i < obj.GetFixed32Count(12); i++)
                 {
                     field12.Add(obj.IndexFixed32(12, (uint) i));
@@ -489,7 +501,8 @@ namespace Generated.Improbable.Gdk.Tests
 
                 component.field13Handle = Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field13Provider.Allocate(world);
 
-                var field13 = component.Field13 = new global::System.Collections.Generic.List<ulong>();
+                var field13 = new global::System.Collections.Generic.List<ulong>();
+                Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field13Provider.Set(component.field13Handle, field13);
                 for (var i = 0; i < obj.GetFixed64Count(13); i++)
                 {
                     field13.Add(obj.IndexFixed64(13, (uint) i));
@@ -497,7 +510,8 @@ namespace Generated.Improbable.Gdk.Tests
 
                 component.field14Handle = Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field14Provider.Allocate(world);
 
-                var field14 = component.Field14 = new global::System.Collections.Generic.List<int>();
+                var field14 = new global::System.Collections.Generic.List<int>();
+                Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field14Provider.Set(component.field14Handle, field14);
                 for (var i = 0; i < obj.GetSfixed32Count(14); i++)
                 {
                     field14.Add(obj.IndexSfixed32(14, (uint) i));
@@ -505,7 +519,8 @@ namespace Generated.Improbable.Gdk.Tests
 
                 component.field15Handle = Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field15Provider.Allocate(world);
 
-                var field15 = component.Field15 = new global::System.Collections.Generic.List<long>();
+                var field15 = new global::System.Collections.Generic.List<long>();
+                Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field15Provider.Set(component.field15Handle, field15);
                 for (var i = 0; i < obj.GetSfixed64Count(15); i++)
                 {
                     field15.Add(obj.IndexSfixed64(15, (uint) i));
@@ -513,7 +528,8 @@ namespace Generated.Improbable.Gdk.Tests
 
                 component.field16Handle = Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field16Provider.Allocate(world);
 
-                var field16 = component.Field16 = new global::System.Collections.Generic.List<global::Improbable.Worker.EntityId>();
+                var field16 = new global::System.Collections.Generic.List<global::Improbable.Worker.EntityId>();
+                Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field16Provider.Set(component.field16Handle, field16);
                 for (var i = 0; i < obj.GetEntityIdCount(16); i++)
                 {
                     field16.Add(obj.IndexEntityId(16, (uint) i));
@@ -521,7 +537,8 @@ namespace Generated.Improbable.Gdk.Tests
 
                 component.field17Handle = Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field17Provider.Allocate(world);
 
-                var field17 = component.Field17 = new global::System.Collections.Generic.List<global::Generated.Improbable.Gdk.Tests.SomeType>();
+                var field17 = new global::System.Collections.Generic.List<global::Generated.Improbable.Gdk.Tests.SomeType>();
+                Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReferenceTypeProviders.Field17Provider.Set(component.field17Handle, field17);
                 for (var i = 0; i < obj.GetObjectCount(17); i++)
                 {
                     field17.Add(global::Generated.Improbable.Gdk.Tests.SomeType.Serialization.Deserialize(obj.IndexObject(17, (uint) i)));

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeatedTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeatedTranslation.cs
@@ -61,7 +61,6 @@ namespace Generated.Improbable.Gdk.Tests
                 }
 
                 var data = global::Generated.Improbable.Gdk.Tests.SpatialOSExhaustiveRepeated.Serialization.Deserialize(op.Data.SchemaData.Value.GetFields(), World);
-                data.DirtyBit = false;
                 entityManager.AddComponentData(entity, data);
                 entityManager.AddComponentData(entity, new NotAuthoritative<SpatialOSExhaustiveRepeated>());
 

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingular.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingular.cs
@@ -12,7 +12,7 @@ namespace Generated.Improbable.Gdk.Tests
         public uint ComponentId => 197715;
 
         public BlittableBool DirtyBit { get; set; }
-        private BlittableBool field1;
+        internal BlittableBool field1;
 
         public BlittableBool Field1
         {
@@ -23,7 +23,7 @@ namespace Generated.Improbable.Gdk.Tests
                 field1 = value;
             }
         }
-        private float field2;
+        internal float field2;
 
         public float Field2
         {
@@ -46,7 +46,7 @@ namespace Generated.Improbable.Gdk.Tests
                 Generated.Improbable.Gdk.Tests.ExhaustiveSingular.ReferenceTypeProviders.Field3Provider.Set(field3Handle, value);
             }
         }
-        private int field4;
+        internal int field4;
 
         public int Field4
         {
@@ -57,7 +57,7 @@ namespace Generated.Improbable.Gdk.Tests
                 field4 = value;
             }
         }
-        private long field5;
+        internal long field5;
 
         public long Field5
         {
@@ -68,7 +68,7 @@ namespace Generated.Improbable.Gdk.Tests
                 field5 = value;
             }
         }
-        private double field6;
+        internal double field6;
 
         public double Field6
         {
@@ -91,7 +91,7 @@ namespace Generated.Improbable.Gdk.Tests
                 Generated.Improbable.Gdk.Tests.ExhaustiveSingular.ReferenceTypeProviders.Field7Provider.Set(field7Handle, value);
             }
         }
-        private uint field8;
+        internal uint field8;
 
         public uint Field8
         {
@@ -102,7 +102,7 @@ namespace Generated.Improbable.Gdk.Tests
                 field8 = value;
             }
         }
-        private ulong field9;
+        internal ulong field9;
 
         public ulong Field9
         {
@@ -113,7 +113,7 @@ namespace Generated.Improbable.Gdk.Tests
                 field9 = value;
             }
         }
-        private int field10;
+        internal int field10;
 
         public int Field10
         {
@@ -124,7 +124,7 @@ namespace Generated.Improbable.Gdk.Tests
                 field10 = value;
             }
         }
-        private long field11;
+        internal long field11;
 
         public long Field11
         {
@@ -135,7 +135,7 @@ namespace Generated.Improbable.Gdk.Tests
                 field11 = value;
             }
         }
-        private uint field12;
+        internal uint field12;
 
         public uint Field12
         {
@@ -146,7 +146,7 @@ namespace Generated.Improbable.Gdk.Tests
                 field12 = value;
             }
         }
-        private ulong field13;
+        internal ulong field13;
 
         public ulong Field13
         {
@@ -157,7 +157,7 @@ namespace Generated.Improbable.Gdk.Tests
                 field13 = value;
             }
         }
-        private int field14;
+        internal int field14;
 
         public int Field14
         {
@@ -168,7 +168,7 @@ namespace Generated.Improbable.Gdk.Tests
                 field14 = value;
             }
         }
-        private long field15;
+        internal long field15;
 
         public long Field15
         {
@@ -179,7 +179,7 @@ namespace Generated.Improbable.Gdk.Tests
                 field15 = value;
             }
         }
-        private global::Improbable.Worker.EntityId field16;
+        internal global::Improbable.Worker.EntityId field16;
 
         public global::Improbable.Worker.EntityId Field16
         {
@@ -190,7 +190,7 @@ namespace Generated.Improbable.Gdk.Tests
                 field16 = value;
             }
         }
-        private global::Generated.Improbable.Gdk.Tests.SomeType field17;
+        internal global::Generated.Improbable.Gdk.Tests.SomeType field17;
 
         public global::Generated.Improbable.Gdk.Tests.SomeType Field17
         {

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingular.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingular.cs
@@ -274,42 +274,42 @@ namespace Generated.Improbable.Gdk.Tests
             {
                 var component = new SpatialOSExhaustiveSingular();
 
+                component.field1 = obj.GetBool(1);
 
-                component.Field1 = obj.GetBool(1);
+                component.field2 = obj.GetFloat(2);
 
-                component.Field2 = obj.GetFloat(2);
                 component.field3Handle = Generated.Improbable.Gdk.Tests.ExhaustiveSingular.ReferenceTypeProviders.Field3Provider.Allocate(world);
+                Generated.Improbable.Gdk.Tests.ExhaustiveSingular.ReferenceTypeProviders.Field3Provider.Set(component.field3Handle, obj.GetBytes(3));                
 
-                component.Field3 = obj.GetBytes(3);
+                component.field4 = obj.GetInt32(4);
 
-                component.Field4 = obj.GetInt32(4);
+                component.field5 = obj.GetInt64(5);
 
-                component.Field5 = obj.GetInt64(5);
+                component.field6 = obj.GetDouble(6);
 
-                component.Field6 = obj.GetDouble(6);
                 component.field7Handle = Generated.Improbable.Gdk.Tests.ExhaustiveSingular.ReferenceTypeProviders.Field7Provider.Allocate(world);
+                Generated.Improbable.Gdk.Tests.ExhaustiveSingular.ReferenceTypeProviders.Field7Provider.Set(component.field7Handle, obj.GetString(7));                
 
-                component.Field7 = obj.GetString(7);
+                component.field8 = obj.GetUint32(8);
 
-                component.Field8 = obj.GetUint32(8);
+                component.field9 = obj.GetUint64(9);
 
-                component.Field9 = obj.GetUint64(9);
+                component.field10 = obj.GetSint32(10);
 
-                component.Field10 = obj.GetSint32(10);
+                component.field11 = obj.GetSint64(11);
 
-                component.Field11 = obj.GetSint64(11);
+                component.field12 = obj.GetFixed32(12);
 
-                component.Field12 = obj.GetFixed32(12);
+                component.field13 = obj.GetFixed64(13);
 
-                component.Field13 = obj.GetFixed64(13);
+                component.field14 = obj.GetSfixed32(14);
 
-                component.Field14 = obj.GetSfixed32(14);
+                component.field15 = obj.GetSfixed64(15);
 
-                component.Field15 = obj.GetSfixed64(15);
+                component.field16 = obj.GetEntityId(16);
 
-                component.Field16 = obj.GetEntityId(16);
+                component.field17 = global::Generated.Improbable.Gdk.Tests.SomeType.Serialization.Deserialize(obj.GetObject(17));
 
-                component.Field17 = global::Generated.Improbable.Gdk.Tests.SomeType.Serialization.Deserialize(obj.GetObject(17));
                 return component;
             }
 
@@ -320,103 +320,103 @@ namespace Generated.Improbable.Gdk.Tests
                 {
                     var value = obj.GetBool(1);
                     update.Field1 = new Option<BlittableBool>(value);
-                    component.Field1 = value;
+                    component.field1 = value;
                 }
                 if (obj.GetFloatCount(2) == 1)
                 {
                     var value = obj.GetFloat(2);
                     update.Field2 = new Option<float>(value);
-                    component.Field2 = value;
+                    component.field2 = value;
                 }
                 if (obj.GetBytesCount(3) == 1)
                 {
                     var value = obj.GetBytes(3);
                     update.Field3 = new Option<byte[]>(value);
-                    component.Field3 = value;
+                    Generated.Improbable.Gdk.Tests.ExhaustiveSingular.ReferenceTypeProviders.Field3Provider.Set(component.field3Handle, value);                
                 }
                 if (obj.GetInt32Count(4) == 1)
                 {
                     var value = obj.GetInt32(4);
                     update.Field4 = new Option<int>(value);
-                    component.Field4 = value;
+                    component.field4 = value;
                 }
                 if (obj.GetInt64Count(5) == 1)
                 {
                     var value = obj.GetInt64(5);
                     update.Field5 = new Option<long>(value);
-                    component.Field5 = value;
+                    component.field5 = value;
                 }
                 if (obj.GetDoubleCount(6) == 1)
                 {
                     var value = obj.GetDouble(6);
                     update.Field6 = new Option<double>(value);
-                    component.Field6 = value;
+                    component.field6 = value;
                 }
                 if (obj.GetStringCount(7) == 1)
                 {
                     var value = obj.GetString(7);
                     update.Field7 = new Option<string>(value);
-                    component.Field7 = value;
+                    Generated.Improbable.Gdk.Tests.ExhaustiveSingular.ReferenceTypeProviders.Field7Provider.Set(component.field7Handle, value);                
                 }
                 if (obj.GetUint32Count(8) == 1)
                 {
                     var value = obj.GetUint32(8);
                     update.Field8 = new Option<uint>(value);
-                    component.Field8 = value;
+                    component.field8 = value;
                 }
                 if (obj.GetUint64Count(9) == 1)
                 {
                     var value = obj.GetUint64(9);
                     update.Field9 = new Option<ulong>(value);
-                    component.Field9 = value;
+                    component.field9 = value;
                 }
                 if (obj.GetSint32Count(10) == 1)
                 {
                     var value = obj.GetSint32(10);
                     update.Field10 = new Option<int>(value);
-                    component.Field10 = value;
+                    component.field10 = value;
                 }
                 if (obj.GetSint64Count(11) == 1)
                 {
                     var value = obj.GetSint64(11);
                     update.Field11 = new Option<long>(value);
-                    component.Field11 = value;
+                    component.field11 = value;
                 }
                 if (obj.GetFixed32Count(12) == 1)
                 {
                     var value = obj.GetFixed32(12);
                     update.Field12 = new Option<uint>(value);
-                    component.Field12 = value;
+                    component.field12 = value;
                 }
                 if (obj.GetFixed64Count(13) == 1)
                 {
                     var value = obj.GetFixed64(13);
                     update.Field13 = new Option<ulong>(value);
-                    component.Field13 = value;
+                    component.field13 = value;
                 }
                 if (obj.GetSfixed32Count(14) == 1)
                 {
                     var value = obj.GetSfixed32(14);
                     update.Field14 = new Option<int>(value);
-                    component.Field14 = value;
+                    component.field14 = value;
                 }
                 if (obj.GetSfixed64Count(15) == 1)
                 {
                     var value = obj.GetSfixed64(15);
                     update.Field15 = new Option<long>(value);
-                    component.Field15 = value;
+                    component.field15 = value;
                 }
                 if (obj.GetEntityIdCount(16) == 1)
                 {
                     var value = obj.GetEntityId(16);
                     update.Field16 = new Option<global::Improbable.Worker.EntityId>(value);
-                    component.Field16 = value;
+                    component.field16 = value;
                 }
                 if (obj.GetObjectCount(17) == 1)
                 {
                     var value = global::Generated.Improbable.Gdk.Tests.SomeType.Serialization.Deserialize(obj.GetObject(17));
                     update.Field17 = new Option<global::Generated.Improbable.Gdk.Tests.SomeType>(value);
-                    component.Field17 = value;
+                    component.field17 = value;
                 }
                 return update;
             }

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingularTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingularTranslation.cs
@@ -46,7 +46,6 @@ namespace Generated.Improbable.Gdk.Tests
                 }
 
                 var data = global::Generated.Improbable.Gdk.Tests.SpatialOSExhaustiveSingular.Serialization.Deserialize(op.Data.SchemaData.Value.GetFields(), World);
-                data.DirtyBit = false;
                 entityManager.AddComponentData(entity, data);
                 entityManager.AddComponentData(entity, new NotAuthoritative<SpatialOSExhaustiveSingular>());
 

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/NestedComponent.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/NestedComponent.cs
@@ -48,8 +48,8 @@ namespace Generated.Improbable.Gdk.Tests
             {
                 var component = new SpatialOSNestedComponent();
 
+                component.nestedType = global::Generated.Improbable.Gdk.Tests.TypeName.Serialization.Deserialize(obj.GetObject(1));
 
-                component.NestedType = global::Generated.Improbable.Gdk.Tests.TypeName.Serialization.Deserialize(obj.GetObject(1));
                 return component;
             }
 
@@ -60,7 +60,7 @@ namespace Generated.Improbable.Gdk.Tests
                 {
                     var value = global::Generated.Improbable.Gdk.Tests.TypeName.Serialization.Deserialize(obj.GetObject(1));
                     update.NestedType = new Option<global::Generated.Improbable.Gdk.Tests.TypeName>(value);
-                    component.NestedType = value;
+                    component.nestedType = value;
                 }
                 return update;
             }

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/NestedComponent.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/NestedComponent.cs
@@ -12,7 +12,7 @@ namespace Generated.Improbable.Gdk.Tests
         public uint ComponentId => 20152;
 
         public BlittableBool DirtyBit { get; set; }
-        private global::Generated.Improbable.Gdk.Tests.TypeName nestedType;
+        internal global::Generated.Improbable.Gdk.Tests.TypeName nestedType;
 
         public global::Generated.Improbable.Gdk.Tests.TypeName NestedType
         {

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/NestedComponentTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/NestedComponentTranslation.cs
@@ -44,7 +44,6 @@ namespace Generated.Improbable.Gdk.Tests
                 }
 
                 var data = global::Generated.Improbable.Gdk.Tests.SpatialOSNestedComponent.Serialization.Deserialize(op.Data.SchemaData.Value.GetFields(), World);
-                data.DirtyBit = false;
                 entityManager.AddComponentData(entity, data);
                 entityManager.AddComponentData(entity, new NotAuthoritative<SpatialOSNestedComponent>());
 

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/ConnectionTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/ConnectionTranslation.cs
@@ -45,7 +45,6 @@ namespace Generated.Improbable.Gdk.Tests.AlternateSchemaSyntax
                 }
 
                 var data = global::Generated.Improbable.Gdk.Tests.AlternateSchemaSyntax.SpatialOSConnection.Serialization.Deserialize(op.Data.SchemaData.Value.GetFields(), World);
-                data.DirtyBit = false;
                 entityManager.AddComponentData(entity, data);
                 entityManager.AddComponentData(entity, new NotAuthoritative<SpatialOSConnection>());
 

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponent.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponent.cs
@@ -104,16 +104,16 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
             {
                 var component = new SpatialOSBlittableComponent();
 
+                component.boolField = obj.GetBool(1);
 
-                component.BoolField = obj.GetBool(1);
+                component.intField = obj.GetInt32(2);
 
-                component.IntField = obj.GetInt32(2);
+                component.longField = obj.GetInt64(3);
 
-                component.LongField = obj.GetInt64(3);
+                component.floatField = obj.GetFloat(4);
 
-                component.FloatField = obj.GetFloat(4);
+                component.doubleField = obj.GetDouble(5);
 
-                component.DoubleField = obj.GetDouble(5);
                 return component;
             }
 
@@ -124,31 +124,31 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
                 {
                     var value = obj.GetBool(1);
                     update.BoolField = new Option<BlittableBool>(value);
-                    component.BoolField = value;
+                    component.boolField = value;
                 }
                 if (obj.GetInt32Count(2) == 1)
                 {
                     var value = obj.GetInt32(2);
                     update.IntField = new Option<int>(value);
-                    component.IntField = value;
+                    component.intField = value;
                 }
                 if (obj.GetInt64Count(3) == 1)
                 {
                     var value = obj.GetInt64(3);
                     update.LongField = new Option<long>(value);
-                    component.LongField = value;
+                    component.longField = value;
                 }
                 if (obj.GetFloatCount(4) == 1)
                 {
                     var value = obj.GetFloat(4);
                     update.FloatField = new Option<float>(value);
-                    component.FloatField = value;
+                    component.floatField = value;
                 }
                 if (obj.GetDoubleCount(5) == 1)
                 {
                     var value = obj.GetDouble(5);
                     update.DoubleField = new Option<double>(value);
-                    component.DoubleField = value;
+                    component.doubleField = value;
                 }
                 return update;
             }

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponent.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponent.cs
@@ -12,7 +12,7 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
         public uint ComponentId => 1001;
 
         public BlittableBool DirtyBit { get; set; }
-        private BlittableBool boolField;
+        internal BlittableBool boolField;
 
         public BlittableBool BoolField
         {
@@ -23,7 +23,7 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
                 boolField = value;
             }
         }
-        private int intField;
+        internal int intField;
 
         public int IntField
         {
@@ -34,7 +34,7 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
                 intField = value;
             }
         }
-        private long longField;
+        internal long longField;
 
         public long LongField
         {
@@ -45,7 +45,7 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
                 longField = value;
             }
         }
-        private float floatField;
+        internal float floatField;
 
         public float FloatField
         {
@@ -56,7 +56,7 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
                 floatField = value;
             }
         }
-        private double doubleField;
+        internal double doubleField;
 
         public double DoubleField
         {

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentTranslation.cs
@@ -50,7 +50,6 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
                 }
 
                 var data = global::Generated.Improbable.Gdk.Tests.BlittableTypes.SpatialOSBlittableComponent.Serialization.Deserialize(op.Data.SchemaData.Value.GetFields(), World);
-                data.DirtyBit = false;
                 entityManager.AddComponentData(entity, data);
                 entityManager.AddComponentData(entity, new NotAuthoritative<SpatialOSBlittableComponent>());
 

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsTranslation.cs
@@ -44,7 +44,6 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 }
 
                 var data = global::Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.SpatialOSComponentWithNoFields.Serialization.Deserialize(op.Data.SchemaData.Value.GetFields(), World);
-                data.DirtyBit = false;
                 entityManager.AddComponentData(entity, data);
                 entityManager.AddComponentData(entity, new NotAuthoritative<SpatialOSComponentWithNoFields>());
 

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsTranslation.cs
@@ -46,7 +46,6 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 }
 
                 var data = global::Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.SpatialOSComponentWithNoFieldsWithCommands.Serialization.Deserialize(op.Data.SchemaData.Value.GetFields(), World);
-                data.DirtyBit = false;
                 entityManager.AddComponentData(entity, data);
                 entityManager.AddComponentData(entity, new NotAuthoritative<SpatialOSComponentWithNoFieldsWithCommands>());
 

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEventsTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEventsTranslation.cs
@@ -45,7 +45,6 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 }
 
                 var data = global::Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.SpatialOSComponentWithNoFieldsWithEvents.Serialization.Deserialize(op.Data.SchemaData.Value.GetFields(), World);
-                data.DirtyBit = false;
                 entityManager.AddComponentData(entity, data);
                 entityManager.AddComponentData(entity, new NotAuthoritative<SpatialOSComponentWithNoFieldsWithEvents>());
 

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponent.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponent.cs
@@ -186,27 +186,26 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
             {
                 var component = new SpatialOSNonBlittableComponent();
 
+                component.boolField = obj.GetBool(1);
 
-                component.BoolField = obj.GetBool(1);
+                component.intField = obj.GetInt32(2);
 
-                component.IntField = obj.GetInt32(2);
+                component.longField = obj.GetInt64(3);
 
-                component.LongField = obj.GetInt64(3);
+                component.floatField = obj.GetFloat(4);
 
-                component.FloatField = obj.GetFloat(4);
+                component.doubleField = obj.GetDouble(5);
 
-                component.DoubleField = obj.GetDouble(5);
                 component.stringFieldHandle = Generated.Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.StringFieldProvider.Allocate(world);
+                Generated.Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.StringFieldProvider.Set(component.stringFieldHandle, obj.GetString(6));                
 
-                component.StringField = obj.GetString(6);
                 component.optionalFieldHandle = Generated.Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.OptionalFieldProvider.Allocate(world);
-
                 if (obj.GetInt32Count(7) == 1)
                 {
                     component.OptionalField = obj.GetInt32(7);
                 }
-                component.listFieldHandle = Generated.Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.ListFieldProvider.Allocate(world);
 
+                component.listFieldHandle = Generated.Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.ListFieldProvider.Allocate(world);
                 var listField = new global::System.Collections.Generic.List<int>();
                 Generated.Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.ListFieldProvider.Set(component.listFieldHandle, listField);
                 for (var i = 0; i < obj.GetInt32Count(8); i++)
@@ -214,8 +213,8 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                     listField.Add(obj.IndexInt32(8, (uint) i));
                 }
 
-                component.mapFieldHandle = Generated.Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.MapFieldProvider.Allocate(world);
 
+                component.mapFieldHandle = Generated.Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.MapFieldProvider.Allocate(world);
                 {
                     var mapField = new global::System.Collections.Generic.Dictionary<int,string>();
                     Generated.Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.MapFieldProvider.Set(component.mapFieldHandle, mapField);
@@ -228,6 +227,7 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                         mapField.Add(key, value);
                     }
                 }
+
                 return component;
             }
 
@@ -238,37 +238,37 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                 {
                     var value = obj.GetBool(1);
                     update.BoolField = new Option<BlittableBool>(value);
-                    component.BoolField = value;
+                    component.boolField = value;
                 }
                 if (obj.GetInt32Count(2) == 1)
                 {
                     var value = obj.GetInt32(2);
                     update.IntField = new Option<int>(value);
-                    component.IntField = value;
+                    component.intField = value;
                 }
                 if (obj.GetInt64Count(3) == 1)
                 {
                     var value = obj.GetInt64(3);
                     update.LongField = new Option<long>(value);
-                    component.LongField = value;
+                    component.longField = value;
                 }
                 if (obj.GetFloatCount(4) == 1)
                 {
                     var value = obj.GetFloat(4);
                     update.FloatField = new Option<float>(value);
-                    component.FloatField = value;
+                    component.floatField = value;
                 }
                 if (obj.GetDoubleCount(5) == 1)
                 {
                     var value = obj.GetDouble(5);
                     update.DoubleField = new Option<double>(value);
-                    component.DoubleField = value;
+                    component.doubleField = value;
                 }
                 if (obj.GetStringCount(6) == 1)
                 {
                     var value = obj.GetString(6);
                     update.StringField = new Option<string>(value);
-                    component.StringField = value;
+                    Generated.Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.StringFieldProvider.Set(component.stringFieldHandle, value);                
                 }
                 if (obj.GetInt32Count(7) == 1)
                 {

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponent.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponent.cs
@@ -202,7 +202,7 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                 component.optionalFieldHandle = Generated.Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.OptionalFieldProvider.Allocate(world);
                 if (obj.GetInt32Count(7) == 1)
                 {
-                    component.OptionalField = obj.GetInt32(7);
+                    Generated.Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.OptionalFieldProvider.Set(component.optionalFieldHandle, obj.GetInt32(7));                
                 }
 
                 component.listFieldHandle = Generated.Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.ListFieldProvider.Allocate(world);
@@ -274,7 +274,7 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                 {
                     var value = obj.GetInt32(7);
                     update.OptionalField = new Option<global::System.Nullable<int>>(value);
-                    component.OptionalField = value;
+                    Generated.Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.OptionalFieldProvider.Set(component.optionalFieldHandle, value);                
                 }
                 {
                     var listSize = obj.GetInt32Count(8);

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponent.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponent.cs
@@ -12,7 +12,7 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
         public uint ComponentId => 1002;
 
         public BlittableBool DirtyBit { get; set; }
-        private BlittableBool boolField;
+        internal BlittableBool boolField;
 
         public BlittableBool BoolField
         {
@@ -23,7 +23,7 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                 boolField = value;
             }
         }
-        private int intField;
+        internal int intField;
 
         public int IntField
         {
@@ -34,7 +34,7 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                 intField = value;
             }
         }
-        private long longField;
+        internal long longField;
 
         public long LongField
         {
@@ -45,7 +45,7 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                 longField = value;
             }
         }
-        private float floatField;
+        internal float floatField;
 
         public float FloatField
         {
@@ -56,7 +56,7 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                 floatField = value;
             }
         }
-        private double doubleField;
+        internal double doubleField;
 
         public double DoubleField
         {

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponent.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponent.cs
@@ -207,7 +207,8 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                 }
                 component.listFieldHandle = Generated.Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.ListFieldProvider.Allocate(world);
 
-                var listField = component.ListField = new global::System.Collections.Generic.List<int>();
+                var listField = new global::System.Collections.Generic.List<int>();
+                Generated.Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.ListFieldProvider.Set(component.listFieldHandle, listField);
                 for (var i = 0; i < obj.GetInt32Count(8); i++)
                 {
                     listField.Add(obj.IndexInt32(8, (uint) i));
@@ -216,7 +217,8 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                 component.mapFieldHandle = Generated.Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.MapFieldProvider.Allocate(world);
 
                 {
-                    var mapField = component.MapField = new global::System.Collections.Generic.Dictionary<int,string>();
+                    var mapField = new global::System.Collections.Generic.Dictionary<int,string>();
+                    Generated.Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReferenceTypeProviders.MapFieldProvider.Set(component.mapFieldHandle, mapField);
                     var mapSize = obj.GetObjectCount(9);
                     for (var i = 0; i < mapSize; i++)
                     {

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentTranslation.cs
@@ -54,7 +54,6 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                 }
 
                 var data = global::Generated.Improbable.Gdk.Tests.NonblittableTypes.SpatialOSNonBlittableComponent.Serialization.Deserialize(op.Data.SchemaData.Value.GetFields(), World);
-                data.DirtyBit = false;
                 entityManager.AddComponentData(entity, data);
                 entityManager.AddComponentData(entity, new NotAuthoritative<SpatialOSNonBlittableComponent>());
 

--- a/workers/unity/Packages/com.improbable.gdk.core/Systems/SpatialOSReceiveSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Systems/SpatialOSReceiveSystem.cs
@@ -94,9 +94,9 @@ namespace Improbable.Gdk.Core
             });
             EntityManager.AddComponentData(entity, new NewlyAddedSpatialOSEntity());
 
-            foreach (var AddCommandCompoent in AddAllCommandComponents)
+            foreach (var addCommandComponentAction in AddAllCommandComponents)
             {
-                AddCommandCompoent(entity);
+                addCommandComponentAction(entity);
             }
 
             WorldCommands.AddWorldCommandRequesters(World, EntityManager, entity);


### PR DESCRIPTION
#### Description
This PR contains some small optimisations to `OnAddComponent` and `OnComponentUpdate`. Instead of using the public setter for the data properties, we make the backing internal and write directly to those.

This avoids a function call per field per deserialization attempt and a DirtyBit set.

We can also remove the `DirtyBit = false` after those method calls. 

This comes at the cost of a small codegen complexity increase (which I desperately want to cleanup soon ™️ )
#### Tests
Added debug logs in code gen - the dirty bit was false after hitting the deserialise functions always.
#### Documentation
N/A - internal impl
#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
@zeroZshadow 