### PR TITLE
Docs: Open Unity before running spatial.

### DIFF
--- a/docs/setup-and-installing.md
+++ b/docs/setup-and-installing.md
@@ -13,13 +13,13 @@
 
 1. Clone the repository: `git clone git@github.com:spatialos/UnityGDK.git`  or `git clone  https://github.com/spatialos/UnityGDK.git`
 
-2. Run `bash prepare-workspace.sh`.
+1. Run `bash prepare-workspace.sh`.
+
+1. Launch the Unity Editor and open the Unity project located at`UnityGDK\workers\unity`.
 
 1. Run `spatial local launch`.
 
-1. Open the `workers/unity` project in your Unity Editor.
-
-1. In the Editor, open **Assets** > **Playground** > **Scenes** > **SampleScene**.
+1. In the Unity Editor, open **Assets** > **Playground** > **Scenes** > **SampleScene**.
 
 ## Full version
 
@@ -86,12 +86,12 @@ Currently, you can try this out using the `Playground`.
 
 #### 2. Run the `Playground` locally using SpatialOS
 
+1. Open Unity and open the Unity project located at`UnityGDK\workers\unity`.
+<br>This causes Unity to generate a Visual Studio solution, `unity.sln`, within `UnityGDK/workers/unity`. It also runs `spatial auth login`, which may open browser window prompting you to login to your SpatialOS account. If this happens please login.
+
 1. In the same terminal window, run `spatial local launch`.
 <br>This launches a SpatialOS deployment locally. You can open the [Inspector](https://docs.improbable.io/reference/13.0/shared/glossary#inspector) and see what’s happening in the game.
     > **It’s done when:** You see `SpatialOS ready. Access the Inspector at http://localhost:21000/inspector` printed in your console output.
-
-1. Open Unity, and open the `unity` project.
-<br>This causes Unity to generate a Visual Studio solution, `unity.sln`, within `UnityGDK/workers/unity`.
 
 1. In the Unity Editor's Project window, open **Assets** > **Playground** > **Scenes** > **SampleScene**.
 

--- a/docs/setup-and-installing.md
+++ b/docs/setup-and-installing.md
@@ -87,7 +87,7 @@ Currently, you can try this out using the `Playground`.
 #### 2. Run the `Playground` locally using SpatialOS
 
 1. Open Unity and open the Unity project located at`UnityGDK\workers\unity`.
-<br>This causes Unity to generate a Visual Studio solution, `unity.sln`, within `UnityGDK/workers/unity`. It also runs `spatial auth login`, which may open browser window prompting you to login to your SpatialOS account. If this happens please login.
+<br>Unity will automatically download several required SpatialOS libraries. Unity may open a browser window prompting you to login to your SpatialOS account. If this happens, please login. This will only happen the first time you open you project, or if the version of the required libraries changes.
 
 1. In the same terminal window, run `spatial local launch`.
 <br>This launches a SpatialOS deployment locally. You can open the [Inspector](https://docs.improbable.io/reference/13.0/shared/glossary#inspector) and see what’s happening in the game.


### PR DESCRIPTION
#### Description
A docs changes that instructs users to open Unity prior to running `spatial local launch`. This is necessitated by changes to our build scripts.
#### Tests
Tested the negative and positive use cases manually.
#### Documentation
This is documentation bro.