### PR TITLE
Pass in command contexts

### DIFF
--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentCommandPayloads.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentCommandPayloads.cs
@@ -22,12 +22,14 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
                 public global::Generated.Improbable.Gdk.Tests.BlittableTypes.FirstCommandRequest Payload { get; internal set; }
                 public uint? TimeoutMillis { get; internal set; }
                 public bool AllowShortCircuiting { get; internal set; }
+                public System.Object Context { get; internal set; }
             }
 
             public static Request CreateRequest(EntityId targetEntityId,
                 global::Generated.Improbable.Gdk.Tests.BlittableTypes.FirstCommandRequest request,
                 uint? timeoutMillis = null,
-                bool allowShortCircuiting = false)
+                bool allowShortCircuiting = false,
+                System.Object context = null)
             {
                 return new Request
                 {
@@ -35,6 +37,7 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
                     Payload = request,
                     TimeoutMillis = timeoutMillis,
                     AllowShortCircuiting = allowShortCircuiting,
+                    Context = context
                 };
             }
 
@@ -122,12 +125,14 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
                 public global::Generated.Improbable.Gdk.Tests.BlittableTypes.SecondCommandRequest Payload { get; internal set; }
                 public uint? TimeoutMillis { get; internal set; }
                 public bool AllowShortCircuiting { get; internal set; }
+                public System.Object Context { get; internal set; }
             }
 
             public static Request CreateRequest(EntityId targetEntityId,
                 global::Generated.Improbable.Gdk.Tests.BlittableTypes.SecondCommandRequest request,
                 uint? timeoutMillis = null,
-                bool allowShortCircuiting = false)
+                bool allowShortCircuiting = false,
+                System.Object context = null)
             {
                 return new Request
                 {
@@ -135,6 +140,7 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
                     Payload = request,
                     TimeoutMillis = timeoutMillis,
                     AllowShortCircuiting = allowShortCircuiting,
+                    Context = context
                 };
             }
 

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentCommandPayloads.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentCommandPayloads.cs
@@ -23,6 +23,7 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
                 public uint? TimeoutMillis { get; internal set; }
                 public bool AllowShortCircuiting { get; internal set; }
                 public System.Object Context { get; internal set; }
+                public long RequestId { get; internal set; }
             }
 
             public static Request CreateRequest(EntityId targetEntityId,
@@ -37,7 +38,8 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
                     Payload = request,
                     TimeoutMillis = timeoutMillis,
                     AllowShortCircuiting = allowShortCircuiting,
-                    Context = context
+                    Context = context,
+                    RequestId = global::Improbable.Gdk.Core.CommandRequestIdGenerator.GetNext(),
                 };
             }
 
@@ -98,18 +100,24 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
                 public StatusCode StatusCode { get; }
                 public global::Generated.Improbable.Gdk.Tests.BlittableTypes.FirstCommandResponse? ResponsePayload { get; }
                 public global::Generated.Improbable.Gdk.Tests.BlittableTypes.FirstCommandRequest RequestPayload { get; }
+                public System.Object Context { get; }
+                public long RequestId { get; }
 
                 public ReceivedResponse(EntityId entityId,
                     string message,
                     StatusCode statusCode,
                     global::Generated.Improbable.Gdk.Tests.BlittableTypes.FirstCommandResponse? response,
-                    global::Generated.Improbable.Gdk.Tests.BlittableTypes.FirstCommandRequest request)
+                    global::Generated.Improbable.Gdk.Tests.BlittableTypes.FirstCommandRequest request,
+                    System.Object context,
+                    long requestId)
                 {
                     EntityId = entityId;
                     Message = message;
                     StatusCode = statusCode;
                     ResponsePayload = response;
                     RequestPayload = request;
+                    Context = context;
+                    RequestId = requestId;
                 }
             }
         }
@@ -126,6 +134,7 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
                 public uint? TimeoutMillis { get; internal set; }
                 public bool AllowShortCircuiting { get; internal set; }
                 public System.Object Context { get; internal set; }
+                public long RequestId { get; internal set; }
             }
 
             public static Request CreateRequest(EntityId targetEntityId,
@@ -140,7 +149,8 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
                     Payload = request,
                     TimeoutMillis = timeoutMillis,
                     AllowShortCircuiting = allowShortCircuiting,
-                    Context = context
+                    Context = context,
+                    RequestId = global::Improbable.Gdk.Core.CommandRequestIdGenerator.GetNext(),
                 };
             }
 
@@ -201,18 +211,24 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
                 public StatusCode StatusCode { get; }
                 public global::Generated.Improbable.Gdk.Tests.BlittableTypes.SecondCommandResponse? ResponsePayload { get; }
                 public global::Generated.Improbable.Gdk.Tests.BlittableTypes.SecondCommandRequest RequestPayload { get; }
+                public System.Object Context { get; }
+                public long RequestId { get; }
 
                 public ReceivedResponse(EntityId entityId,
                     string message,
                     StatusCode statusCode,
                     global::Generated.Improbable.Gdk.Tests.BlittableTypes.SecondCommandResponse? response,
-                    global::Generated.Improbable.Gdk.Tests.BlittableTypes.SecondCommandRequest request)
+                    global::Generated.Improbable.Gdk.Tests.BlittableTypes.SecondCommandRequest request,
+                    System.Object context,
+                    long requestId)
                 {
                     EntityId = entityId;
                     Message = message;
                     StatusCode = statusCode;
                     ResponsePayload = response;
                     RequestPayload = request;
+                    Context = context;
+                    RequestId = requestId;
                 }
             }
         }

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentTranslation.cs
@@ -512,7 +512,9 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
                     op.Message,
                     op.StatusCode,
                     response,
-                    requestBundle.Request));
+                    requestBundle.Request,
+                    requestBundle.Context,
+                    requestBundle.RequestId));
             }
             private void OnSecondCommandRequest(CommandRequestOp op)
             {
@@ -588,7 +590,9 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
                     op.Message,
                     op.StatusCode,
                     response,
-                    requestBundle.Request));
+                    requestBundle.Request,
+                    requestBundle.Context,
+                    requestBundle.RequestId));
             }
         }
 
@@ -707,7 +711,7 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
                                 wrappedCommandRequest.AllowShortCircuiting ? ShortCircuitParameters : null);
 
                             firstCommandStorage.CommandRequestsInFlight[requestId.Id] =
