### PR TITLE
UTY-595: Upgrade to Bridge v2

### DIFF
--- a/cloud_launch.json
+++ b/cloud_launch.json
@@ -1,5 +1,5 @@
 {
-  "template": "small",
+  "template": "small_bridge_v2",
   "world": {
     "chunkEdgeLengthMeters": 50,
     "snapshots": {

--- a/default_launch.json
+++ b/default_launch.json
@@ -1,5 +1,5 @@
 {
-  "template": "small",
+  "template": "small_bridge_v2",
   "world": {
     "chunkEdgeLengthMeters": 50,
     "snapshots": {

--- a/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/BufferedTransform.cs
+++ b/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Components/BufferedTransform.cs
@@ -1,4 +1,5 @@
 using Generated.Improbable.Transform;
+using Improbable.Gdk.Core;
 using UnityEngine;
 
 namespace Improbable.Gdk.TransformSynchronization
@@ -7,6 +8,7 @@ namespace Improbable.Gdk.TransformSynchronization
     {
         public System.Collections.Generic.List<SpatialOSTransform> TransformUpdates;
         public SpatialOSTransform LastTransformSnapshot;
+        public BlittableBool IsInitialised;
 
         public BufferedTransform()
         {

--- a/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/ApplyTransformUpdatesSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/ApplyTransformUpdatesSystem.cs
@@ -14,6 +14,7 @@ namespace Improbable.Gdk.TransformSynchronization
             [ReadOnly] public ComponentDataArray<SpatialOSTransform.ReceivedUpdates> TransformUpdate;
             public ComponentArray<BufferedTransform> BufferedTransform;
             [ReadOnly] public ComponentDataArray<NotAuthoritative<SpatialOSTransform>> TransformAuthority;
+            [ReadOnly] public ComponentDataArray<SpatialOSTransform> Transform;
         }
 
         [Inject] private TransformUpdateData transformUpdateData;
@@ -23,7 +24,15 @@ namespace Improbable.Gdk.TransformSynchronization
             for (var i = 0; i < transformUpdateData.Length; i++)
             {
                 var transformUpdates = transformUpdateData.TransformUpdate[i].Updates;
-                var lastTransformSnapshot = transformUpdateData.BufferedTransform[i].LastTransformSnapshot;
+                var bufferedTransform = transformUpdateData.BufferedTransform[i];
+                var lastTransformSnapshot = bufferedTransform.LastTransformSnapshot;
+
+                if (!bufferedTransform.IsInitialised)
+                {
+                    lastTransformSnapshot = transformUpdateData.Transform[i];
+                    bufferedTransform.IsInitialised = true;
+                }
+
                 foreach (var update in transformUpdates)
                 {
                     if (update.Location.HasValue)


### PR DESCRIPTION
#### Description
Upgraded to Bridge v2 in both current configurations. Also fixed a strange bug that presented itself whereby `BufferdTransform.LastTransformSnapshot` was uninitialised - so if you received an update with no location or rotation you would end up with bogus data being propagated to the interpolation system. 
#### Tests
1. Ran local deployment
2. Ran cloud deployment, connected client and ran around.
3. @DanailPenev Said he had tested mobile with bridge v2
#### Documentation
N/A - not necessary
#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
@samiwh 