### PR TITLE
Removing WorldCommandRequesters from worker entity when disconnected

### DIFF
--- a/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands.cs
@@ -45,6 +45,14 @@ namespace Improbable.Gdk.Core.Commands
             manager.AddComponentData(entity, entityQuerySender);
         }
 
+        internal static void RemoveWorldCommandRequesters(EntityManager manager, Unity.Entities.Entity entity)
+        {
+            manager.RemoveComponent<CreateEntity.CommandSender>(entity);
+            manager.RemoveComponent<DeleteEntity.CommandSender>(entity);
+            manager.RemoveComponent<ReserveEntityIds.CommandSender>(entity);
+            manager.RemoveComponent<EntityQuery.CommandSender>(entity);
+        }
+
         internal static void DeallocateWorldCommandRequesters(EntityManager manager, Unity.Entities.Entity entity)
         {
             var createEntityData = manager.GetComponentData<CreateEntity.CommandSender>(entity);
@@ -125,7 +133,7 @@ namespace Improbable.Gdk.Core.Commands
                 {
                     if (!Storage.TryGetValue(handle, out var value))
                     {
-                        throw new ArgumentException($"UpdatesProvider does not contain handle {handle}");
+                        throw new ArgumentException($"RequestsProvider does not contain handle {handle}");
                     }
 
                     return value;
@@ -135,7 +143,7 @@ namespace Improbable.Gdk.Core.Commands
                 {
                     if (!Storage.ContainsKey(handle))
                     {
-                        throw new ArgumentException($"UpdatesProvider does not contain handle {handle}");
+                        throw new ArgumentException($"RequestsProvider does not contain handle {handle}");
                     }
 
                     Storage[handle] = value;
@@ -190,7 +198,7 @@ namespace Improbable.Gdk.Core.Commands
                 {
                     if (!Storage.TryGetValue(handle, out var value))
                     {
-                        throw new ArgumentException($"UpdatesProvider does not contain handle {handle}");
+                        throw new ArgumentException($"ResponsesProvider does not contain handle {handle}");
                     }
 
                     return value;
@@ -200,7 +208,7 @@ namespace Improbable.Gdk.Core.Commands
                 {
                     if (!Storage.ContainsKey(handle))
                     {
-                        throw new ArgumentException($"UpdatesProvider does not contain handle {handle}");
+                        throw new ArgumentException($"ResponsesProvider does not contain handle {handle}");
                     }
 
                     Storage[handle] = value;
@@ -305,7 +313,7 @@ namespace Improbable.Gdk.Core.Commands
                 {
                     if (!Storage.TryGetValue(handle, out var value))
                     {
-                        throw new ArgumentException($"UpdatesProvider does not contain handle {handle}");
+                        throw new ArgumentException($"RequestsProvider does not contain handle {handle}");
                     }
 
                     return value;
@@ -315,7 +323,7 @@ namespace Improbable.Gdk.Core.Commands
                 {
                     if (!Storage.ContainsKey(handle))
                     {
-                        throw new ArgumentException($"UpdatesProvider does not contain handle {handle}");
+                        throw new ArgumentException($"RequestsProvider does not contain handle {handle}");
                     }
 
                     Storage[handle] = value;
@@ -370,7 +378,7 @@ namespace Improbable.Gdk.Core.Commands
                 {
                     if (!Storage.TryGetValue(handle, out var value))
                     {
-                        throw new ArgumentException($"UpdatesProvider does not contain handle {handle}");
+                        throw new ArgumentException($"ResponsesProvider does not contain handle {handle}");
                     }
 
                     return value;
@@ -380,7 +388,7 @@ namespace Improbable.Gdk.Core.Commands
                 {
                     if (!Storage.ContainsKey(handle))
                     {
-                        throw new ArgumentException($"UpdatesProvider does not contain handle {handle}");
+                        throw new ArgumentException($"ResponsesProvider does not contain handle {handle}");
                     }
 
                     Storage[handle] = value;
@@ -485,7 +493,7 @@ namespace Improbable.Gdk.Core.Commands
                 {
                     if (!Storage.TryGetValue(handle, out var value))
                     {
-                        throw new ArgumentException($"UpdatesProvider does not contain handle {handle}");
+                        throw new ArgumentException($"RequestsProvider does not contain handle {handle}");
                     }
 
                     return value;
@@ -495,7 +503,7 @@ namespace Improbable.Gdk.Core.Commands
                 {
                     if (!Storage.ContainsKey(handle))
                     {
-                        throw new ArgumentException($"UpdatesProvider does not contain handle {handle}");
+                        throw new ArgumentException($"RequestsProvider does not contain handle {handle}");
                     }
 
                     Storage[handle] = value;
@@ -550,7 +558,7 @@ namespace Improbable.Gdk.Core.Commands
                 {
                     if (!Storage.TryGetValue(handle, out var value))
                     {
-                        throw new ArgumentException($"UpdatesProvider does not contain handle {handle}");
+                        throw new ArgumentException($"ResponsesProvider does not contain handle {handle}");
                     }
 
                     return value;
@@ -560,7 +568,7 @@ namespace Improbable.Gdk.Core.Commands
                 {
                     if (!Storage.ContainsKey(handle))
                     {
-                        throw new ArgumentException($"UpdatesProvider does not contain handle {handle}");
+                        throw new ArgumentException($"ResponsesProvider does not contain handle {handle}");
                     }
 
                     Storage[handle] = value;
@@ -665,7 +673,7 @@ namespace Improbable.Gdk.Core.Commands
                 {
                     if (!Storage.TryGetValue(handle, out var value))
                     {
-                        throw new ArgumentException($"UpdatesProvider does not contain handle {handle}");
+                        throw new ArgumentException($"RequestsProvider does not contain handle {handle}");
                     }
 
                     return value;
@@ -675,7 +683,7 @@ namespace Improbable.Gdk.Core.Commands
                 {
                     if (!Storage.ContainsKey(handle))
                     {
-                        throw new ArgumentException($"UpdatesProvider does not contain handle {handle}");
+                        throw new ArgumentException($"RequestsProvider does not contain handle {handle}");
                     }
 
                     Storage[handle] = value;
@@ -730,7 +738,7 @@ namespace Improbable.Gdk.Core.Commands
                 {
                     if (!Storage.TryGetValue(handle, out var value))
                     {
-                        throw new ArgumentException($"UpdatesProvider does not contain handle {handle}");
+                        throw new ArgumentException($"ResponsesProvider does not contain handle {handle}");
                     }
 
                     return value;
@@ -740,7 +748,7 @@ namespace Improbable.Gdk.Core.Commands
                 {
                     if (!Storage.ContainsKey(handle))
                     {
-                        throw new ArgumentException($"UpdatesProvider does not contain handle {handle}");
+                        throw new ArgumentException($"ResponsesProvider does not contain handle {handle}");
                     }
 
                     Storage[handle] = value;

--- a/workers/unity/Packages/com.improbable.gdk.core/Systems/SpatialOSReceiveSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Systems/SpatialOSReceiveSystem.cs
@@ -122,6 +122,7 @@ namespace Improbable.Gdk.Core
         private void OnDisconnect(DisconnectOp op)
         {
             WorldCommands.DeallocateWorldCommandRequesters(EntityManager, worker.WorkerEntity);
+            WorldCommands.RemoveWorldCommandRequesters(EntityManager, worker.WorkerEntity);
             EntityManager.AddSharedComponentData(worker.WorkerEntity,
                 new OnDisconnected { ReasonForDisconnect = op.Reason });
         }


### PR DESCRIPTION
This fixes the `ArgumentException: UpdatesProvider does not contain handle 0` exception that was seen when losing connection.
Fix copy paste errors in Provider logs