-                                new CommandRequestStore<global::Generated.Improbable.Gdk.Tests.BlittableTypes.FirstCommandRequest>(entityArray[j], wrappedCommandRequest.Payload, null);
+                                new CommandRequestStore<global::Generated.Improbable.Gdk.Tests.BlittableTypes.FirstCommandRequest>(entityArray[j], wrappedCommandRequest.Payload, wrappedCommandRequest.Context, wrappedCommandRequest.RequestId);
                         }
 
                         requests.Clear();
@@ -780,7 +784,7 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
                                 wrappedCommandRequest.AllowShortCircuiting ? ShortCircuitParameters : null);
 
                             secondCommandStorage.CommandRequestsInFlight[requestId.Id] =
-                                new CommandRequestStore<global::Generated.Improbable.Gdk.Tests.BlittableTypes.SecondCommandRequest>(entityArray[j], wrappedCommandRequest.Payload, null);
+                                new CommandRequestStore<global::Generated.Improbable.Gdk.Tests.BlittableTypes.SecondCommandRequest>(entityArray[j], wrappedCommandRequest.Payload, wrappedCommandRequest.Context, wrappedCommandRequest.RequestId);
                         }
 
                         requests.Clear();

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsCommandPayloads.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsCommandPayloads.cs
@@ -22,12 +22,14 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 public global::Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.Empty Payload { get; internal set; }
                 public uint? TimeoutMillis { get; internal set; }
                 public bool AllowShortCircuiting { get; internal set; }
+                public System.Object Context { get; internal set; }
             }
 
             public static Request CreateRequest(EntityId targetEntityId,
                 global::Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.Empty request,
                 uint? timeoutMillis = null,
-                bool allowShortCircuiting = false)
+                bool allowShortCircuiting = false,
+                System.Object context = null)
             {
                 return new Request
                 {
@@ -35,6 +37,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                     Payload = request,
                     TimeoutMillis = timeoutMillis,
                     AllowShortCircuiting = allowShortCircuiting,
+                    Context = context
                 };
             }
 

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsCommandPayloads.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsCommandPayloads.cs
@@ -23,6 +23,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 public uint? TimeoutMillis { get; internal set; }
                 public bool AllowShortCircuiting { get; internal set; }
                 public System.Object Context { get; internal set; }
+                public long RequestId { get; internal set; }
             }
 
             public static Request CreateRequest(EntityId targetEntityId,
@@ -37,7 +38,8 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                     Payload = request,
                     TimeoutMillis = timeoutMillis,
                     AllowShortCircuiting = allowShortCircuiting,
-                    Context = context
+                    Context = context,
+                    RequestId = global::Improbable.Gdk.Core.CommandRequestIdGenerator.GetNext(),
                 };
             }
 
@@ -98,18 +100,24 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 public StatusCode StatusCode { get; }
                 public global::Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.Empty? ResponsePayload { get; }
                 public global::Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.Empty RequestPayload { get; }
+                public System.Object Context { get; }
+                public long RequestId { get; }
 
                 public ReceivedResponse(EntityId entityId,
                     string message,
                     StatusCode statusCode,
                     global::Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.Empty? response,
-                    global::Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.Empty request)
+                    global::Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.Empty request,
+                    System.Object context,
+                    long requestId)
                 {
                     EntityId = entityId;
                     Message = message;
                     StatusCode = statusCode;
                     ResponsePayload = response;
                     RequestPayload = request;
+                    Context = context;
+                    RequestId = requestId;
                 }
             }
         }

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsTranslation.cs
@@ -391,7 +391,9 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                     op.Message,
                     op.StatusCode,
                     response,
-                    requestBundle.Request));
+                    requestBundle.Request,
+                    requestBundle.Context,
+                    requestBundle.RequestId));
             }
         }
 
@@ -474,7 +476,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                                 wrappedCommandRequest.AllowShortCircuiting ? ShortCircuitParameters : null);
 
                             cmdStorage.CommandRequestsInFlight[requestId.Id] =
-                                new CommandRequestStore<global::Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.Empty>(entityArray[j], wrappedCommandRequest.Payload, null);
+                                new CommandRequestStore<global::Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.Empty>(entityArray[j], wrappedCommandRequest.Payload, wrappedCommandRequest.Context, wrappedCommandRequest.RequestId);
                         }
 
                         requests.Clear();

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentCommandPayloads.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentCommandPayloads.cs
@@ -23,6 +23,7 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                 public uint? TimeoutMillis { get; internal set; }
                 public bool AllowShortCircuiting { get; internal set; }
                 public System.Object Context { get; internal set; }
+                public long RequestId { get; internal set; }
             }
 
             public static Request CreateRequest(EntityId targetEntityId,
@@ -37,7 +38,8 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                     Payload = request,
                     TimeoutMillis = timeoutMillis,
                     AllowShortCircuiting = allowShortCircuiting,
-                    Context = context
+                    Context = context,
+                    RequestId = global::Improbable.Gdk.Core.CommandRequestIdGenerator.GetNext(),
                 };
             }
 
@@ -98,18 +100,24 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                 public StatusCode StatusCode { get; }
                 public global::Generated.Improbable.Gdk.Tests.NonblittableTypes.FirstCommandResponse? ResponsePayload { get; }
                 public global::Generated.Improbable.Gdk.Tests.NonblittableTypes.FirstCommandRequest RequestPayload { get; }
+                public System.Object Context { get; }
+                public long RequestId { get; }
 
                 public ReceivedResponse(EntityId entityId,
                     string message,
                     StatusCode statusCode,
                     global::Generated.Improbable.Gdk.Tests.NonblittableTypes.FirstCommandResponse? response,
-                    global::Generated.Improbable.Gdk.Tests.NonblittableTypes.FirstCommandRequest request)
+                    global::Generated.Improbable.Gdk.Tests.NonblittableTypes.FirstCommandRequest request,
+                    System.Object context,
+                    long requestId)
                 {
                     EntityId = entityId;
                     Message = message;
                     StatusCode = statusCode;
                     ResponsePayload = response;
                     RequestPayload = request;
+                    Context = context;
+                    RequestId = requestId;
                 }
             }
         }
@@ -126,6 +134,7 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                 public uint? TimeoutMillis { get; internal set; }
                 public bool AllowShortCircuiting { get; internal set; }
                 public System.Object Context { get; internal set; }
+                public long RequestId { get; internal set; }
             }
 
             public static Request CreateRequest(EntityId targetEntityId,
@@ -140,7 +149,8 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                     Payload = request,
                     TimeoutMillis = timeoutMillis,
                     AllowShortCircuiting = allowShortCircuiting,
-                    Context = context
+                    Context = context,
+                    RequestId = global::Improbable.Gdk.Core.CommandRequestIdGenerator.GetNext(),
                 };
             }
 
@@ -201,18 +211,24 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                 public StatusCode StatusCode { get; }
                 public global::Generated.Improbable.Gdk.Tests.NonblittableTypes.SecondCommandResponse? ResponsePayload { get; }
                 public global::Generated.Improbable.Gdk.Tests.NonblittableTypes.SecondCommandRequest RequestPayload { get; }
+                public System.Object Context { get; }
+                public long RequestId { get; }
 
                 public ReceivedResponse(EntityId entityId,
                     string message,
                     StatusCode statusCode,
                     global::Generated.Improbable.Gdk.Tests.NonblittableTypes.SecondCommandResponse? response,
-                    global::Generated.Improbable.Gdk.Tests.NonblittableTypes.SecondCommandRequest request)
+                    global::Generated.Improbable.Gdk.Tests.NonblittableTypes.SecondCommandRequest request,
+                    System.Object context,
+                    long requestId)
                 {
                     EntityId = entityId;
                     Message = message;
                     StatusCode = statusCode;
                     ResponsePayload = response;
                     RequestPayload = request;
+                    Context = context;
+                    RequestId = requestId;
                 }
             }
         }

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentCommandPayloads.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentCommandPayloads.cs
@@ -22,12 +22,14 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                 public global::Generated.Improbable.Gdk.Tests.NonblittableTypes.FirstCommandRequest Payload { get; internal set; }
                 public uint? TimeoutMillis { get; internal set; }
                 public bool AllowShortCircuiting { get; internal set; }
+                public System.Object Context { get; internal set; }
             }
 
             public static Request CreateRequest(EntityId targetEntityId,
                 global::Generated.Improbable.Gdk.Tests.NonblittableTypes.FirstCommandRequest request,
                 uint? timeoutMillis = null,
-                bool allowShortCircuiting = false)
+                bool allowShortCircuiting = false,
+                System.Object context = null)
             {
                 return new Request
                 {
@@ -35,6 +37,7 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                     Payload = request,
                     TimeoutMillis = timeoutMillis,
                     AllowShortCircuiting = allowShortCircuiting,
+                    Context = context
                 };
             }
 
@@ -122,12 +125,14 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                 public global::Generated.Improbable.Gdk.Tests.NonblittableTypes.SecondCommandRequest Payload { get; internal set; }
                 public uint? TimeoutMillis { get; internal set; }
                 public bool AllowShortCircuiting { get; internal set; }
+                public System.Object Context { get; internal set; }
             }
 
             public static Request CreateRequest(EntityId targetEntityId,
                 global::Generated.Improbable.Gdk.Tests.NonblittableTypes.SecondCommandRequest request,
                 uint? timeoutMillis = null,
-                bool allowShortCircuiting = false)
+                bool allowShortCircuiting = false,
+                System.Object context = null)
             {
                 return new Request
                 {
@@ -135,6 +140,7 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                     Payload = request,
                     TimeoutMillis = timeoutMillis,
                     AllowShortCircuiting = allowShortCircuiting,
+                    Context = context
                 };
             }
 

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentTranslation.cs
@@ -526,7 +526,9 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                     op.Message,
                     op.StatusCode,
                     response,
-                    requestBundle.Request));
+                    requestBundle.Request,
+                    requestBundle.Context,
+                    requestBundle.RequestId));
             }
             private void OnSecondCommandRequest(CommandRequestOp op)
             {
@@ -602,7 +604,9 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                     op.Message,
                     op.StatusCode,
                     response,
-                    requestBundle.Request));
+                    requestBundle.Request,
+                    requestBundle.Context,
+                    requestBundle.RequestId));
             }
         }
 
@@ -721,7 +725,7 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                                 wrappedCommandRequest.AllowShortCircuiting ? ShortCircuitParameters : null);
 
                             firstCommandStorage.CommandRequestsInFlight[requestId.Id] =
-                                new CommandRequestStore<global::Generated.Improbable.Gdk.Tests.NonblittableTypes.FirstCommandRequest>(entityArray[j], wrappedCommandRequest.Payload, null);
+                                new CommandRequestStore<global::Generated.Improbable.Gdk.Tests.NonblittableTypes.FirstCommandRequest>(entityArray[j], wrappedCommandRequest.Payload, wrappedCommandRequest.Context, wrappedCommandRequest.RequestId);
                         }
 
                         requests.Clear();
@@ -794,7 +798,7 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                                 wrappedCommandRequest.AllowShortCircuiting ? ShortCircuitParameters : null);
 
                             secondCommandStorage.CommandRequestsInFlight[requestId.Id] =
-                                new CommandRequestStore<global::Generated.Improbable.Gdk.Tests.NonblittableTypes.SecondCommandRequest>(entityArray[j], wrappedCommandRequest.Payload, null);
+                                new CommandRequestStore<global::Generated.Improbable.Gdk.Tests.NonblittableTypes.SecondCommandRequest>(entityArray[j], wrappedCommandRequest.Payload, wrappedCommandRequest.Context, wrappedCommandRequest.RequestId);
                         }
 
                         requests.Clear();

--- a/workers/unity/Packages/com.improbable.gdk.core/Commands/CommandStorage.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Commands/CommandStorage.cs
@@ -11,12 +11,14 @@ namespace Improbable.Gdk.Core.Commands
         public Entity Entity;
         public T Request;
         public object Context;
+        public long RequestId;
 
-        public CommandRequestStore(Entity entity, T request, object context)
+        public CommandRequestStore(Entity entity, T request, object context, long requestId)
         {
             Entity = entity;
             Request = request;
             Context = context;
+            RequestId = requestId;
         }
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands.cs
@@ -75,6 +75,7 @@ namespace Improbable.Gdk.Core.Commands
                 public Entity Entity;
                 public EntityId? EntityId;
                 public uint? TimeoutMillis;
+                public Object Context;
             }
 
             public struct ReceivedResponse
@@ -255,6 +256,7 @@ namespace Improbable.Gdk.Core.Commands
             {
                 public EntityId EntityId;
                 public uint? TimeoutMillis;
+                public Object Context;
             }
 
             public struct ReceivedResponse
@@ -435,6 +437,7 @@ namespace Improbable.Gdk.Core.Commands
             {
                 public uint NumberOfEntityIds;
                 public uint? TimeoutMillis;
+                public Object Context;
             }
 
             public struct ReceivedResponse
@@ -615,6 +618,7 @@ namespace Improbable.Gdk.Core.Commands
             {
                 public Improbable.Worker.Query.EntityQuery EntityQuery;
                 public uint? TimeoutMillis;
+                public Object Context;
             }
 
             public struct ReceivedResponse

--- a/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands.cs
@@ -70,12 +70,29 @@ namespace Improbable.Gdk.Core.Commands
 
         public static class CreateEntity
         {
+            /// <summary>
+            ///     Please do not use the default constructor. Use CreateRequest instead.
+            ///     Using CreateRequest will ensure a correctly formed structure.
+            /// </summary>
             public struct Request
             {
                 public Entity Entity;
                 public EntityId? EntityId;
                 public uint? TimeoutMillis;
                 public Object Context;
+                public long RequestId;
+            }
+
+            public static Request CreateRequest(Entity entity, EntityId? entityId = null, uint? timeoutMillis = null, Object context = null)
+            {
+                return new Request
+                {
+                    Entity = entity,
+                    EntityId = entityId,
+                    TimeoutMillis = timeoutMillis,
+                    Context = context,
+                    RequestId = CommandRequestIdGenerator.GetNext(),
+                };
             }
 
             public struct ReceivedResponse
@@ -83,12 +100,14 @@ namespace Improbable.Gdk.Core.Commands
                 public CreateEntityResponseOp Op { get; }
                 public Request RequestPayload { get; }
                 public object Context { get; }
+                public long RequestId { get; }
 
-                internal ReceivedResponse(CreateEntityResponseOp op, Request req, object context)
+                internal ReceivedResponse(CreateEntityResponseOp op, Request req, object context, long requestId)
                 {
                     Op = op;
                     RequestPayload = req;
                     Context = context;
+                    RequestId = requestId;
                 }
             }
 
@@ -252,11 +271,27 @@ namespace Improbable.Gdk.Core.Commands
 
         public static class DeleteEntity
         {
+            /// <summary>
+            ///     Please do not use the default constructor. Use CreateRequest instead.
+            ///     Using CreateRequest will ensure a correctly formed structure.
+            /// </summary>
             public struct Request
             {
                 public EntityId EntityId;
                 public uint? TimeoutMillis;
                 public Object Context;
+                public long RequestId;
+            }
+
+            public static Request CreateRequest(EntityId entityId, uint? timeoutMillis = null, Object context = null)
+            {
+                return new Request
+                {
+                    EntityId = entityId,
+                    TimeoutMillis = timeoutMillis,
+                    Context = context,
+                    RequestId = CommandRequestIdGenerator.GetNext(),
+                };
             }
 
             public struct ReceivedResponse
@@ -264,12 +299,14 @@ namespace Improbable.Gdk.Core.Commands
                 public DeleteEntityResponseOp Op { get; }
                 public Request RequestPayload { get; }
                 public object Context { get; }
+                public long RequestId { get; }
 
-                internal ReceivedResponse(DeleteEntityResponseOp op, Request req, object context)
+                internal ReceivedResponse(DeleteEntityResponseOp op, Request req, object context, long requestId)
                 {
                     Op = op;
                     RequestPayload = req;
                     Context = context;
+                    RequestId = requestId;
                 }
             }
 
@@ -433,11 +470,27 @@ namespace Improbable.Gdk.Core.Commands
 
         public static class ReserveEntityIds
         {
+            /// <summary>
+            ///     Please do not use the default constructor. Use CreateRequest instead.
+            ///     Using CreateRequest will ensure a correctly formed structure.
+            /// </summary>
             public struct Request
             {
                 public uint NumberOfEntityIds;
                 public uint? TimeoutMillis;
                 public Object Context;
+                public long RequestId;
+            }
+
+            public static Request CreateRequest(uint numberOfEntityIds, uint? timeoutMillis = null, Object context = null)
+            {
+                return new Request
+                {
+                    NumberOfEntityIds = numberOfEntityIds,
+                    TimeoutMillis = timeoutMillis,
+                    Context = context,
+                    RequestId = CommandRequestIdGenerator.GetNext(),
+                };
             }
 
             public struct ReceivedResponse
@@ -445,12 +498,14 @@ namespace Improbable.Gdk.Core.Commands
                 public ReserveEntityIdsResponseOp Op { get; }
                 public Request RequestPayload { get; }
                 public object Context { get; }
+                public long RequestId { get; }
 
-                internal ReceivedResponse(ReserveEntityIdsResponseOp op, Request req, object context)
+                internal ReceivedResponse(ReserveEntityIdsResponseOp op, Request req, object context, long requestId)
                 {
                     Op = op;
                     RequestPayload = req;
                     Context = context;
+                    RequestId = requestId;
                 }
             }
 
@@ -614,11 +669,27 @@ namespace Improbable.Gdk.Core.Commands
 
         public static class EntityQuery
         {
+            /// <summary>
+            ///     Please do not use the default constructor. Use CreateRequest instead.
+            ///     Using CreateRequest will ensure a correctly formed structure.
+            /// </summary>
             public struct Request
             {
                 public Improbable.Worker.Query.EntityQuery EntityQuery;
                 public uint? TimeoutMillis;
                 public Object Context;
+                public long RequestId;
+            }
+
+            public static Request CreateRequest(Improbable.Worker.Query.EntityQuery entityQuery, uint? timeoutMillis = null, Object context = null)
+            {
+                return new Request
+                {
+                    EntityQuery = entityQuery,
+                    TimeoutMillis = timeoutMillis,
+                    Context = context,
+                    RequestId = CommandRequestIdGenerator.GetNext(),
+                };
             }
 
             public struct ReceivedResponse
@@ -626,12 +697,14 @@ namespace Improbable.Gdk.Core.Commands
                 public EntityQueryResponseOp Op { get; }
                 public Request RequestPayload { get; }
                 public object Context { get; }
+                public long RequestId { get; }
 
-                internal ReceivedResponse(EntityQueryResponseOp op, Request req, object context)
+                internal ReceivedResponse(EntityQueryResponseOp op, Request req, object context, long requestId)
                 {
                     Op = op;
                     RequestPayload = req;
                     Context = context;
+                    RequestId = requestId;
                 }
             }
 

--- a/workers/unity/Packages/com.improbable.gdk.core/Systems/SpatialOSReceiveSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Systems/SpatialOSReceiveSystem.cs
@@ -245,7 +245,7 @@ namespace Improbable.Gdk.Core
             }
 
             responses.Add(
-                new WorldCommands.CreateEntity.ReceivedResponse(op, requestBundle.Request, requestBundle.Context));
+                new WorldCommands.CreateEntity.ReceivedResponse(op, requestBundle.Request, requestBundle.Context, requestBundle.RequestId));
         }
 
         private void OnDeleteEntityResponse(DeleteEntityResponseOp op)
@@ -288,7 +288,7 @@ namespace Improbable.Gdk.Core
             }
 
             responses.Add(
-                new WorldCommands.DeleteEntity.ReceivedResponse(op, requestBundle.Request, requestBundle.Context));
+                new WorldCommands.DeleteEntity.ReceivedResponse(op, requestBundle.Request, requestBundle.Context, requestBundle.RequestId));
         }
 
         private void OnReserveEntityIdsResponse(ReserveEntityIdsResponseOp op)
@@ -331,7 +331,7 @@ namespace Improbable.Gdk.Core
             }
 
             responses.Add(
-                new WorldCommands.ReserveEntityIds.ReceivedResponse(op, requestBundle.Request, requestBundle.Context));
+                new WorldCommands.ReserveEntityIds.ReceivedResponse(op, requestBundle.Request, requestBundle.Context, requestBundle.RequestId));
         }
 
         private void OnEntityQueryResponse(EntityQueryResponseOp op)
@@ -374,7 +374,7 @@ namespace Improbable.Gdk.Core
             }
 
             responses.Add(
-                new WorldCommands.EntityQuery.ReceivedResponse(op, requestBundle.Request, requestBundle.Context));
+                new WorldCommands.EntityQuery.ReceivedResponse(op, requestBundle.Request, requestBundle.Context, requestBundle.RequestId));
         }
 
         private void HandleException(Exception e)

--- a/workers/unity/Packages/com.improbable.gdk.core/Systems/WorldCommandsSendSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Systems/WorldCommandsSendSystem.cs
@@ -77,7 +77,7 @@ namespace Improbable.Gdk.Core
                 {
                     var reqId = worker.Connection.SendCreateEntityRequest(req.Entity, req.EntityId, req.TimeoutMillis);
                     createEntityStorage.CommandRequestsInFlight.Add(reqId.Id,
-                        new CommandRequestStore<WorldCommands.CreateEntity.Request>(entity, req, null));
+                        new CommandRequestStore<WorldCommands.CreateEntity.Request>(entity, req, req.Context));
                 }
 
                 sender.RequestsToSend.Clear();
@@ -91,7 +91,7 @@ namespace Improbable.Gdk.Core
                 {
                     var reqId = worker.Connection.SendDeleteEntityRequest(req.EntityId, req.TimeoutMillis);
                     deleteEntityStorage.CommandRequestsInFlight.Add(reqId.Id,
-                        new CommandRequestStore<WorldCommands.DeleteEntity.Request>(entity, req, null));
+                        new CommandRequestStore<WorldCommands.DeleteEntity.Request>(entity, req, req.Context));
                 }
 
                 sender.RequestsToSend.Clear();
@@ -106,7 +106,7 @@ namespace Improbable.Gdk.Core
                 {
                     var reqId = worker.Connection.SendReserveEntityIdsRequest(req.NumberOfEntityIds, req.TimeoutMillis);
                     reserveEntityIdsStorage.CommandRequestsInFlight.Add(reqId.Id,
-                        new CommandRequestStore<WorldCommands.ReserveEntityIds.Request>(entity, req, null));
+                        new CommandRequestStore<WorldCommands.ReserveEntityIds.Request>(entity, req, req.Context));
                 }
 
                 sender.RequestsToSend.Clear();
@@ -120,7 +120,7 @@ namespace Improbable.Gdk.Core
                 {
                     var reqId = worker.Connection.SendEntityQueryRequest(req.EntityQuery, req.TimeoutMillis);
                     entityQueryStorage.CommandRequestsInFlight.Add(reqId.Id,
-                        new CommandRequestStore<WorldCommands.EntityQuery.Request>(entity, req, null));
+                        new CommandRequestStore<WorldCommands.EntityQuery.Request>(entity, req, req.Context));
                 }
 
                 sender.RequestsToSend.Clear();

--- a/workers/unity/Packages/com.improbable.gdk.core/Systems/WorldCommandsSendSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Systems/WorldCommandsSendSystem.cs
@@ -77,7 +77,7 @@ namespace Improbable.Gdk.Core
                 {
                     var reqId = worker.Connection.SendCreateEntityRequest(req.Entity, req.EntityId, req.TimeoutMillis);
                     createEntityStorage.CommandRequestsInFlight.Add(reqId.Id,
-                        new CommandRequestStore<WorldCommands.CreateEntity.Request>(entity, req, req.Context));
+                        new CommandRequestStore<WorldCommands.CreateEntity.Request>(entity, req, req.Context, req.RequestId));
                 }
 
                 sender.RequestsToSend.Clear();
@@ -91,7 +91,7 @@ namespace Improbable.Gdk.Core
                 {
                     var reqId = worker.Connection.SendDeleteEntityRequest(req.EntityId, req.TimeoutMillis);
                     deleteEntityStorage.CommandRequestsInFlight.Add(reqId.Id,
-                        new CommandRequestStore<WorldCommands.DeleteEntity.Request>(entity, req, req.Context));
+                        new CommandRequestStore<WorldCommands.DeleteEntity.Request>(entity, req, req.Context, req.RequestId));
                 }
 
                 sender.RequestsToSend.Clear();
@@ -106,7 +106,7 @@ namespace Improbable.Gdk.Core
                 {
                     var reqId = worker.Connection.SendReserveEntityIdsRequest(req.NumberOfEntityIds, req.TimeoutMillis);
                     reserveEntityIdsStorage.CommandRequestsInFlight.Add(reqId.Id,
-                        new CommandRequestStore<WorldCommands.ReserveEntityIds.Request>(entity, req, req.Context));
+                        new CommandRequestStore<WorldCommands.ReserveEntityIds.Request>(entity, req, req.Context, req.RequestId));
                 }
 
                 sender.RequestsToSend.Clear();
@@ -120,7 +120,7 @@ namespace Improbable.Gdk.Core
                 {
                     var reqId = worker.Connection.SendEntityQueryRequest(req.EntityQuery, req.TimeoutMillis);
                     entityQueryStorage.CommandRequestsInFlight.Add(reqId.Id,
-                        new CommandRequestStore<WorldCommands.EntityQuery.Request>(entity, req, req.Context));
+                        new CommandRequestStore<WorldCommands.EntityQuery.Request>(entity, req, req.Context, req.RequestId));
                 }
 
                 sender.RequestsToSend.Clear();

--- a/workers/unity/Packages/com.improbable.gdk.core/Utility/CommandRequestIdGenerator.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Utility/CommandRequestIdGenerator.cs
@@ -1,0 +1,14 @@
+namespace Improbable.Gdk.Core
+{
+    public static class CommandRequestIdGenerator
+    {
+        private static long nextRequestId;
+
+        public static long GetNext()
+        {
+            nextRequestId++;
+
+            return nextRequestId;
+        }
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.core/Utility/CommandRequestIdGenerator.cs.meta
+++ b/workers/unity/Packages/com.improbable.gdk.core/Utility/CommandRequestIdGenerator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5f3cd6d3dad4d69429dc513a3fa9ecdf
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerCreation/HandleCreatePlayerRequestSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerCreation/HandleCreatePlayerRequestSystem.cs
@@ -23,16 +23,16 @@ namespace Improbable.Gdk.PlayerLifecycle
 
         [Inject] private CreatePlayerData createPlayerData;
 
-        private struct EntityCreationResponses
+        private struct EntityCreationResponseData
         {
             public readonly int Length;
             public ComponentDataArray<PlayerCreator.CommandResponders.CreatePlayer> CreatePlayerResponders;
             public ComponentDataArray<WorldCommands.CreateEntity.CommandResponses> CreateEntityResponses;
         }
 
-        [Inject] private EntityCreationResponses entityCreationResponseData;
+        [Inject] private EntityCreationResponseData entityCreationResponseData;
 
-        private class EntityCreationRequestContext
+        private class PlayerCreationRequestContext
         {
             public PlayerCreator.CreatePlayer.ReceivedRequest createPlayerRequest;
         }
@@ -54,14 +54,14 @@ namespace Improbable.Gdk.PlayerLifecycle
 
                     var playerEntity = PlayerLifecycleConfig.CreatePlayerEntityTemplate(request.CallerAttributeSet,
                         request.Payload.Position);
-                    createEntitySender.RequestsToSend.Add(new WorldCommands.CreateEntity.Request
-                    {
-                        Entity = playerEntity,
-                        Context = new EntityCreationRequestContext
+                    createEntitySender.RequestsToSend.Add(WorldCommands.CreateEntity.CreateRequest
+                    (
+                        playerEntity,
+                        context: new PlayerCreationRequestContext
                         {
                             createPlayerRequest = request
                         }
-                    });
+                    ));
                 }
 
                 createPlayerData.CreateEntitySender[i] = createEntitySender;
@@ -74,7 +74,7 @@ namespace Improbable.Gdk.PlayerLifecycle
 
                 foreach (var receivedResponse in entityCreationResponses.Responses)
                 {
-                    if (!(receivedResponse.Context is EntityCreationRequestContext requestContext))
+                    if (!(receivedResponse.Context is PlayerCreationRequestContext requestContext))
                     {
                         // Ignore non-player entity creation requests
                         continue;

--- a/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerCreation/HandleCreatePlayerRequestSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerCreation/HandleCreatePlayerRequestSystem.cs
@@ -2,8 +2,10 @@ using System;
 using Generated.Improbable.PlayerLifecycle;
 using Improbable.Gdk.Core;
 using Improbable.Gdk.Core.Commands;
+using Improbable.Worker.Core;
 using Unity.Collections;
 using Unity.Entities;
+using UnityEngine;
 
 namespace Improbable.Gdk.PlayerLifecycle
 {
@@ -13,19 +15,33 @@ namespace Improbable.Gdk.PlayerLifecycle
         private struct CreatePlayerData
         {
             public readonly int Length;
+
             [ReadOnly] public ComponentDataArray<PlayerCreator.CommandRequests.CreatePlayer> CreatePlayerRequests;
-            public ComponentDataArray<PlayerCreator.CommandResponders.CreatePlayer> CreatePlayerResponders;
+
             public ComponentDataArray<WorldCommands.CreateEntity.CommandSender> CreateEntitySender;
         }
 
         [Inject] private CreatePlayerData createPlayerData;
+
+        private struct EntityCreationResponses
+        {
+            public readonly int Length;
+            public ComponentDataArray<PlayerCreator.CommandResponders.CreatePlayer> CreatePlayerResponders;
+            public ComponentDataArray<WorldCommands.CreateEntity.CommandResponses> CreateEntityResponses;
+        }
+
+        [Inject] private EntityCreationResponses entityCreationResponseData;
+
+        private class EntityCreationRequestContext
+        {
+            public PlayerCreator.CreatePlayer.ReceivedRequest createPlayerRequest;
+        }
 
         protected override void OnUpdate()
         {
             for (var i = 0; i < createPlayerData.Length; i++)
             {
                 var requests = createPlayerData.CreatePlayerRequests[i].Requests;
-                var responder = createPlayerData.CreatePlayerResponders[i];
 
                 var createEntitySender = createPlayerData.CreateEntitySender[i];
 
@@ -40,15 +56,47 @@ namespace Improbable.Gdk.PlayerLifecycle
                         request.Payload.Position);
                     createEntitySender.RequestsToSend.Add(new WorldCommands.CreateEntity.Request
                     {
-                        Entity = playerEntity
+                        Entity = playerEntity,
+                        Context = new EntityCreationRequestContext
+                        {
+                            createPlayerRequest = request
+                        }
                     });
-
-                    responder.ResponsesToSend.Add(
-                        PlayerCreator.CreatePlayer.CreateResponse(request, new CreatePlayerResponseType()));
                 }
 
-                createPlayerData.CreatePlayerResponders[i] = responder;
                 createPlayerData.CreateEntitySender[i] = createEntitySender;
+            }
+
+            for (var i = 0; i < entityCreationResponseData.Length; ++i)
+            {
+                var entityCreationResponses = entityCreationResponseData.CreateEntityResponses[i];
+                var responder = entityCreationResponseData.CreatePlayerResponders[i];
+
+                foreach (var receivedResponse in entityCreationResponses.Responses)
+                {
+                    if (!(receivedResponse.Context is EntityCreationRequestContext requestContext))
+                    {
+                        // Ignore non-player entity creation requests
+                        continue;
+                    }
+
+                    var op = receivedResponse.Op;
+
+                    if (op.StatusCode != StatusCode.Success || !op.EntityId.HasValue)
+                    {
+                        responder.ResponsesToSend.Add(PlayerCreator.CreatePlayer
+                            .CreateResponseFailure(requestContext.createPlayerRequest,
+                                $"Failed to create player: \"{op.Message}\""));
+
+                        continue;
+                    }
+
+                    responder.ResponsesToSend.Add(PlayerCreator.CreatePlayer
+                        .CreateResponse(requestContext.createPlayerRequest, new CreatePlayerResponseType
+                        {
+                            CreatedEntityId = op.EntityId.Value
+                        }));
+                }
             }
         }
 

--- a/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerCreation/HandleCreatePlayerRequestSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerCreation/HandleCreatePlayerRequestSystem.cs
@@ -15,10 +15,8 @@ namespace Improbable.Gdk.PlayerLifecycle
         private struct CreatePlayerData
         {
             public readonly int Length;
-
             [ReadOnly] public ComponentDataArray<PlayerCreator.CommandRequests.CreatePlayer> CreatePlayerRequests;
-
-            public ComponentDataArray<WorldCommands.CreateEntity.CommandSender> CreateEntitySender;
+            [ReadOnly] public ComponentDataArray<WorldCommands.CreateEntity.CommandSender> CreateEntitySender;
         }
 
         [Inject] private CreatePlayerData createPlayerData;
@@ -26,8 +24,8 @@ namespace Improbable.Gdk.PlayerLifecycle
         private struct EntityCreationResponseData
         {
             public readonly int Length;
-            public ComponentDataArray<PlayerCreator.CommandResponders.CreatePlayer> CreatePlayerResponders;
-            public ComponentDataArray<WorldCommands.CreateEntity.CommandResponses> CreateEntityResponses;
+            [ReadOnly] public ComponentDataArray<WorldCommands.CreateEntity.CommandResponses> CreateEntityResponses;
+            [ReadOnly] public ComponentDataArray<PlayerCreator.CommandResponders.CreatePlayer> CreatePlayerResponders;
         }
 
         [Inject] private EntityCreationResponseData entityCreationResponseData;
@@ -42,7 +40,6 @@ namespace Improbable.Gdk.PlayerLifecycle
             for (var i = 0; i < createPlayerData.Length; i++)
             {
                 var requests = createPlayerData.CreatePlayerRequests[i].Requests;
-
                 var createEntitySender = createPlayerData.CreateEntitySender[i];
 
                 foreach (var request in requests)
@@ -63,8 +60,6 @@ namespace Improbable.Gdk.PlayerLifecycle
                         }
                     ));
                 }
-
-                createPlayerData.CreateEntitySender[i] = createEntitySender;
             }
 
             for (var i = 0; i < entityCreationResponseData.Length; ++i)

--- a/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerCreation/SendCreatePlayerRequestSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerCreation/SendCreatePlayerRequestSystem.cs
@@ -1,9 +1,10 @@
-using Generated.Improbable;
 using Generated.Improbable.PlayerLifecycle;
 using Improbable.Gdk.Core;
 using Improbable.Worker;
+using Improbable.Worker.Core;
 using Unity.Collections;
 using Unity.Entities;
+using UnityEngine;
 
 namespace Improbable.Gdk.PlayerLifecycle
 {
@@ -12,7 +13,7 @@ namespace Improbable.Gdk.PlayerLifecycle
     {
         private readonly EntityId playerCreatorEntityId = new EntityId(1);
 
-        private struct Data
+        private struct SendData
         {
             public readonly int Length;
             [ReadOnly] public ComponentDataArray<PlayerCreator.CommandSenders.CreatePlayer> RequestSenders;
@@ -20,13 +21,42 @@ namespace Improbable.Gdk.PlayerLifecycle
             [ReadOnly] public ComponentDataArray<OnConnected> DenotesJustConnected;
         }
 
-        [Inject] private Data data;
+        [Inject] private SendData sendData;
+
+        private struct ResponseData
+        {
+            public readonly int Length;
+            [ReadOnly] public ComponentDataArray<PlayerCreator.CommandResponses.CreatePlayer> Responses;
+            [ReadOnly] public ComponentDataArray<WorkerEntityTag> DenotesWorkerEntity;
+        }
+
+        [Inject] private ResponseData responseData;
 
         protected override void OnUpdate()
         {
-            var request = new CreatePlayerRequestType(new Vector3f(0, 0, 0));
-            data.RequestSenders[0].RequestsToSend
-                .Add(PlayerCreator.CreatePlayer.CreateRequest(playerCreatorEntityId, request));
+            for (var i = 0; i < sendData.Length; ++i)
+            {
+                var request = new CreatePlayerRequestType
+                {
+                    Position = new Generated.Improbable.Vector3f { X = 0, Y = 0, Z = 0 }
+                };
+
+                sendData.RequestSenders[i].RequestsToSend
+                    .Add(PlayerCreator.CreatePlayer.CreateRequest(playerCreatorEntityId, request));
+            }
+
+            for (var i = 0; i < responseData.Length; ++i)
+            {
+                foreach (var receivedResponse in responseData.Responses[i].Responses)
+                {
+                    Debug.Log($"Create player response code: {receivedResponse.StatusCode}");
+
+                    if (receivedResponse.StatusCode != StatusCode.Success)
+                    {
+                        Debug.LogError($"Create player failed: {receivedResponse.Message}");
+                    }
+                }
+            }
         }
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerCreation/SendCreatePlayerRequestSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerCreation/SendCreatePlayerRequestSystem.cs
@@ -1,4 +1,3 @@
-using System.Collections.Generic;
 using Generated.Improbable.PlayerLifecycle;
 using Improbable.Gdk.Core;
 using Improbable.Worker;
@@ -33,7 +32,6 @@ namespace Improbable.Gdk.PlayerLifecycle
 
         [Inject] private ResponseData responseData;
 
-        private readonly Dictionary<long, float> requestTimeMap = new Dictionary<long, float>();
         private ILogDispatcher logDispatcher;
 
         protected override void OnCreateManager(int capacity)
@@ -50,8 +48,6 @@ namespace Improbable.Gdk.PlayerLifecycle
                 var request = new CreatePlayerRequestType(new Generated.Improbable.Vector3f { X = 0, Y = 0, Z = 0 });
                 var createPlayerRequest = PlayerCreator.CreatePlayer.CreateRequest(playerCreatorEntityId, request);
 
-                requestTimeMap[createPlayerRequest.RequestId] = Time.realtimeSinceStartup;
-
                 sendData.RequestSenders[i].RequestsToSend
                     .Add(createPlayerRequest);
             }
@@ -61,22 +57,6 @@ namespace Improbable.Gdk.PlayerLifecycle
                 foreach (var receivedResponse in responseData.Responses[i].Responses)
                 {
                     var requestId = receivedResponse.RequestId;
-
-                    if (requestTimeMap.TryGetValue(requestId, out var requestTime))
-                    {
-                        requestTimeMap.Remove(requestId);
-
-                        logDispatcher.HandleLog(LogType.Log,
-                            new LogEvent(
-                                $"Time taken to be spawned : {Time.realtimeSinceStartup - requestTime:0.00}s."));
-
-                        continue;
-                    }
-                    else
-                    {
-                        logDispatcher.HandleLog(LogType.Error,
-                            new LogEvent($"Failed to get timing information for request with ID {requestId}."));
-                    }
 
                     if (receivedResponse.StatusCode != StatusCode.Success)
                     {

--- a/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerCreation/SendCreatePlayerRequestSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerCreation/SendCreatePlayerRequestSystem.cs
@@ -48,7 +48,6 @@ namespace Improbable.Gdk.PlayerLifecycle
             for (var i = 0; i < sendData.Length; ++i)
             {
                 var request = new CreatePlayerRequestType(new Generated.Improbable.Vector3f { X = 0, Y = 0, Z = 0 });
-
                 var createPlayerRequest = PlayerCreator.CreatePlayer.CreateRequest(playerCreatorEntityId, request);
 
                 requestTimeMap[createPlayerRequest.RequestId] = Time.realtimeSinceStartup;

--- a/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerHeartbeat/HandlePlayerHeartbeatResponseSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerHeartbeat/HandlePlayerHeartbeatResponseSystem.cs
@@ -57,10 +57,10 @@ namespace Improbable.Gdk.PlayerLifecycle
                             PlayerLifecycleConfig.MaxNumFailedPlayerHeartbeats)
                         {
                             Debug.LogFormat(Messages.DeletingPlayer, entityId);
-                            entityDeleteSender.RequestsToSend.Add(new WorldCommands.DeleteEntity.Request
-                            {
-                                EntityId = entityId,
-                            });
+                            entityDeleteSender.RequestsToSend.Add(WorldCommands.DeleteEntity.CreateRequest
+                            (
+                                entityId
+                            ));
                             data.WorldCommandSenders[i] = entityDeleteSender;
                         }
                     }

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityCommandPayloadGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityCommandPayloadGenerator.tt
@@ -29,6 +29,7 @@ namespace <#= qualifiedNamespace #>
                 public uint? TimeoutMillis { get; internal set; }
                 public bool AllowShortCircuiting { get; internal set; }
                 public System.Object Context { get; internal set; }
+                public long RequestId { get; internal set; }
             }
 
             public static Request CreateRequest(EntityId targetEntityId,
@@ -43,7 +44,8 @@ namespace <#= qualifiedNamespace #>
                     Payload = request,
                     TimeoutMillis = timeoutMillis,
                     AllowShortCircuiting = allowShortCircuiting,
-                    Context = context
+                    Context = context,
+                    RequestId = global::Improbable.Gdk.Core.CommandRequestIdGenerator.GetNext(),
                 };
             }
 
@@ -104,18 +106,24 @@ namespace <#= qualifiedNamespace #>
                 public StatusCode StatusCode { get; }
                 public <#= commandDetails.FqnResponseType #>? ResponsePayload { get; }
                 public <#= commandDetails.FqnRequestType #> RequestPayload { get; }
+                public System.Object Context { get; }
+                public long RequestId { get; }
 
                 public ReceivedResponse(EntityId entityId,
                     string message,
                     StatusCode statusCode,
                     <#= commandDetails.FqnResponseType #>? response,
-                    <#= commandDetails.FqnRequestType #> request)
+                    <#= commandDetails.FqnRequestType #> request,
+                    System.Object context,
+                    long requestId)
                 {
                     EntityId = entityId;
                     Message = message;
                     StatusCode = statusCode;
                     ResponsePayload = response;
                     RequestPayload = request;
+                    Context = context;
+                    RequestId = requestId;
                 }
             }
         }

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityCommandPayloadGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityCommandPayloadGenerator.tt
@@ -28,12 +28,14 @@ namespace <#= qualifiedNamespace #>
                 public <#= commandDetails.FqnRequestType #> Payload { get; internal set; }
                 public uint? TimeoutMillis { get; internal set; }
                 public bool AllowShortCircuiting { get; internal set; }
+                public System.Object Context { get; internal set; }
             }
 
             public static Request CreateRequest(EntityId targetEntityId,
                 <#= commandDetails.FqnRequestType #> request,
                 uint? timeoutMillis = null,
-                bool allowShortCircuiting = false)
+                bool allowShortCircuiting = false,
+                System.Object context = null)
             {
                 return new Request
                 {
@@ -41,6 +43,7 @@ namespace <#= qualifiedNamespace #>
                     Payload = request,
                     TimeoutMillis = timeoutMillis,
                     AllowShortCircuiting = allowShortCircuiting,
+                    Context = context
                 };
             }
 

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityComponentConversionGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityComponentConversionGenerator.tt
@@ -493,7 +493,9 @@ namespace <#= qualifiedNamespace #>
                     op.Message,
                     op.StatusCode,
                     response,
-                    requestBundle.Request));
+                    requestBundle.Request,
+                    requestBundle.Context,
+                    requestBundle.RequestId));
             }
 <# } #>
         }
@@ -616,7 +618,7 @@ for (var i = 0; i < commandDetailsList.Count; i++) {
                                 wrappedCommandRequest.AllowShortCircuiting ? ShortCircuitParameters : null);
 
                             <#= commandDetails.CamelCaseCommandName #>Storage.CommandRequestsInFlight[requestId.Id] =
-                                new CommandRequestStore<<#= commandDetails.FqnRequestType #>>(entityArray[j], wrappedCommandRequest.Payload, null);
+                                new CommandRequestStore<<#= commandDetails.FqnRequestType #>>(entityArray[j], wrappedCommandRequest.Payload, wrappedCommandRequest.Context, wrappedCommandRequest.RequestId);
                         }
 
                         requests.Clear();


### PR DESCRIPTION
Also use them for player requests

**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Passes command contexts to commands so responders can use them
Adds an example case

#### Tests
Automated testing hard to do without mock connection
Tested locally using player creation

#### Documentation
Missing

#### Primary reviewers
@jamiebrynes7 @MPeti01 