### PR TITLE
UTY-1106: replace entity index with entity

### DIFF
--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveBlittableSingularGameObjectComponentDispatcher.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveBlittableSingularGameObjectComponentDispatcher.cs
@@ -59,7 +59,7 @@ namespace Generated.Improbable.Gdk.Tests
             private const uint componentId = 197720;
             private static readonly InjectableId readerWriterInjectableId = new InjectableId(InjectableType.ReaderWriter, componentId);
 
-            public override void MarkComponentsAddedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkComponentsAddedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityToManagers)
             {
                 if (ComponentAddedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -69,12 +69,12 @@ namespace Generated.Improbable.Gdk.Tests
                 var entities = ComponentAddedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i]];
+                    var activationManager = entityToManagers[entities[i]];
                     activationManager.AddComponent(componentId);
                 }
             }
 
-            public override void MarkComponentsRemovedForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkComponentsRemovedForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityToManagers)
             {
                 if (ComponentRemovedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -84,12 +84,12 @@ namespace Generated.Improbable.Gdk.Tests
                 var entities = ComponentRemovedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i]];
+                    var activationManager = entityToManagers[entities[i]];
                     activationManager.RemoveComponent(componentId);
                 }
             }
 
-            public override void MarkAuthorityGainedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkAuthorityGainedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityToManagers)
             {
                 if (AuthorityGainedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -100,7 +100,7 @@ namespace Generated.Improbable.Gdk.Tests
                 var entities = AuthorityGainedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i]];
+                    var activationManager = entityToManagers[entities[i]];
                     // Call once except if flip-flopped back to starting state
                     if (IsFirstAuthChange(Authority.Authoritative, authoritiesChangedTags[i]))
                     {
@@ -109,7 +109,7 @@ namespace Generated.Improbable.Gdk.Tests
                 }
             }
 
-            public override void MarkAuthorityLostForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkAuthorityLostForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityToManagers)
             {
                 if (AuthorityLostComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -120,7 +120,7 @@ namespace Generated.Improbable.Gdk.Tests
                 var entities = AuthorityLostComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i]];
+                    var activationManager = entityToManagers[entities[i]];
                     // Call once except if flip-flopped back to starting state
                     if (IsFirstAuthChange(Authority.NotAuthoritative, authoritiesChangedTags[i]))
                     {
@@ -129,7 +129,7 @@ namespace Generated.Improbable.Gdk.Tests
                 }
             }
 
-            public override void InvokeOnComponentUpdateCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnComponentUpdateCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 if (ComponentsUpdatedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -140,7 +140,7 @@ namespace Generated.Improbable.Gdk.Tests
                 var updateLists = ComponentsUpdatedComponentGroup.GetComponentDataArray<Generated.Improbable.Gdk.Tests.ExhaustiveBlittableSingular.ReceivedUpdates>();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i]];
+                    var injectableStore = entityToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -157,20 +157,20 @@ namespace Generated.Improbable.Gdk.Tests
                 }
             }
 
-            public override void InvokeOnEventCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnEventCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
             }
 
-            public override void InvokeOnCommandRequestCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnCommandRequestCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
             }
 
-            public override void InvokeOnCommandResponseCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnCommandResponseCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 // TODO UTY-542 Command Response handlers
             }
 
-            public override void InvokeOnAuthorityGainedCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityGainedCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 if (AuthorityGainedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -183,7 +183,7 @@ namespace Generated.Improbable.Gdk.Tests
                 // Call once on all entities unless they flip-flopped back into the state they started in
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i]];
+                    var injectableStore = entityToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -199,7 +199,7 @@ namespace Generated.Improbable.Gdk.Tests
                 }
             }
 
-            public override void InvokeOnAuthorityLostCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityLostCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 if (AuthorityLostComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -212,7 +212,7 @@ namespace Generated.Improbable.Gdk.Tests
                 // Call once on all entities unless they flip-flopped back into the state they started in
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i]];
+                    var injectableStore = entityToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -240,7 +240,7 @@ namespace Generated.Improbable.Gdk.Tests
                 return false;
             }
 
-            public override void InvokeOnAuthorityLossImminentCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityLossImminentCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 if (AuthorityLossImminentComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -252,7 +252,7 @@ namespace Generated.Improbable.Gdk.Tests
                 // Call once on all entities
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i]];
+                    var injectableStore = entityToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveBlittableSingularGameObjectComponentDispatcher.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveBlittableSingularGameObjectComponentDispatcher.cs
@@ -59,7 +59,7 @@ namespace Generated.Improbable.Gdk.Tests
             private const uint componentId = 197720;
             private static readonly InjectableId readerWriterInjectableId = new InjectableId(InjectableType.ReaderWriter, componentId);
 
-            public override void MarkComponentsAddedForActivation(Dictionary<int, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkComponentsAddedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
             {
                 if (ComponentAddedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -69,12 +69,12 @@ namespace Generated.Improbable.Gdk.Tests
                 var entities = ComponentAddedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i].Index];
+                    var activationManager = entityIndexToManagers[entities[i]];
                     activationManager.AddComponent(componentId);
                 }
             }
 
-            public override void MarkComponentsRemovedForDeactivation(Dictionary<int, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkComponentsRemovedForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
             {
                 if (ComponentRemovedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -84,12 +84,12 @@ namespace Generated.Improbable.Gdk.Tests
                 var entities = ComponentRemovedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i].Index];
+                    var activationManager = entityIndexToManagers[entities[i]];
                     activationManager.RemoveComponent(componentId);
                 }
             }
 
-            public override void MarkAuthorityGainedForActivation(Dictionary<int, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkAuthorityGainedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
             {
                 if (AuthorityGainedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -100,7 +100,7 @@ namespace Generated.Improbable.Gdk.Tests
                 var entities = AuthorityGainedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i].Index];
+                    var activationManager = entityIndexToManagers[entities[i]];
                     // Call once except if flip-flopped back to starting state
                     if (IsFirstAuthChange(Authority.Authoritative, authoritiesChangedTags[i]))
                     {
@@ -109,7 +109,7 @@ namespace Generated.Improbable.Gdk.Tests
                 }
             }
 
-            public override void MarkAuthorityLostForDeactivation(Dictionary<int, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkAuthorityLostForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
             {
                 if (AuthorityLostComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -120,7 +120,7 @@ namespace Generated.Improbable.Gdk.Tests
                 var entities = AuthorityLostComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i].Index];
+                    var activationManager = entityIndexToManagers[entities[i]];
                     // Call once except if flip-flopped back to starting state
                     if (IsFirstAuthChange(Authority.NotAuthoritative, authoritiesChangedTags[i]))
                     {
@@ -129,7 +129,7 @@ namespace Generated.Improbable.Gdk.Tests
                 }
             }
 
-            public override void InvokeOnComponentUpdateCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnComponentUpdateCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 if (ComponentsUpdatedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -140,7 +140,7 @@ namespace Generated.Improbable.Gdk.Tests
                 var updateLists = ComponentsUpdatedComponentGroup.GetComponentDataArray<Generated.Improbable.Gdk.Tests.ExhaustiveBlittableSingular.ReceivedUpdates>();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i].Index];
+                    var injectableStore = entityIndexToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -157,20 +157,20 @@ namespace Generated.Improbable.Gdk.Tests
                 }
             }
 
-            public override void InvokeOnEventCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnEventCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
             }
 
-            public override void InvokeOnCommandRequestCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnCommandRequestCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
             }
 
-            public override void InvokeOnCommandResponseCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnCommandResponseCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 // TODO UTY-542 Command Response handlers
             }
 
-            public override void InvokeOnAuthorityGainedCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityGainedCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 if (AuthorityGainedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -183,7 +183,7 @@ namespace Generated.Improbable.Gdk.Tests
                 // Call once on all entities unless they flip-flopped back into the state they started in
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i].Index];
+                    var injectableStore = entityIndexToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -199,7 +199,7 @@ namespace Generated.Improbable.Gdk.Tests
                 }
             }
 
-            public override void InvokeOnAuthorityLostCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityLostCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 if (AuthorityLostComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -212,7 +212,7 @@ namespace Generated.Improbable.Gdk.Tests
                 // Call once on all entities unless they flip-flopped back into the state they started in
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i].Index];
+                    var injectableStore = entityIndexToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -240,7 +240,7 @@ namespace Generated.Improbable.Gdk.Tests
                 return false;
             }
 
-            public override void InvokeOnAuthorityLossImminentCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityLossImminentCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 if (AuthorityLossImminentComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -252,7 +252,7 @@ namespace Generated.Improbable.Gdk.Tests
                 // Call once on all entities
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i].Index];
+                    var injectableStore = entityIndexToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKeyGameObjectComponentDispatcher.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKeyGameObjectComponentDispatcher.cs
@@ -59,7 +59,7 @@ namespace Generated.Improbable.Gdk.Tests
             private const uint componentId = 197719;
             private static readonly InjectableId readerWriterInjectableId = new InjectableId(InjectableType.ReaderWriter, componentId);
 
-            public override void MarkComponentsAddedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkComponentsAddedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityToManagers)
             {
                 if (ComponentAddedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -69,12 +69,12 @@ namespace Generated.Improbable.Gdk.Tests
                 var entities = ComponentAddedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i]];
+                    var activationManager = entityToManagers[entities[i]];
                     activationManager.AddComponent(componentId);
                 }
             }
 
-            public override void MarkComponentsRemovedForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkComponentsRemovedForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityToManagers)
             {
                 if (ComponentRemovedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -84,12 +84,12 @@ namespace Generated.Improbable.Gdk.Tests
                 var entities = ComponentRemovedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i]];
+                    var activationManager = entityToManagers[entities[i]];
                     activationManager.RemoveComponent(componentId);
                 }
             }
 
-            public override void MarkAuthorityGainedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkAuthorityGainedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityToManagers)
             {
                 if (AuthorityGainedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -100,7 +100,7 @@ namespace Generated.Improbable.Gdk.Tests
                 var entities = AuthorityGainedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i]];
+                    var activationManager = entityToManagers[entities[i]];
                     // Call once except if flip-flopped back to starting state
                     if (IsFirstAuthChange(Authority.Authoritative, authoritiesChangedTags[i]))
                     {
@@ -109,7 +109,7 @@ namespace Generated.Improbable.Gdk.Tests
                 }
             }
 
-            public override void MarkAuthorityLostForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkAuthorityLostForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityToManagers)
             {
                 if (AuthorityLostComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -120,7 +120,7 @@ namespace Generated.Improbable.Gdk.Tests
                 var entities = AuthorityLostComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i]];
+                    var activationManager = entityToManagers[entities[i]];
                     // Call once except if flip-flopped back to starting state
                     if (IsFirstAuthChange(Authority.NotAuthoritative, authoritiesChangedTags[i]))
                     {
@@ -129,7 +129,7 @@ namespace Generated.Improbable.Gdk.Tests
                 }
             }
 
-            public override void InvokeOnComponentUpdateCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnComponentUpdateCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 if (ComponentsUpdatedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -140,7 +140,7 @@ namespace Generated.Improbable.Gdk.Tests
                 var updateLists = ComponentsUpdatedComponentGroup.GetComponentDataArray<Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReceivedUpdates>();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i]];
+                    var injectableStore = entityToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -157,20 +157,20 @@ namespace Generated.Improbable.Gdk.Tests
                 }
             }
 
-            public override void InvokeOnEventCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnEventCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
             }
 
-            public override void InvokeOnCommandRequestCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnCommandRequestCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
             }
 
-            public override void InvokeOnCommandResponseCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnCommandResponseCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 // TODO UTY-542 Command Response handlers
             }
 
-            public override void InvokeOnAuthorityGainedCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityGainedCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 if (AuthorityGainedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -183,7 +183,7 @@ namespace Generated.Improbable.Gdk.Tests
                 // Call once on all entities unless they flip-flopped back into the state they started in
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i]];
+                    var injectableStore = entityToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -199,7 +199,7 @@ namespace Generated.Improbable.Gdk.Tests
                 }
             }
 
-            public override void InvokeOnAuthorityLostCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityLostCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 if (AuthorityLostComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -212,7 +212,7 @@ namespace Generated.Improbable.Gdk.Tests
                 // Call once on all entities unless they flip-flopped back into the state they started in
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i]];
+                    var injectableStore = entityToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -240,7 +240,7 @@ namespace Generated.Improbable.Gdk.Tests
                 return false;
             }
 
-            public override void InvokeOnAuthorityLossImminentCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityLossImminentCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 if (AuthorityLossImminentComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -252,7 +252,7 @@ namespace Generated.Improbable.Gdk.Tests
                 // Call once on all entities
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i]];
+                    var injectableStore = entityToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKeyGameObjectComponentDispatcher.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKeyGameObjectComponentDispatcher.cs
@@ -59,7 +59,7 @@ namespace Generated.Improbable.Gdk.Tests
             private const uint componentId = 197719;
             private static readonly InjectableId readerWriterInjectableId = new InjectableId(InjectableType.ReaderWriter, componentId);
 
-            public override void MarkComponentsAddedForActivation(Dictionary<int, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkComponentsAddedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
             {
                 if (ComponentAddedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -69,12 +69,12 @@ namespace Generated.Improbable.Gdk.Tests
                 var entities = ComponentAddedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i].Index];
+                    var activationManager = entityIndexToManagers[entities[i]];
                     activationManager.AddComponent(componentId);
                 }
             }
 
-            public override void MarkComponentsRemovedForDeactivation(Dictionary<int, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkComponentsRemovedForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
             {
                 if (ComponentRemovedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -84,12 +84,12 @@ namespace Generated.Improbable.Gdk.Tests
                 var entities = ComponentRemovedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i].Index];
+                    var activationManager = entityIndexToManagers[entities[i]];
                     activationManager.RemoveComponent(componentId);
                 }
             }
 
-            public override void MarkAuthorityGainedForActivation(Dictionary<int, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkAuthorityGainedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
             {
                 if (AuthorityGainedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -100,7 +100,7 @@ namespace Generated.Improbable.Gdk.Tests
                 var entities = AuthorityGainedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i].Index];
+                    var activationManager = entityIndexToManagers[entities[i]];
                     // Call once except if flip-flopped back to starting state
                     if (IsFirstAuthChange(Authority.Authoritative, authoritiesChangedTags[i]))
                     {
@@ -109,7 +109,7 @@ namespace Generated.Improbable.Gdk.Tests
                 }
             }
 
-            public override void MarkAuthorityLostForDeactivation(Dictionary<int, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkAuthorityLostForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
             {
                 if (AuthorityLostComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -120,7 +120,7 @@ namespace Generated.Improbable.Gdk.Tests
                 var entities = AuthorityLostComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i].Index];
+                    var activationManager = entityIndexToManagers[entities[i]];
                     // Call once except if flip-flopped back to starting state
                     if (IsFirstAuthChange(Authority.NotAuthoritative, authoritiesChangedTags[i]))
                     {
@@ -129,7 +129,7 @@ namespace Generated.Improbable.Gdk.Tests
                 }
             }
 
-            public override void InvokeOnComponentUpdateCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnComponentUpdateCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 if (ComponentsUpdatedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -140,7 +140,7 @@ namespace Generated.Improbable.Gdk.Tests
                 var updateLists = ComponentsUpdatedComponentGroup.GetComponentDataArray<Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.ReceivedUpdates>();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i].Index];
+                    var injectableStore = entityIndexToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -157,20 +157,20 @@ namespace Generated.Improbable.Gdk.Tests
                 }
             }
 
-            public override void InvokeOnEventCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnEventCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
             }
 
-            public override void InvokeOnCommandRequestCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnCommandRequestCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
             }
 
-            public override void InvokeOnCommandResponseCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnCommandResponseCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 // TODO UTY-542 Command Response handlers
             }
 
-            public override void InvokeOnAuthorityGainedCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityGainedCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 if (AuthorityGainedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -183,7 +183,7 @@ namespace Generated.Improbable.Gdk.Tests
                 // Call once on all entities unless they flip-flopped back into the state they started in
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i].Index];
+                    var injectableStore = entityIndexToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -199,7 +199,7 @@ namespace Generated.Improbable.Gdk.Tests
                 }
             }
 
-            public override void InvokeOnAuthorityLostCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityLostCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 if (AuthorityLostComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -212,7 +212,7 @@ namespace Generated.Improbable.Gdk.Tests
                 // Call once on all entities unless they flip-flopped back into the state they started in
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i].Index];
+                    var injectableStore = entityIndexToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -240,7 +240,7 @@ namespace Generated.Improbable.Gdk.Tests
                 return false;
             }
 
-            public override void InvokeOnAuthorityLossImminentCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityLossImminentCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 if (AuthorityLossImminentComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -252,7 +252,7 @@ namespace Generated.Improbable.Gdk.Tests
                 // Call once on all entities
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i].Index];
+                    var injectableStore = entityIndexToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValueGameObjectComponentDispatcher.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValueGameObjectComponentDispatcher.cs
@@ -59,7 +59,7 @@ namespace Generated.Improbable.Gdk.Tests
             private const uint componentId = 197718;
             private static readonly InjectableId readerWriterInjectableId = new InjectableId(InjectableType.ReaderWriter, componentId);
 
-            public override void MarkComponentsAddedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkComponentsAddedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityToManagers)
             {
                 if (ComponentAddedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -69,12 +69,12 @@ namespace Generated.Improbable.Gdk.Tests
                 var entities = ComponentAddedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i]];
+                    var activationManager = entityToManagers[entities[i]];
                     activationManager.AddComponent(componentId);
                 }
             }
 
-            public override void MarkComponentsRemovedForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkComponentsRemovedForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityToManagers)
             {
                 if (ComponentRemovedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -84,12 +84,12 @@ namespace Generated.Improbable.Gdk.Tests
                 var entities = ComponentRemovedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i]];
+                    var activationManager = entityToManagers[entities[i]];
                     activationManager.RemoveComponent(componentId);
                 }
             }
 
-            public override void MarkAuthorityGainedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkAuthorityGainedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityToManagers)
             {
                 if (AuthorityGainedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -100,7 +100,7 @@ namespace Generated.Improbable.Gdk.Tests
                 var entities = AuthorityGainedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i]];
+                    var activationManager = entityToManagers[entities[i]];
                     // Call once except if flip-flopped back to starting state
                     if (IsFirstAuthChange(Authority.Authoritative, authoritiesChangedTags[i]))
                     {
@@ -109,7 +109,7 @@ namespace Generated.Improbable.Gdk.Tests
                 }
             }
 
-            public override void MarkAuthorityLostForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkAuthorityLostForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityToManagers)
             {
                 if (AuthorityLostComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -120,7 +120,7 @@ namespace Generated.Improbable.Gdk.Tests
                 var entities = AuthorityLostComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i]];
+                    var activationManager = entityToManagers[entities[i]];
                     // Call once except if flip-flopped back to starting state
                     if (IsFirstAuthChange(Authority.NotAuthoritative, authoritiesChangedTags[i]))
                     {
@@ -129,7 +129,7 @@ namespace Generated.Improbable.Gdk.Tests
                 }
             }
 
-            public override void InvokeOnComponentUpdateCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnComponentUpdateCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 if (ComponentsUpdatedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -140,7 +140,7 @@ namespace Generated.Improbable.Gdk.Tests
                 var updateLists = ComponentsUpdatedComponentGroup.GetComponentDataArray<Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReceivedUpdates>();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i]];
+                    var injectableStore = entityToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -157,20 +157,20 @@ namespace Generated.Improbable.Gdk.Tests
                 }
             }
 
-            public override void InvokeOnEventCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnEventCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
             }
 
-            public override void InvokeOnCommandRequestCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnCommandRequestCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
             }
 
-            public override void InvokeOnCommandResponseCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnCommandResponseCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 // TODO UTY-542 Command Response handlers
             }
 
-            public override void InvokeOnAuthorityGainedCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityGainedCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 if (AuthorityGainedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -183,7 +183,7 @@ namespace Generated.Improbable.Gdk.Tests
                 // Call once on all entities unless they flip-flopped back into the state they started in
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i]];
+                    var injectableStore = entityToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -199,7 +199,7 @@ namespace Generated.Improbable.Gdk.Tests
                 }
             }
 
-            public override void InvokeOnAuthorityLostCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityLostCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 if (AuthorityLostComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -212,7 +212,7 @@ namespace Generated.Improbable.Gdk.Tests
                 // Call once on all entities unless they flip-flopped back into the state they started in
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i]];
+                    var injectableStore = entityToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -240,7 +240,7 @@ namespace Generated.Improbable.Gdk.Tests
                 return false;
             }
 
-            public override void InvokeOnAuthorityLossImminentCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityLossImminentCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 if (AuthorityLossImminentComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -252,7 +252,7 @@ namespace Generated.Improbable.Gdk.Tests
                 // Call once on all entities
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i]];
+                    var injectableStore = entityToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValueGameObjectComponentDispatcher.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValueGameObjectComponentDispatcher.cs
@@ -59,7 +59,7 @@ namespace Generated.Improbable.Gdk.Tests
             private const uint componentId = 197718;
             private static readonly InjectableId readerWriterInjectableId = new InjectableId(InjectableType.ReaderWriter, componentId);
 
-            public override void MarkComponentsAddedForActivation(Dictionary<int, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkComponentsAddedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
             {
                 if (ComponentAddedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -69,12 +69,12 @@ namespace Generated.Improbable.Gdk.Tests
                 var entities = ComponentAddedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i].Index];
+                    var activationManager = entityIndexToManagers[entities[i]];
                     activationManager.AddComponent(componentId);
                 }
             }
 
-            public override void MarkComponentsRemovedForDeactivation(Dictionary<int, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkComponentsRemovedForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
             {
                 if (ComponentRemovedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -84,12 +84,12 @@ namespace Generated.Improbable.Gdk.Tests
                 var entities = ComponentRemovedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i].Index];
+                    var activationManager = entityIndexToManagers[entities[i]];
                     activationManager.RemoveComponent(componentId);
                 }
             }
 
-            public override void MarkAuthorityGainedForActivation(Dictionary<int, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkAuthorityGainedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
             {
                 if (AuthorityGainedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -100,7 +100,7 @@ namespace Generated.Improbable.Gdk.Tests
                 var entities = AuthorityGainedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i].Index];
+                    var activationManager = entityIndexToManagers[entities[i]];
                     // Call once except if flip-flopped back to starting state
                     if (IsFirstAuthChange(Authority.Authoritative, authoritiesChangedTags[i]))
                     {
@@ -109,7 +109,7 @@ namespace Generated.Improbable.Gdk.Tests
                 }
             }
 
-            public override void MarkAuthorityLostForDeactivation(Dictionary<int, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkAuthorityLostForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
             {
                 if (AuthorityLostComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -120,7 +120,7 @@ namespace Generated.Improbable.Gdk.Tests
                 var entities = AuthorityLostComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i].Index];
+                    var activationManager = entityIndexToManagers[entities[i]];
                     // Call once except if flip-flopped back to starting state
                     if (IsFirstAuthChange(Authority.NotAuthoritative, authoritiesChangedTags[i]))
                     {
@@ -129,7 +129,7 @@ namespace Generated.Improbable.Gdk.Tests
                 }
             }
 
-            public override void InvokeOnComponentUpdateCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnComponentUpdateCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 if (ComponentsUpdatedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -140,7 +140,7 @@ namespace Generated.Improbable.Gdk.Tests
                 var updateLists = ComponentsUpdatedComponentGroup.GetComponentDataArray<Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.ReceivedUpdates>();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i].Index];
+                    var injectableStore = entityIndexToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -157,20 +157,20 @@ namespace Generated.Improbable.Gdk.Tests
                 }
             }
 
-            public override void InvokeOnEventCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnEventCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
             }
 
-            public override void InvokeOnCommandRequestCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnCommandRequestCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
             }
 
-            public override void InvokeOnCommandResponseCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnCommandResponseCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 // TODO UTY-542 Command Response handlers
             }
 
-            public override void InvokeOnAuthorityGainedCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityGainedCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 if (AuthorityGainedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -183,7 +183,7 @@ namespace Generated.Improbable.Gdk.Tests
                 // Call once on all entities unless they flip-flopped back into the state they started in
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i].Index];
+                    var injectableStore = entityIndexToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -199,7 +199,7 @@ namespace Generated.Improbable.Gdk.Tests
                 }
             }
 
-            public override void InvokeOnAuthorityLostCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityLostCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 if (AuthorityLostComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -212,7 +212,7 @@ namespace Generated.Improbable.Gdk.Tests
                 // Call once on all entities unless they flip-flopped back into the state they started in
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i].Index];
+                    var injectableStore = entityIndexToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -240,7 +240,7 @@ namespace Generated.Improbable.Gdk.Tests
                 return false;
             }
 
-            public override void InvokeOnAuthorityLossImminentCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityLossImminentCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 if (AuthorityLossImminentComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -252,7 +252,7 @@ namespace Generated.Improbable.Gdk.Tests
                 // Call once on all entities
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i].Index];
+                    var injectableStore = entityIndexToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptionalGameObjectComponentDispatcher.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptionalGameObjectComponentDispatcher.cs
@@ -59,7 +59,7 @@ namespace Generated.Improbable.Gdk.Tests
             private const uint componentId = 197716;
             private static readonly InjectableId readerWriterInjectableId = new InjectableId(InjectableType.ReaderWriter, componentId);
 
-            public override void MarkComponentsAddedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkComponentsAddedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityToManagers)
             {
                 if (ComponentAddedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -69,12 +69,12 @@ namespace Generated.Improbable.Gdk.Tests
                 var entities = ComponentAddedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i]];
+                    var activationManager = entityToManagers[entities[i]];
                     activationManager.AddComponent(componentId);
                 }
             }
 
-            public override void MarkComponentsRemovedForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkComponentsRemovedForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityToManagers)
             {
                 if (ComponentRemovedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -84,12 +84,12 @@ namespace Generated.Improbable.Gdk.Tests
                 var entities = ComponentRemovedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i]];
+                    var activationManager = entityToManagers[entities[i]];
                     activationManager.RemoveComponent(componentId);
                 }
             }
 
-            public override void MarkAuthorityGainedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkAuthorityGainedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityToManagers)
             {
                 if (AuthorityGainedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -100,7 +100,7 @@ namespace Generated.Improbable.Gdk.Tests
                 var entities = AuthorityGainedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i]];
+                    var activationManager = entityToManagers[entities[i]];
                     // Call once except if flip-flopped back to starting state
                     if (IsFirstAuthChange(Authority.Authoritative, authoritiesChangedTags[i]))
                     {
@@ -109,7 +109,7 @@ namespace Generated.Improbable.Gdk.Tests
                 }
             }
 
-            public override void MarkAuthorityLostForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkAuthorityLostForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityToManagers)
             {
                 if (AuthorityLostComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -120,7 +120,7 @@ namespace Generated.Improbable.Gdk.Tests
                 var entities = AuthorityLostComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i]];
+                    var activationManager = entityToManagers[entities[i]];
                     // Call once except if flip-flopped back to starting state
                     if (IsFirstAuthChange(Authority.NotAuthoritative, authoritiesChangedTags[i]))
                     {
@@ -129,7 +129,7 @@ namespace Generated.Improbable.Gdk.Tests
                 }
             }
 
-            public override void InvokeOnComponentUpdateCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnComponentUpdateCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 if (ComponentsUpdatedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -140,7 +140,7 @@ namespace Generated.Improbable.Gdk.Tests
                 var updateLists = ComponentsUpdatedComponentGroup.GetComponentDataArray<Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReceivedUpdates>();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i]];
+                    var injectableStore = entityToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -157,20 +157,20 @@ namespace Generated.Improbable.Gdk.Tests
                 }
             }
 
-            public override void InvokeOnEventCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnEventCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
             }
 
-            public override void InvokeOnCommandRequestCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnCommandRequestCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
             }
 
-            public override void InvokeOnCommandResponseCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnCommandResponseCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 // TODO UTY-542 Command Response handlers
             }
 
-            public override void InvokeOnAuthorityGainedCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityGainedCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 if (AuthorityGainedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -183,7 +183,7 @@ namespace Generated.Improbable.Gdk.Tests
                 // Call once on all entities unless they flip-flopped back into the state they started in
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i]];
+                    var injectableStore = entityToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -199,7 +199,7 @@ namespace Generated.Improbable.Gdk.Tests
                 }
             }
 
-            public override void InvokeOnAuthorityLostCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityLostCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 if (AuthorityLostComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -212,7 +212,7 @@ namespace Generated.Improbable.Gdk.Tests
                 // Call once on all entities unless they flip-flopped back into the state they started in
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i]];
+                    var injectableStore = entityToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -240,7 +240,7 @@ namespace Generated.Improbable.Gdk.Tests
                 return false;
             }
 
-            public override void InvokeOnAuthorityLossImminentCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityLossImminentCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 if (AuthorityLossImminentComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -252,7 +252,7 @@ namespace Generated.Improbable.Gdk.Tests
                 // Call once on all entities
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i]];
+                    var injectableStore = entityToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptionalGameObjectComponentDispatcher.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptionalGameObjectComponentDispatcher.cs
@@ -59,7 +59,7 @@ namespace Generated.Improbable.Gdk.Tests
             private const uint componentId = 197716;
             private static readonly InjectableId readerWriterInjectableId = new InjectableId(InjectableType.ReaderWriter, componentId);
 
-            public override void MarkComponentsAddedForActivation(Dictionary<int, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkComponentsAddedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
             {
                 if (ComponentAddedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -69,12 +69,12 @@ namespace Generated.Improbable.Gdk.Tests
                 var entities = ComponentAddedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i].Index];
+                    var activationManager = entityIndexToManagers[entities[i]];
                     activationManager.AddComponent(componentId);
                 }
             }
 
-            public override void MarkComponentsRemovedForDeactivation(Dictionary<int, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkComponentsRemovedForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
             {
                 if (ComponentRemovedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -84,12 +84,12 @@ namespace Generated.Improbable.Gdk.Tests
                 var entities = ComponentRemovedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i].Index];
+                    var activationManager = entityIndexToManagers[entities[i]];
                     activationManager.RemoveComponent(componentId);
                 }
             }
 
-            public override void MarkAuthorityGainedForActivation(Dictionary<int, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkAuthorityGainedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
             {
                 if (AuthorityGainedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -100,7 +100,7 @@ namespace Generated.Improbable.Gdk.Tests
                 var entities = AuthorityGainedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i].Index];
+                    var activationManager = entityIndexToManagers[entities[i]];
                     // Call once except if flip-flopped back to starting state
                     if (IsFirstAuthChange(Authority.Authoritative, authoritiesChangedTags[i]))
                     {
@@ -109,7 +109,7 @@ namespace Generated.Improbable.Gdk.Tests
                 }
             }
 
-            public override void MarkAuthorityLostForDeactivation(Dictionary<int, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkAuthorityLostForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
             {
                 if (AuthorityLostComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -120,7 +120,7 @@ namespace Generated.Improbable.Gdk.Tests
                 var entities = AuthorityLostComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i].Index];
+                    var activationManager = entityIndexToManagers[entities[i]];
                     // Call once except if flip-flopped back to starting state
                     if (IsFirstAuthChange(Authority.NotAuthoritative, authoritiesChangedTags[i]))
                     {
@@ -129,7 +129,7 @@ namespace Generated.Improbable.Gdk.Tests
                 }
             }
 
-            public override void InvokeOnComponentUpdateCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnComponentUpdateCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 if (ComponentsUpdatedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -140,7 +140,7 @@ namespace Generated.Improbable.Gdk.Tests
                 var updateLists = ComponentsUpdatedComponentGroup.GetComponentDataArray<Generated.Improbable.Gdk.Tests.ExhaustiveOptional.ReceivedUpdates>();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i].Index];
+                    var injectableStore = entityIndexToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -157,20 +157,20 @@ namespace Generated.Improbable.Gdk.Tests
                 }
             }
 
-            public override void InvokeOnEventCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnEventCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
             }
 
-            public override void InvokeOnCommandRequestCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnCommandRequestCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
             }
 
-            public override void InvokeOnCommandResponseCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnCommandResponseCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 // TODO UTY-542 Command Response handlers
             }
 
-            public override void InvokeOnAuthorityGainedCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityGainedCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 if (AuthorityGainedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -183,7 +183,7 @@ namespace Generated.Improbable.Gdk.Tests
                 // Call once on all entities unless they flip-flopped back into the state they started in
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i].Index];
+                    var injectableStore = entityIndexToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -199,7 +199,7 @@ namespace Generated.Improbable.Gdk.Tests
                 }
             }
 
-            public override void InvokeOnAuthorityLostCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityLostCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 if (AuthorityLostComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -212,7 +212,7 @@ namespace Generated.Improbable.Gdk.Tests
                 // Call once on all entities unless they flip-flopped back into the state they started in
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i].Index];
+                    var injectableStore = entityIndexToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -240,7 +240,7 @@ namespace Generated.Improbable.Gdk.Tests
                 return false;
             }
 
-            public override void InvokeOnAuthorityLossImminentCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityLossImminentCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 if (AuthorityLossImminentComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -252,7 +252,7 @@ namespace Generated.Improbable.Gdk.Tests
                 // Call once on all entities
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i].Index];
+                    var injectableStore = entityIndexToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeatedGameObjectComponentDispatcher.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeatedGameObjectComponentDispatcher.cs
@@ -59,7 +59,7 @@ namespace Generated.Improbable.Gdk.Tests
             private const uint componentId = 197717;
             private static readonly InjectableId readerWriterInjectableId = new InjectableId(InjectableType.ReaderWriter, componentId);
 
-            public override void MarkComponentsAddedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkComponentsAddedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityToManagers)
             {
                 if (ComponentAddedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -69,12 +69,12 @@ namespace Generated.Improbable.Gdk.Tests
                 var entities = ComponentAddedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i]];
+                    var activationManager = entityToManagers[entities[i]];
                     activationManager.AddComponent(componentId);
                 }
             }
 
-            public override void MarkComponentsRemovedForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkComponentsRemovedForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityToManagers)
             {
                 if (ComponentRemovedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -84,12 +84,12 @@ namespace Generated.Improbable.Gdk.Tests
                 var entities = ComponentRemovedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i]];
+                    var activationManager = entityToManagers[entities[i]];
                     activationManager.RemoveComponent(componentId);
                 }
             }
 
-            public override void MarkAuthorityGainedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkAuthorityGainedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityToManagers)
             {
                 if (AuthorityGainedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -100,7 +100,7 @@ namespace Generated.Improbable.Gdk.Tests
                 var entities = AuthorityGainedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i]];
+                    var activationManager = entityToManagers[entities[i]];
                     // Call once except if flip-flopped back to starting state
                     if (IsFirstAuthChange(Authority.Authoritative, authoritiesChangedTags[i]))
                     {
@@ -109,7 +109,7 @@ namespace Generated.Improbable.Gdk.Tests
                 }
             }
 
-            public override void MarkAuthorityLostForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkAuthorityLostForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityToManagers)
             {
                 if (AuthorityLostComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -120,7 +120,7 @@ namespace Generated.Improbable.Gdk.Tests
                 var entities = AuthorityLostComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i]];
+                    var activationManager = entityToManagers[entities[i]];
                     // Call once except if flip-flopped back to starting state
                     if (IsFirstAuthChange(Authority.NotAuthoritative, authoritiesChangedTags[i]))
                     {
@@ -129,7 +129,7 @@ namespace Generated.Improbable.Gdk.Tests
                 }
             }
 
-            public override void InvokeOnComponentUpdateCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnComponentUpdateCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 if (ComponentsUpdatedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -140,7 +140,7 @@ namespace Generated.Improbable.Gdk.Tests
                 var updateLists = ComponentsUpdatedComponentGroup.GetComponentDataArray<Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReceivedUpdates>();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i]];
+                    var injectableStore = entityToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -157,20 +157,20 @@ namespace Generated.Improbable.Gdk.Tests
                 }
             }
 
-            public override void InvokeOnEventCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnEventCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
             }
 
-            public override void InvokeOnCommandRequestCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnCommandRequestCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
             }
 
-            public override void InvokeOnCommandResponseCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnCommandResponseCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 // TODO UTY-542 Command Response handlers
             }
 
-            public override void InvokeOnAuthorityGainedCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityGainedCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 if (AuthorityGainedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -183,7 +183,7 @@ namespace Generated.Improbable.Gdk.Tests
                 // Call once on all entities unless they flip-flopped back into the state they started in
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i]];
+                    var injectableStore = entityToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -199,7 +199,7 @@ namespace Generated.Improbable.Gdk.Tests
                 }
             }
 
-            public override void InvokeOnAuthorityLostCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityLostCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 if (AuthorityLostComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -212,7 +212,7 @@ namespace Generated.Improbable.Gdk.Tests
                 // Call once on all entities unless they flip-flopped back into the state they started in
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i]];
+                    var injectableStore = entityToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -240,7 +240,7 @@ namespace Generated.Improbable.Gdk.Tests
                 return false;
             }
 
-            public override void InvokeOnAuthorityLossImminentCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityLossImminentCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 if (AuthorityLossImminentComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -252,7 +252,7 @@ namespace Generated.Improbable.Gdk.Tests
                 // Call once on all entities
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i]];
+                    var injectableStore = entityToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeatedGameObjectComponentDispatcher.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeatedGameObjectComponentDispatcher.cs
@@ -59,7 +59,7 @@ namespace Generated.Improbable.Gdk.Tests
             private const uint componentId = 197717;
             private static readonly InjectableId readerWriterInjectableId = new InjectableId(InjectableType.ReaderWriter, componentId);
 
-            public override void MarkComponentsAddedForActivation(Dictionary<int, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkComponentsAddedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
             {
                 if (ComponentAddedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -69,12 +69,12 @@ namespace Generated.Improbable.Gdk.Tests
                 var entities = ComponentAddedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i].Index];
+                    var activationManager = entityIndexToManagers[entities[i]];
                     activationManager.AddComponent(componentId);
                 }
             }
 
-            public override void MarkComponentsRemovedForDeactivation(Dictionary<int, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkComponentsRemovedForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
             {
                 if (ComponentRemovedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -84,12 +84,12 @@ namespace Generated.Improbable.Gdk.Tests
                 var entities = ComponentRemovedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i].Index];
+                    var activationManager = entityIndexToManagers[entities[i]];
                     activationManager.RemoveComponent(componentId);
                 }
             }
 
-            public override void MarkAuthorityGainedForActivation(Dictionary<int, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkAuthorityGainedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
             {
                 if (AuthorityGainedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -100,7 +100,7 @@ namespace Generated.Improbable.Gdk.Tests
                 var entities = AuthorityGainedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i].Index];
+                    var activationManager = entityIndexToManagers[entities[i]];
                     // Call once except if flip-flopped back to starting state
                     if (IsFirstAuthChange(Authority.Authoritative, authoritiesChangedTags[i]))
                     {
@@ -109,7 +109,7 @@ namespace Generated.Improbable.Gdk.Tests
                 }
             }
 
-            public override void MarkAuthorityLostForDeactivation(Dictionary<int, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkAuthorityLostForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
             {
                 if (AuthorityLostComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -120,7 +120,7 @@ namespace Generated.Improbable.Gdk.Tests
                 var entities = AuthorityLostComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i].Index];
+                    var activationManager = entityIndexToManagers[entities[i]];
                     // Call once except if flip-flopped back to starting state
                     if (IsFirstAuthChange(Authority.NotAuthoritative, authoritiesChangedTags[i]))
                     {
@@ -129,7 +129,7 @@ namespace Generated.Improbable.Gdk.Tests
                 }
             }
 
-            public override void InvokeOnComponentUpdateCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnComponentUpdateCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 if (ComponentsUpdatedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -140,7 +140,7 @@ namespace Generated.Improbable.Gdk.Tests
                 var updateLists = ComponentsUpdatedComponentGroup.GetComponentDataArray<Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.ReceivedUpdates>();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i].Index];
+                    var injectableStore = entityIndexToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -157,20 +157,20 @@ namespace Generated.Improbable.Gdk.Tests
                 }
             }
 
-            public override void InvokeOnEventCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnEventCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
             }
 
-            public override void InvokeOnCommandRequestCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnCommandRequestCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
             }
 
-            public override void InvokeOnCommandResponseCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnCommandResponseCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 // TODO UTY-542 Command Response handlers
             }
 
-            public override void InvokeOnAuthorityGainedCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityGainedCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 if (AuthorityGainedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -183,7 +183,7 @@ namespace Generated.Improbable.Gdk.Tests
                 // Call once on all entities unless they flip-flopped back into the state they started in
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i].Index];
+                    var injectableStore = entityIndexToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -199,7 +199,7 @@ namespace Generated.Improbable.Gdk.Tests
                 }
             }
 
-            public override void InvokeOnAuthorityLostCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityLostCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 if (AuthorityLostComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -212,7 +212,7 @@ namespace Generated.Improbable.Gdk.Tests
                 // Call once on all entities unless they flip-flopped back into the state they started in
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i].Index];
+                    var injectableStore = entityIndexToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -240,7 +240,7 @@ namespace Generated.Improbable.Gdk.Tests
                 return false;
             }
 
-            public override void InvokeOnAuthorityLossImminentCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityLossImminentCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 if (AuthorityLossImminentComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -252,7 +252,7 @@ namespace Generated.Improbable.Gdk.Tests
                 // Call once on all entities
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i].Index];
+                    var injectableStore = entityIndexToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingularGameObjectComponentDispatcher.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingularGameObjectComponentDispatcher.cs
@@ -59,7 +59,7 @@ namespace Generated.Improbable.Gdk.Tests
             private const uint componentId = 197715;
             private static readonly InjectableId readerWriterInjectableId = new InjectableId(InjectableType.ReaderWriter, componentId);
 
-            public override void MarkComponentsAddedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkComponentsAddedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityToManagers)
             {
                 if (ComponentAddedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -69,12 +69,12 @@ namespace Generated.Improbable.Gdk.Tests
                 var entities = ComponentAddedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i]];
+                    var activationManager = entityToManagers[entities[i]];
                     activationManager.AddComponent(componentId);
                 }
             }
 
-            public override void MarkComponentsRemovedForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkComponentsRemovedForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityToManagers)
             {
                 if (ComponentRemovedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -84,12 +84,12 @@ namespace Generated.Improbable.Gdk.Tests
                 var entities = ComponentRemovedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i]];
+                    var activationManager = entityToManagers[entities[i]];
                     activationManager.RemoveComponent(componentId);
                 }
             }
 
-            public override void MarkAuthorityGainedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkAuthorityGainedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityToManagers)
             {
                 if (AuthorityGainedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -100,7 +100,7 @@ namespace Generated.Improbable.Gdk.Tests
                 var entities = AuthorityGainedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i]];
+                    var activationManager = entityToManagers[entities[i]];
                     // Call once except if flip-flopped back to starting state
                     if (IsFirstAuthChange(Authority.Authoritative, authoritiesChangedTags[i]))
                     {
@@ -109,7 +109,7 @@ namespace Generated.Improbable.Gdk.Tests
                 }
             }
 
-            public override void MarkAuthorityLostForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkAuthorityLostForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityToManagers)
             {
                 if (AuthorityLostComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -120,7 +120,7 @@ namespace Generated.Improbable.Gdk.Tests
                 var entities = AuthorityLostComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i]];
+                    var activationManager = entityToManagers[entities[i]];
                     // Call once except if flip-flopped back to starting state
                     if (IsFirstAuthChange(Authority.NotAuthoritative, authoritiesChangedTags[i]))
                     {
@@ -129,7 +129,7 @@ namespace Generated.Improbable.Gdk.Tests
                 }
             }
 
-            public override void InvokeOnComponentUpdateCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnComponentUpdateCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 if (ComponentsUpdatedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -140,7 +140,7 @@ namespace Generated.Improbable.Gdk.Tests
                 var updateLists = ComponentsUpdatedComponentGroup.GetComponentDataArray<Generated.Improbable.Gdk.Tests.ExhaustiveSingular.ReceivedUpdates>();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i]];
+                    var injectableStore = entityToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -157,20 +157,20 @@ namespace Generated.Improbable.Gdk.Tests
                 }
             }
 
-            public override void InvokeOnEventCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnEventCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
             }
 
-            public override void InvokeOnCommandRequestCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnCommandRequestCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
             }
 
-            public override void InvokeOnCommandResponseCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnCommandResponseCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 // TODO UTY-542 Command Response handlers
             }
 
-            public override void InvokeOnAuthorityGainedCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityGainedCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 if (AuthorityGainedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -183,7 +183,7 @@ namespace Generated.Improbable.Gdk.Tests
                 // Call once on all entities unless they flip-flopped back into the state they started in
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i]];
+                    var injectableStore = entityToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -199,7 +199,7 @@ namespace Generated.Improbable.Gdk.Tests
                 }
             }
 
-            public override void InvokeOnAuthorityLostCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityLostCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 if (AuthorityLostComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -212,7 +212,7 @@ namespace Generated.Improbable.Gdk.Tests
                 // Call once on all entities unless they flip-flopped back into the state they started in
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i]];
+                    var injectableStore = entityToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -240,7 +240,7 @@ namespace Generated.Improbable.Gdk.Tests
                 return false;
             }
 
-            public override void InvokeOnAuthorityLossImminentCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityLossImminentCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 if (AuthorityLossImminentComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -252,7 +252,7 @@ namespace Generated.Improbable.Gdk.Tests
                 // Call once on all entities
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i]];
+                    var injectableStore = entityToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingularGameObjectComponentDispatcher.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingularGameObjectComponentDispatcher.cs
@@ -59,7 +59,7 @@ namespace Generated.Improbable.Gdk.Tests
             private const uint componentId = 197715;
             private static readonly InjectableId readerWriterInjectableId = new InjectableId(InjectableType.ReaderWriter, componentId);
 
-            public override void MarkComponentsAddedForActivation(Dictionary<int, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkComponentsAddedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
             {
                 if (ComponentAddedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -69,12 +69,12 @@ namespace Generated.Improbable.Gdk.Tests
                 var entities = ComponentAddedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i].Index];
+                    var activationManager = entityIndexToManagers[entities[i]];
                     activationManager.AddComponent(componentId);
                 }
             }
 
-            public override void MarkComponentsRemovedForDeactivation(Dictionary<int, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkComponentsRemovedForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
             {
                 if (ComponentRemovedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -84,12 +84,12 @@ namespace Generated.Improbable.Gdk.Tests
                 var entities = ComponentRemovedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i].Index];
+                    var activationManager = entityIndexToManagers[entities[i]];
                     activationManager.RemoveComponent(componentId);
                 }
             }
 
-            public override void MarkAuthorityGainedForActivation(Dictionary<int, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkAuthorityGainedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
             {
                 if (AuthorityGainedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -100,7 +100,7 @@ namespace Generated.Improbable.Gdk.Tests
                 var entities = AuthorityGainedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i].Index];
+                    var activationManager = entityIndexToManagers[entities[i]];
                     // Call once except if flip-flopped back to starting state
                     if (IsFirstAuthChange(Authority.Authoritative, authoritiesChangedTags[i]))
                     {
@@ -109,7 +109,7 @@ namespace Generated.Improbable.Gdk.Tests
                 }
             }
 
-            public override void MarkAuthorityLostForDeactivation(Dictionary<int, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkAuthorityLostForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
             {
                 if (AuthorityLostComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -120,7 +120,7 @@ namespace Generated.Improbable.Gdk.Tests
                 var entities = AuthorityLostComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i].Index];
+                    var activationManager = entityIndexToManagers[entities[i]];
                     // Call once except if flip-flopped back to starting state
                     if (IsFirstAuthChange(Authority.NotAuthoritative, authoritiesChangedTags[i]))
                     {
@@ -129,7 +129,7 @@ namespace Generated.Improbable.Gdk.Tests
                 }
             }
 
-            public override void InvokeOnComponentUpdateCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnComponentUpdateCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 if (ComponentsUpdatedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -140,7 +140,7 @@ namespace Generated.Improbable.Gdk.Tests
                 var updateLists = ComponentsUpdatedComponentGroup.GetComponentDataArray<Generated.Improbable.Gdk.Tests.ExhaustiveSingular.ReceivedUpdates>();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i].Index];
+                    var injectableStore = entityIndexToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -157,20 +157,20 @@ namespace Generated.Improbable.Gdk.Tests
                 }
             }
 
-            public override void InvokeOnEventCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnEventCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
             }
 
-            public override void InvokeOnCommandRequestCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnCommandRequestCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
             }
 
-            public override void InvokeOnCommandResponseCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnCommandResponseCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 // TODO UTY-542 Command Response handlers
             }
 
-            public override void InvokeOnAuthorityGainedCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityGainedCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 if (AuthorityGainedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -183,7 +183,7 @@ namespace Generated.Improbable.Gdk.Tests
                 // Call once on all entities unless they flip-flopped back into the state they started in
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i].Index];
+                    var injectableStore = entityIndexToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -199,7 +199,7 @@ namespace Generated.Improbable.Gdk.Tests
                 }
             }
 
-            public override void InvokeOnAuthorityLostCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityLostCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 if (AuthorityLostComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -212,7 +212,7 @@ namespace Generated.Improbable.Gdk.Tests
                 // Call once on all entities unless they flip-flopped back into the state they started in
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i].Index];
+                    var injectableStore = entityIndexToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -240,7 +240,7 @@ namespace Generated.Improbable.Gdk.Tests
                 return false;
             }
 
-            public override void InvokeOnAuthorityLossImminentCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityLossImminentCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 if (AuthorityLossImminentComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -252,7 +252,7 @@ namespace Generated.Improbable.Gdk.Tests
                 // Call once on all entities
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i].Index];
+                    var injectableStore = entityIndexToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/NestedComponentGameObjectComponentDispatcher.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/NestedComponentGameObjectComponentDispatcher.cs
@@ -59,7 +59,7 @@ namespace Generated.Improbable.Gdk.Tests
             private const uint componentId = 20152;
             private static readonly InjectableId readerWriterInjectableId = new InjectableId(InjectableType.ReaderWriter, componentId);
 
-            public override void MarkComponentsAddedForActivation(Dictionary<int, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkComponentsAddedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
             {
                 if (ComponentAddedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -69,12 +69,12 @@ namespace Generated.Improbable.Gdk.Tests
                 var entities = ComponentAddedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i].Index];
+                    var activationManager = entityIndexToManagers[entities[i]];
                     activationManager.AddComponent(componentId);
                 }
             }
 
-            public override void MarkComponentsRemovedForDeactivation(Dictionary<int, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkComponentsRemovedForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
             {
                 if (ComponentRemovedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -84,12 +84,12 @@ namespace Generated.Improbable.Gdk.Tests
                 var entities = ComponentRemovedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i].Index];
+                    var activationManager = entityIndexToManagers[entities[i]];
                     activationManager.RemoveComponent(componentId);
                 }
             }
 
-            public override void MarkAuthorityGainedForActivation(Dictionary<int, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkAuthorityGainedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
             {
                 if (AuthorityGainedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -100,7 +100,7 @@ namespace Generated.Improbable.Gdk.Tests
                 var entities = AuthorityGainedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i].Index];
+                    var activationManager = entityIndexToManagers[entities[i]];
                     // Call once except if flip-flopped back to starting state
                     if (IsFirstAuthChange(Authority.Authoritative, authoritiesChangedTags[i]))
                     {
@@ -109,7 +109,7 @@ namespace Generated.Improbable.Gdk.Tests
                 }
             }
 
-            public override void MarkAuthorityLostForDeactivation(Dictionary<int, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkAuthorityLostForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
             {
                 if (AuthorityLostComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -120,7 +120,7 @@ namespace Generated.Improbable.Gdk.Tests
                 var entities = AuthorityLostComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i].Index];
+                    var activationManager = entityIndexToManagers[entities[i]];
                     // Call once except if flip-flopped back to starting state
                     if (IsFirstAuthChange(Authority.NotAuthoritative, authoritiesChangedTags[i]))
                     {
@@ -129,7 +129,7 @@ namespace Generated.Improbable.Gdk.Tests
                 }
             }
 
-            public override void InvokeOnComponentUpdateCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnComponentUpdateCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 if (ComponentsUpdatedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -140,7 +140,7 @@ namespace Generated.Improbable.Gdk.Tests
                 var updateLists = ComponentsUpdatedComponentGroup.GetComponentDataArray<Generated.Improbable.Gdk.Tests.NestedComponent.ReceivedUpdates>();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i].Index];
+                    var injectableStore = entityIndexToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -157,20 +157,20 @@ namespace Generated.Improbable.Gdk.Tests
                 }
             }
 
-            public override void InvokeOnEventCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnEventCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
             }
 
-            public override void InvokeOnCommandRequestCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnCommandRequestCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
             }
 
-            public override void InvokeOnCommandResponseCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnCommandResponseCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 // TODO UTY-542 Command Response handlers
             }
 
-            public override void InvokeOnAuthorityGainedCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityGainedCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 if (AuthorityGainedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -183,7 +183,7 @@ namespace Generated.Improbable.Gdk.Tests
                 // Call once on all entities unless they flip-flopped back into the state they started in
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i].Index];
+                    var injectableStore = entityIndexToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -199,7 +199,7 @@ namespace Generated.Improbable.Gdk.Tests
                 }
             }
 
-            public override void InvokeOnAuthorityLostCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityLostCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 if (AuthorityLostComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -212,7 +212,7 @@ namespace Generated.Improbable.Gdk.Tests
                 // Call once on all entities unless they flip-flopped back into the state they started in
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i].Index];
+                    var injectableStore = entityIndexToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -240,7 +240,7 @@ namespace Generated.Improbable.Gdk.Tests
                 return false;
             }
 
-            public override void InvokeOnAuthorityLossImminentCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityLossImminentCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 if (AuthorityLossImminentComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -252,7 +252,7 @@ namespace Generated.Improbable.Gdk.Tests
                 // Call once on all entities
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i].Index];
+                    var injectableStore = entityIndexToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/NestedComponentGameObjectComponentDispatcher.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/NestedComponentGameObjectComponentDispatcher.cs
@@ -59,7 +59,7 @@ namespace Generated.Improbable.Gdk.Tests
             private const uint componentId = 20152;
             private static readonly InjectableId readerWriterInjectableId = new InjectableId(InjectableType.ReaderWriter, componentId);
 
-            public override void MarkComponentsAddedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkComponentsAddedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityToManagers)
             {
                 if (ComponentAddedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -69,12 +69,12 @@ namespace Generated.Improbable.Gdk.Tests
                 var entities = ComponentAddedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i]];
+                    var activationManager = entityToManagers[entities[i]];
                     activationManager.AddComponent(componentId);
                 }
             }
 
-            public override void MarkComponentsRemovedForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkComponentsRemovedForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityToManagers)
             {
                 if (ComponentRemovedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -84,12 +84,12 @@ namespace Generated.Improbable.Gdk.Tests
                 var entities = ComponentRemovedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i]];
+                    var activationManager = entityToManagers[entities[i]];
                     activationManager.RemoveComponent(componentId);
                 }
             }
 
-            public override void MarkAuthorityGainedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkAuthorityGainedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityToManagers)
             {
                 if (AuthorityGainedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -100,7 +100,7 @@ namespace Generated.Improbable.Gdk.Tests
                 var entities = AuthorityGainedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i]];
+                    var activationManager = entityToManagers[entities[i]];
                     // Call once except if flip-flopped back to starting state
                     if (IsFirstAuthChange(Authority.Authoritative, authoritiesChangedTags[i]))
                     {
@@ -109,7 +109,7 @@ namespace Generated.Improbable.Gdk.Tests
                 }
             }
 
-            public override void MarkAuthorityLostForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkAuthorityLostForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityToManagers)
             {
                 if (AuthorityLostComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -120,7 +120,7 @@ namespace Generated.Improbable.Gdk.Tests
                 var entities = AuthorityLostComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i]];
+                    var activationManager = entityToManagers[entities[i]];
                     // Call once except if flip-flopped back to starting state
                     if (IsFirstAuthChange(Authority.NotAuthoritative, authoritiesChangedTags[i]))
                     {
@@ -129,7 +129,7 @@ namespace Generated.Improbable.Gdk.Tests
                 }
             }
 
-            public override void InvokeOnComponentUpdateCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnComponentUpdateCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 if (ComponentsUpdatedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -140,7 +140,7 @@ namespace Generated.Improbable.Gdk.Tests
                 var updateLists = ComponentsUpdatedComponentGroup.GetComponentDataArray<Generated.Improbable.Gdk.Tests.NestedComponent.ReceivedUpdates>();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i]];
+                    var injectableStore = entityToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -157,20 +157,20 @@ namespace Generated.Improbable.Gdk.Tests
                 }
             }
 
-            public override void InvokeOnEventCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnEventCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
             }
 
-            public override void InvokeOnCommandRequestCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnCommandRequestCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
             }
 
-            public override void InvokeOnCommandResponseCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnCommandResponseCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 // TODO UTY-542 Command Response handlers
             }
 
-            public override void InvokeOnAuthorityGainedCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityGainedCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 if (AuthorityGainedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -183,7 +183,7 @@ namespace Generated.Improbable.Gdk.Tests
                 // Call once on all entities unless they flip-flopped back into the state they started in
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i]];
+                    var injectableStore = entityToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -199,7 +199,7 @@ namespace Generated.Improbable.Gdk.Tests
                 }
             }
 
-            public override void InvokeOnAuthorityLostCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityLostCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 if (AuthorityLostComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -212,7 +212,7 @@ namespace Generated.Improbable.Gdk.Tests
                 // Call once on all entities unless they flip-flopped back into the state they started in
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i]];
+                    var injectableStore = entityToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -240,7 +240,7 @@ namespace Generated.Improbable.Gdk.Tests
                 return false;
             }
 
-            public override void InvokeOnAuthorityLossImminentCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityLossImminentCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 if (AuthorityLossImminentComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -252,7 +252,7 @@ namespace Generated.Improbable.Gdk.Tests
                 // Call once on all entities
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i]];
+                    var injectableStore = entityToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/ConnectionGameObjectComponentDispatcher.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/ConnectionGameObjectComponentDispatcher.cs
@@ -59,7 +59,7 @@ namespace Generated.Improbable.Gdk.Tests.AlternateSchemaSyntax
             private const uint componentId = 1105;
             private static readonly InjectableId readerWriterInjectableId = new InjectableId(InjectableType.ReaderWriter, componentId);
 
-            public override void MarkComponentsAddedForActivation(Dictionary<int, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkComponentsAddedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
             {
                 if (ComponentAddedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -69,12 +69,12 @@ namespace Generated.Improbable.Gdk.Tests.AlternateSchemaSyntax
                 var entities = ComponentAddedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i].Index];
+                    var activationManager = entityIndexToManagers[entities[i]];
                     activationManager.AddComponent(componentId);
                 }
             }
 
-            public override void MarkComponentsRemovedForDeactivation(Dictionary<int, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkComponentsRemovedForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
             {
                 if (ComponentRemovedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -84,12 +84,12 @@ namespace Generated.Improbable.Gdk.Tests.AlternateSchemaSyntax
                 var entities = ComponentRemovedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i].Index];
+                    var activationManager = entityIndexToManagers[entities[i]];
                     activationManager.RemoveComponent(componentId);
                 }
             }
 
-            public override void MarkAuthorityGainedForActivation(Dictionary<int, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkAuthorityGainedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
             {
                 if (AuthorityGainedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -100,7 +100,7 @@ namespace Generated.Improbable.Gdk.Tests.AlternateSchemaSyntax
                 var entities = AuthorityGainedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i].Index];
+                    var activationManager = entityIndexToManagers[entities[i]];
                     // Call once except if flip-flopped back to starting state
                     if (IsFirstAuthChange(Authority.Authoritative, authoritiesChangedTags[i]))
                     {
@@ -109,7 +109,7 @@ namespace Generated.Improbable.Gdk.Tests.AlternateSchemaSyntax
                 }
             }
 
-            public override void MarkAuthorityLostForDeactivation(Dictionary<int, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkAuthorityLostForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
             {
                 if (AuthorityLostComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -120,7 +120,7 @@ namespace Generated.Improbable.Gdk.Tests.AlternateSchemaSyntax
                 var entities = AuthorityLostComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i].Index];
+                    var activationManager = entityIndexToManagers[entities[i]];
                     // Call once except if flip-flopped back to starting state
                     if (IsFirstAuthChange(Authority.NotAuthoritative, authoritiesChangedTags[i]))
                     {
@@ -129,11 +129,11 @@ namespace Generated.Improbable.Gdk.Tests.AlternateSchemaSyntax
                 }
             }
 
-            public override void InvokeOnComponentUpdateCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnComponentUpdateCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
             }
 
-            public override void InvokeOnEventCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnEventCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 if (!EventsReceivedComponentGroups[0].IsEmptyIgnoreFilter)
                 {
@@ -141,7 +141,7 @@ namespace Generated.Improbable.Gdk.Tests.AlternateSchemaSyntax
                     var eventLists = EventsReceivedComponentGroups[0].GetComponentDataArray<ReceivedEvents.MyEvent>();
                     for (var i = 0; i < entities.Length; i++)
                     {
-                        var injectableStore = entityIndexToInjectableStore[entities[i].Index];
+                        var injectableStore = entityIndexToInjectableStore[entities[i]];
                         if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                         {
                             continue;
@@ -161,16 +161,16 @@ namespace Generated.Improbable.Gdk.Tests.AlternateSchemaSyntax
 
             }
 
-            public override void InvokeOnCommandRequestCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnCommandRequestCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
             }
 
-            public override void InvokeOnCommandResponseCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnCommandResponseCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 // TODO UTY-542 Command Response handlers
             }
 
-            public override void InvokeOnAuthorityGainedCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityGainedCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 if (AuthorityGainedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -183,7 +183,7 @@ namespace Generated.Improbable.Gdk.Tests.AlternateSchemaSyntax
                 // Call once on all entities unless they flip-flopped back into the state they started in
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i].Index];
+                    var injectableStore = entityIndexToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -199,7 +199,7 @@ namespace Generated.Improbable.Gdk.Tests.AlternateSchemaSyntax
                 }
             }
 
-            public override void InvokeOnAuthorityLostCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityLostCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 if (AuthorityLostComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -212,7 +212,7 @@ namespace Generated.Improbable.Gdk.Tests.AlternateSchemaSyntax
                 // Call once on all entities unless they flip-flopped back into the state they started in
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i].Index];
+                    var injectableStore = entityIndexToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -240,7 +240,7 @@ namespace Generated.Improbable.Gdk.Tests.AlternateSchemaSyntax
                 return false;
             }
 
-            public override void InvokeOnAuthorityLossImminentCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityLossImminentCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 if (AuthorityLossImminentComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -252,7 +252,7 @@ namespace Generated.Improbable.Gdk.Tests.AlternateSchemaSyntax
                 // Call once on all entities
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i].Index];
+                    var injectableStore = entityIndexToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/ConnectionGameObjectComponentDispatcher.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/ConnectionGameObjectComponentDispatcher.cs
@@ -59,7 +59,7 @@ namespace Generated.Improbable.Gdk.Tests.AlternateSchemaSyntax
             private const uint componentId = 1105;
             private static readonly InjectableId readerWriterInjectableId = new InjectableId(InjectableType.ReaderWriter, componentId);
 
-            public override void MarkComponentsAddedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkComponentsAddedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityToManagers)
             {
                 if (ComponentAddedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -69,12 +69,12 @@ namespace Generated.Improbable.Gdk.Tests.AlternateSchemaSyntax
                 var entities = ComponentAddedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i]];
+                    var activationManager = entityToManagers[entities[i]];
                     activationManager.AddComponent(componentId);
                 }
             }
 
-            public override void MarkComponentsRemovedForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkComponentsRemovedForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityToManagers)
             {
                 if (ComponentRemovedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -84,12 +84,12 @@ namespace Generated.Improbable.Gdk.Tests.AlternateSchemaSyntax
                 var entities = ComponentRemovedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i]];
+                    var activationManager = entityToManagers[entities[i]];
                     activationManager.RemoveComponent(componentId);
                 }
             }
 
-            public override void MarkAuthorityGainedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkAuthorityGainedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityToManagers)
             {
                 if (AuthorityGainedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -100,7 +100,7 @@ namespace Generated.Improbable.Gdk.Tests.AlternateSchemaSyntax
                 var entities = AuthorityGainedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i]];
+                    var activationManager = entityToManagers[entities[i]];
                     // Call once except if flip-flopped back to starting state
                     if (IsFirstAuthChange(Authority.Authoritative, authoritiesChangedTags[i]))
                     {
@@ -109,7 +109,7 @@ namespace Generated.Improbable.Gdk.Tests.AlternateSchemaSyntax
                 }
             }
 
-            public override void MarkAuthorityLostForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkAuthorityLostForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityToManagers)
             {
                 if (AuthorityLostComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -120,7 +120,7 @@ namespace Generated.Improbable.Gdk.Tests.AlternateSchemaSyntax
                 var entities = AuthorityLostComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i]];
+                    var activationManager = entityToManagers[entities[i]];
                     // Call once except if flip-flopped back to starting state
                     if (IsFirstAuthChange(Authority.NotAuthoritative, authoritiesChangedTags[i]))
                     {
@@ -129,11 +129,11 @@ namespace Generated.Improbable.Gdk.Tests.AlternateSchemaSyntax
                 }
             }
 
-            public override void InvokeOnComponentUpdateCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnComponentUpdateCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
             }
 
-            public override void InvokeOnEventCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnEventCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 if (!EventsReceivedComponentGroups[0].IsEmptyIgnoreFilter)
                 {
@@ -141,7 +141,7 @@ namespace Generated.Improbable.Gdk.Tests.AlternateSchemaSyntax
                     var eventLists = EventsReceivedComponentGroups[0].GetComponentDataArray<ReceivedEvents.MyEvent>();
                     for (var i = 0; i < entities.Length; i++)
                     {
-                        var injectableStore = entityIndexToInjectableStore[entities[i]];
+                        var injectableStore = entityToInjectableStore[entities[i]];
                         if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                         {
                             continue;
@@ -161,16 +161,16 @@ namespace Generated.Improbable.Gdk.Tests.AlternateSchemaSyntax
 
             }
 
-            public override void InvokeOnCommandRequestCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnCommandRequestCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
             }
 
-            public override void InvokeOnCommandResponseCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnCommandResponseCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 // TODO UTY-542 Command Response handlers
             }
 
-            public override void InvokeOnAuthorityGainedCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityGainedCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 if (AuthorityGainedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -183,7 +183,7 @@ namespace Generated.Improbable.Gdk.Tests.AlternateSchemaSyntax
                 // Call once on all entities unless they flip-flopped back into the state they started in
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i]];
+                    var injectableStore = entityToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -199,7 +199,7 @@ namespace Generated.Improbable.Gdk.Tests.AlternateSchemaSyntax
                 }
             }
 
-            public override void InvokeOnAuthorityLostCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityLostCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 if (AuthorityLostComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -212,7 +212,7 @@ namespace Generated.Improbable.Gdk.Tests.AlternateSchemaSyntax
                 // Call once on all entities unless they flip-flopped back into the state they started in
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i]];
+                    var injectableStore = entityToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -240,7 +240,7 @@ namespace Generated.Improbable.Gdk.Tests.AlternateSchemaSyntax
                 return false;
             }
 
-            public override void InvokeOnAuthorityLossImminentCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityLossImminentCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 if (AuthorityLossImminentComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -252,7 +252,7 @@ namespace Generated.Improbable.Gdk.Tests.AlternateSchemaSyntax
                 // Call once on all entities
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i]];
+                    var injectableStore = entityToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentGameObjectComponentDispatcher.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentGameObjectComponentDispatcher.cs
@@ -64,7 +64,7 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
             private static readonly InjectableId readerWriterInjectableId = new InjectableId(InjectableType.ReaderWriter, componentId);
             private static readonly InjectableId commandRequestHandlerInjectableId = new InjectableId(InjectableType.CommandRequestHandler, componentId);
 
-            public override void MarkComponentsAddedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkComponentsAddedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityToManagers)
             {
                 if (ComponentAddedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -74,12 +74,12 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
                 var entities = ComponentAddedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i]];
+                    var activationManager = entityToManagers[entities[i]];
                     activationManager.AddComponent(componentId);
                 }
             }
 
-            public override void MarkComponentsRemovedForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkComponentsRemovedForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityToManagers)
             {
                 if (ComponentRemovedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -89,12 +89,12 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
                 var entities = ComponentRemovedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i]];
+                    var activationManager = entityToManagers[entities[i]];
                     activationManager.RemoveComponent(componentId);
                 }
             }
 
-            public override void MarkAuthorityGainedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkAuthorityGainedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityToManagers)
             {
                 if (AuthorityGainedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -105,7 +105,7 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
                 var entities = AuthorityGainedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i]];
+                    var activationManager = entityToManagers[entities[i]];
                     // Call once except if flip-flopped back to starting state
                     if (IsFirstAuthChange(Authority.Authoritative, authoritiesChangedTags[i]))
                     {
@@ -114,7 +114,7 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
                 }
             }
 
-            public override void MarkAuthorityLostForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkAuthorityLostForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityToManagers)
             {
                 if (AuthorityLostComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -125,7 +125,7 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
                 var entities = AuthorityLostComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i]];
+                    var activationManager = entityToManagers[entities[i]];
                     // Call once except if flip-flopped back to starting state
                     if (IsFirstAuthChange(Authority.NotAuthoritative, authoritiesChangedTags[i]))
                     {
@@ -134,7 +134,7 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
                 }
             }
 
-            public override void InvokeOnComponentUpdateCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnComponentUpdateCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 if (ComponentsUpdatedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -145,7 +145,7 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
                 var updateLists = ComponentsUpdatedComponentGroup.GetComponentDataArray<Generated.Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReceivedUpdates>();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i]];
+                    var injectableStore = entityToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -162,7 +162,7 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
                 }
             }
 
-            public override void InvokeOnEventCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnEventCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 if (!EventsReceivedComponentGroups[0].IsEmptyIgnoreFilter)
                 {
@@ -170,7 +170,7 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
                     var eventLists = EventsReceivedComponentGroups[0].GetComponentDataArray<ReceivedEvents.FirstEvent>();
                     for (var i = 0; i < entities.Length; i++)
                     {
-                        var injectableStore = entityIndexToInjectableStore[entities[i]];
+                        var injectableStore = entityToInjectableStore[entities[i]];
                         if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                         {
                             continue;
@@ -194,7 +194,7 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
                     var eventLists = EventsReceivedComponentGroups[1].GetComponentDataArray<ReceivedEvents.SecondEvent>();
                     for (var i = 0; i < entities.Length; i++)
                     {
-                        var injectableStore = entityIndexToInjectableStore[entities[i]];
+                        var injectableStore = entityToInjectableStore[entities[i]];
                         if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                         {
                             continue;
@@ -214,7 +214,7 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
 
             }
 
-            public override void InvokeOnCommandRequestCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnCommandRequestCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 if (!CommandRequestsComponentGroups[0].IsEmptyIgnoreFilter)
                 {
@@ -222,7 +222,7 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
                     var commandRequestLists = CommandRequestsComponentGroups[0].GetComponentDataArray<CommandRequests.FirstCommand>();
                     for (var i = 0; i < entities.Length; i++)
                     {
-                        var injectableStore = entityIndexToInjectableStore[entities[i]];
+                        var injectableStore = entityToInjectableStore[entities[i]];
                         if (!injectableStore.TryGetInjectablesForComponent(commandRequestHandlerInjectableId, out var commandRequestHandlers))
                         {
                             continue;
@@ -244,7 +244,7 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
                     var commandRequestLists = CommandRequestsComponentGroups[1].GetComponentDataArray<CommandRequests.SecondCommand>();
                     for (var i = 0; i < entities.Length; i++)
                     {
-                        var injectableStore = entityIndexToInjectableStore[entities[i]];
+                        var injectableStore = entityToInjectableStore[entities[i]];
                         if (!injectableStore.TryGetInjectablesForComponent(commandRequestHandlerInjectableId, out var commandRequestHandlers))
                         {
                             continue;
@@ -262,12 +262,12 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
 
             }
 
-            public override void InvokeOnCommandResponseCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnCommandResponseCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 // TODO UTY-542 Command Response handlers
             }
 
-            public override void InvokeOnAuthorityGainedCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityGainedCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 if (AuthorityGainedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -280,7 +280,7 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
                 // Call once on all entities unless they flip-flopped back into the state they started in
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i]];
+                    var injectableStore = entityToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -296,7 +296,7 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
                 }
             }
 
-            public override void InvokeOnAuthorityLostCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityLostCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 if (AuthorityLostComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -309,7 +309,7 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
                 // Call once on all entities unless they flip-flopped back into the state they started in
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i]];
+                    var injectableStore = entityToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -337,7 +337,7 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
                 return false;
             }
 
-            public override void InvokeOnAuthorityLossImminentCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityLossImminentCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 if (AuthorityLossImminentComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -349,7 +349,7 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
                 // Call once on all entities
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i]];
+                    var injectableStore = entityToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentGameObjectComponentDispatcher.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentGameObjectComponentDispatcher.cs
@@ -64,7 +64,7 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
             private static readonly InjectableId readerWriterInjectableId = new InjectableId(InjectableType.ReaderWriter, componentId);
             private static readonly InjectableId commandRequestHandlerInjectableId = new InjectableId(InjectableType.CommandRequestHandler, componentId);
 
-            public override void MarkComponentsAddedForActivation(Dictionary<int, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkComponentsAddedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
             {
                 if (ComponentAddedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -74,12 +74,12 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
                 var entities = ComponentAddedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i].Index];
+                    var activationManager = entityIndexToManagers[entities[i]];
                     activationManager.AddComponent(componentId);
                 }
             }
 
-            public override void MarkComponentsRemovedForDeactivation(Dictionary<int, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkComponentsRemovedForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
             {
                 if (ComponentRemovedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -89,12 +89,12 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
                 var entities = ComponentRemovedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i].Index];
+                    var activationManager = entityIndexToManagers[entities[i]];
                     activationManager.RemoveComponent(componentId);
                 }
             }
 
-            public override void MarkAuthorityGainedForActivation(Dictionary<int, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkAuthorityGainedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
             {
                 if (AuthorityGainedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -105,7 +105,7 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
                 var entities = AuthorityGainedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i].Index];
+                    var activationManager = entityIndexToManagers[entities[i]];
                     // Call once except if flip-flopped back to starting state
                     if (IsFirstAuthChange(Authority.Authoritative, authoritiesChangedTags[i]))
                     {
@@ -114,7 +114,7 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
                 }
             }
 
-            public override void MarkAuthorityLostForDeactivation(Dictionary<int, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkAuthorityLostForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
             {
                 if (AuthorityLostComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -125,7 +125,7 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
                 var entities = AuthorityLostComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i].Index];
+                    var activationManager = entityIndexToManagers[entities[i]];
                     // Call once except if flip-flopped back to starting state
                     if (IsFirstAuthChange(Authority.NotAuthoritative, authoritiesChangedTags[i]))
                     {
@@ -134,7 +134,7 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
                 }
             }
 
-            public override void InvokeOnComponentUpdateCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnComponentUpdateCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 if (ComponentsUpdatedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -145,7 +145,7 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
                 var updateLists = ComponentsUpdatedComponentGroup.GetComponentDataArray<Generated.Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.ReceivedUpdates>();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i].Index];
+                    var injectableStore = entityIndexToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -162,7 +162,7 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
                 }
             }
 
-            public override void InvokeOnEventCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnEventCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 if (!EventsReceivedComponentGroups[0].IsEmptyIgnoreFilter)
                 {
@@ -170,7 +170,7 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
                     var eventLists = EventsReceivedComponentGroups[0].GetComponentDataArray<ReceivedEvents.FirstEvent>();
                     for (var i = 0; i < entities.Length; i++)
                     {
-                        var injectableStore = entityIndexToInjectableStore[entities[i].Index];
+                        var injectableStore = entityIndexToInjectableStore[entities[i]];
                         if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                         {
                             continue;
@@ -194,7 +194,7 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
                     var eventLists = EventsReceivedComponentGroups[1].GetComponentDataArray<ReceivedEvents.SecondEvent>();
                     for (var i = 0; i < entities.Length; i++)
                     {
-                        var injectableStore = entityIndexToInjectableStore[entities[i].Index];
+                        var injectableStore = entityIndexToInjectableStore[entities[i]];
                         if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                         {
                             continue;
@@ -214,7 +214,7 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
 
             }
 
-            public override void InvokeOnCommandRequestCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnCommandRequestCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 if (!CommandRequestsComponentGroups[0].IsEmptyIgnoreFilter)
                 {
@@ -222,7 +222,7 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
                     var commandRequestLists = CommandRequestsComponentGroups[0].GetComponentDataArray<CommandRequests.FirstCommand>();
                     for (var i = 0; i < entities.Length; i++)
                     {
-                        var injectableStore = entityIndexToInjectableStore[entities[i].Index];
+                        var injectableStore = entityIndexToInjectableStore[entities[i]];
                         if (!injectableStore.TryGetInjectablesForComponent(commandRequestHandlerInjectableId, out var commandRequestHandlers))
                         {
                             continue;
@@ -244,7 +244,7 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
                     var commandRequestLists = CommandRequestsComponentGroups[1].GetComponentDataArray<CommandRequests.SecondCommand>();
                     for (var i = 0; i < entities.Length; i++)
                     {
-                        var injectableStore = entityIndexToInjectableStore[entities[i].Index];
+                        var injectableStore = entityIndexToInjectableStore[entities[i]];
                         if (!injectableStore.TryGetInjectablesForComponent(commandRequestHandlerInjectableId, out var commandRequestHandlers))
                         {
                             continue;
@@ -262,12 +262,12 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
 
             }
 
-            public override void InvokeOnCommandResponseCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnCommandResponseCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 // TODO UTY-542 Command Response handlers
             }
 
-            public override void InvokeOnAuthorityGainedCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityGainedCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 if (AuthorityGainedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -280,7 +280,7 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
                 // Call once on all entities unless they flip-flopped back into the state they started in
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i].Index];
+                    var injectableStore = entityIndexToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -296,7 +296,7 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
                 }
             }
 
-            public override void InvokeOnAuthorityLostCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityLostCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 if (AuthorityLostComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -309,7 +309,7 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
                 // Call once on all entities unless they flip-flopped back into the state they started in
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i].Index];
+                    var injectableStore = entityIndexToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -337,7 +337,7 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
                 return false;
             }
 
-            public override void InvokeOnAuthorityLossImminentCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityLossImminentCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 if (AuthorityLossImminentComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -349,7 +349,7 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
                 // Call once on all entities
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i].Index];
+                    var injectableStore = entityIndexToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsGameObjectComponentDispatcher.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsGameObjectComponentDispatcher.cs
@@ -58,7 +58,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
             private const uint componentId = 1003;
             private static readonly InjectableId readerWriterInjectableId = new InjectableId(InjectableType.ReaderWriter, componentId);
 
-            public override void MarkComponentsAddedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkComponentsAddedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityToManagers)
             {
                 if (ComponentAddedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -68,12 +68,12 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 var entities = ComponentAddedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i]];
+                    var activationManager = entityToManagers[entities[i]];
                     activationManager.AddComponent(componentId);
                 }
             }
 
-            public override void MarkComponentsRemovedForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkComponentsRemovedForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityToManagers)
             {
                 if (ComponentRemovedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -83,12 +83,12 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 var entities = ComponentRemovedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i]];
+                    var activationManager = entityToManagers[entities[i]];
                     activationManager.RemoveComponent(componentId);
                 }
             }
 
-            public override void MarkAuthorityGainedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkAuthorityGainedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityToManagers)
             {
                 if (AuthorityGainedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -99,7 +99,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 var entities = AuthorityGainedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i]];
+                    var activationManager = entityToManagers[entities[i]];
                     // Call once except if flip-flopped back to starting state
                     if (IsFirstAuthChange(Authority.Authoritative, authoritiesChangedTags[i]))
                     {
@@ -108,7 +108,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 }
             }
 
-            public override void MarkAuthorityLostForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkAuthorityLostForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityToManagers)
             {
                 if (AuthorityLostComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -119,7 +119,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 var entities = AuthorityLostComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i]];
+                    var activationManager = entityToManagers[entities[i]];
                     // Call once except if flip-flopped back to starting state
                     if (IsFirstAuthChange(Authority.NotAuthoritative, authoritiesChangedTags[i]))
                     {
@@ -128,24 +128,24 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 }
             }
 
-            public override void InvokeOnComponentUpdateCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnComponentUpdateCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
             }
 
-            public override void InvokeOnEventCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnEventCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
             }
 
-            public override void InvokeOnCommandRequestCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnCommandRequestCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
             }
 
-            public override void InvokeOnCommandResponseCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnCommandResponseCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 // TODO UTY-542 Command Response handlers
             }
 
-            public override void InvokeOnAuthorityGainedCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityGainedCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 if (AuthorityGainedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -158,7 +158,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 // Call once on all entities unless they flip-flopped back into the state they started in
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i]];
+                    var injectableStore = entityToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -174,7 +174,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 }
             }
 
-            public override void InvokeOnAuthorityLostCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityLostCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 if (AuthorityLostComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -187,7 +187,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 // Call once on all entities unless they flip-flopped back into the state they started in
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i]];
+                    var injectableStore = entityToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -215,7 +215,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 return false;
             }
 
-            public override void InvokeOnAuthorityLossImminentCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityLossImminentCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 if (AuthorityLossImminentComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -227,7 +227,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 // Call once on all entities
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i]];
+                    var injectableStore = entityToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsGameObjectComponentDispatcher.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsGameObjectComponentDispatcher.cs
@@ -58,7 +58,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
             private const uint componentId = 1003;
             private static readonly InjectableId readerWriterInjectableId = new InjectableId(InjectableType.ReaderWriter, componentId);
 
-            public override void MarkComponentsAddedForActivation(Dictionary<int, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkComponentsAddedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
             {
                 if (ComponentAddedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -68,12 +68,12 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 var entities = ComponentAddedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i].Index];
+                    var activationManager = entityIndexToManagers[entities[i]];
                     activationManager.AddComponent(componentId);
                 }
             }
 
-            public override void MarkComponentsRemovedForDeactivation(Dictionary<int, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkComponentsRemovedForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
             {
                 if (ComponentRemovedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -83,12 +83,12 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 var entities = ComponentRemovedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i].Index];
+                    var activationManager = entityIndexToManagers[entities[i]];
                     activationManager.RemoveComponent(componentId);
                 }
             }
 
-            public override void MarkAuthorityGainedForActivation(Dictionary<int, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkAuthorityGainedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
             {
                 if (AuthorityGainedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -99,7 +99,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 var entities = AuthorityGainedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i].Index];
+                    var activationManager = entityIndexToManagers[entities[i]];
                     // Call once except if flip-flopped back to starting state
                     if (IsFirstAuthChange(Authority.Authoritative, authoritiesChangedTags[i]))
                     {
@@ -108,7 +108,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 }
             }
 
-            public override void MarkAuthorityLostForDeactivation(Dictionary<int, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkAuthorityLostForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
             {
                 if (AuthorityLostComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -119,7 +119,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 var entities = AuthorityLostComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i].Index];
+                    var activationManager = entityIndexToManagers[entities[i]];
                     // Call once except if flip-flopped back to starting state
                     if (IsFirstAuthChange(Authority.NotAuthoritative, authoritiesChangedTags[i]))
                     {
@@ -128,24 +128,24 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 }
             }
 
-            public override void InvokeOnComponentUpdateCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnComponentUpdateCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
             }
 
-            public override void InvokeOnEventCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnEventCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
             }
 
-            public override void InvokeOnCommandRequestCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnCommandRequestCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
             }
 
-            public override void InvokeOnCommandResponseCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnCommandResponseCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 // TODO UTY-542 Command Response handlers
             }
 
-            public override void InvokeOnAuthorityGainedCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityGainedCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 if (AuthorityGainedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -158,7 +158,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 // Call once on all entities unless they flip-flopped back into the state they started in
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i].Index];
+                    var injectableStore = entityIndexToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -174,7 +174,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 }
             }
 
-            public override void InvokeOnAuthorityLostCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityLostCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 if (AuthorityLostComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -187,7 +187,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 // Call once on all entities unless they flip-flopped back into the state they started in
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i].Index];
+                    var injectableStore = entityIndexToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -215,7 +215,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 return false;
             }
 
-            public override void InvokeOnAuthorityLossImminentCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityLossImminentCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 if (AuthorityLossImminentComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -227,7 +227,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 // Call once on all entities
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i].Index];
+                    var injectableStore = entityIndexToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsGameObjectComponentDispatcher.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsGameObjectComponentDispatcher.cs
@@ -60,7 +60,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
             private static readonly InjectableId readerWriterInjectableId = new InjectableId(InjectableType.ReaderWriter, componentId);
             private static readonly InjectableId commandRequestHandlerInjectableId = new InjectableId(InjectableType.CommandRequestHandler, componentId);
 
-            public override void MarkComponentsAddedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkComponentsAddedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityToManagers)
             {
                 if (ComponentAddedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -70,12 +70,12 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 var entities = ComponentAddedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i]];
+                    var activationManager = entityToManagers[entities[i]];
                     activationManager.AddComponent(componentId);
                 }
             }
 
-            public override void MarkComponentsRemovedForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkComponentsRemovedForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityToManagers)
             {
                 if (ComponentRemovedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -85,12 +85,12 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 var entities = ComponentRemovedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i]];
+                    var activationManager = entityToManagers[entities[i]];
                     activationManager.RemoveComponent(componentId);
                 }
             }
 
-            public override void MarkAuthorityGainedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkAuthorityGainedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityToManagers)
             {
                 if (AuthorityGainedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -101,7 +101,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 var entities = AuthorityGainedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i]];
+                    var activationManager = entityToManagers[entities[i]];
                     // Call once except if flip-flopped back to starting state
                     if (IsFirstAuthChange(Authority.Authoritative, authoritiesChangedTags[i]))
                     {
@@ -110,7 +110,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 }
             }
 
-            public override void MarkAuthorityLostForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkAuthorityLostForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityToManagers)
             {
                 if (AuthorityLostComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -121,7 +121,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 var entities = AuthorityLostComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i]];
+                    var activationManager = entityToManagers[entities[i]];
                     // Call once except if flip-flopped back to starting state
                     if (IsFirstAuthChange(Authority.NotAuthoritative, authoritiesChangedTags[i]))
                     {
@@ -130,15 +130,15 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 }
             }
 
-            public override void InvokeOnComponentUpdateCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnComponentUpdateCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
             }
 
-            public override void InvokeOnEventCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnEventCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
             }
 
-            public override void InvokeOnCommandRequestCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnCommandRequestCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 if (!CommandRequestsComponentGroups[0].IsEmptyIgnoreFilter)
                 {
@@ -146,7 +146,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                     var commandRequestLists = CommandRequestsComponentGroups[0].GetComponentDataArray<CommandRequests.Cmd>();
                     for (var i = 0; i < entities.Length; i++)
                     {
-                        var injectableStore = entityIndexToInjectableStore[entities[i]];
+                        var injectableStore = entityToInjectableStore[entities[i]];
                         if (!injectableStore.TryGetInjectablesForComponent(commandRequestHandlerInjectableId, out var commandRequestHandlers))
                         {
                             continue;
@@ -164,12 +164,12 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
 
             }
 
-            public override void InvokeOnCommandResponseCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnCommandResponseCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 // TODO UTY-542 Command Response handlers
             }
 
-            public override void InvokeOnAuthorityGainedCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityGainedCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 if (AuthorityGainedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -182,7 +182,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 // Call once on all entities unless they flip-flopped back into the state they started in
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i]];
+                    var injectableStore = entityToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -198,7 +198,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 }
             }
 
-            public override void InvokeOnAuthorityLostCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityLostCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 if (AuthorityLostComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -211,7 +211,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 // Call once on all entities unless they flip-flopped back into the state they started in
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i]];
+                    var injectableStore = entityToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -239,7 +239,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 return false;
             }
 
-            public override void InvokeOnAuthorityLossImminentCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityLossImminentCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 if (AuthorityLossImminentComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -251,7 +251,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 // Call once on all entities
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i]];
+                    var injectableStore = entityToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsGameObjectComponentDispatcher.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsGameObjectComponentDispatcher.cs
@@ -60,7 +60,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
             private static readonly InjectableId readerWriterInjectableId = new InjectableId(InjectableType.ReaderWriter, componentId);
             private static readonly InjectableId commandRequestHandlerInjectableId = new InjectableId(InjectableType.CommandRequestHandler, componentId);
 
-            public override void MarkComponentsAddedForActivation(Dictionary<int, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkComponentsAddedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
             {
                 if (ComponentAddedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -70,12 +70,12 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 var entities = ComponentAddedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i].Index];
+                    var activationManager = entityIndexToManagers[entities[i]];
                     activationManager.AddComponent(componentId);
                 }
             }
 
-            public override void MarkComponentsRemovedForDeactivation(Dictionary<int, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkComponentsRemovedForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
             {
                 if (ComponentRemovedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -85,12 +85,12 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 var entities = ComponentRemovedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i].Index];
+                    var activationManager = entityIndexToManagers[entities[i]];
                     activationManager.RemoveComponent(componentId);
                 }
             }
 
-            public override void MarkAuthorityGainedForActivation(Dictionary<int, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkAuthorityGainedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
             {
                 if (AuthorityGainedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -101,7 +101,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 var entities = AuthorityGainedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i].Index];
+                    var activationManager = entityIndexToManagers[entities[i]];
                     // Call once except if flip-flopped back to starting state
                     if (IsFirstAuthChange(Authority.Authoritative, authoritiesChangedTags[i]))
                     {
@@ -110,7 +110,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 }
             }
 
-            public override void MarkAuthorityLostForDeactivation(Dictionary<int, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkAuthorityLostForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
             {
                 if (AuthorityLostComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -121,7 +121,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 var entities = AuthorityLostComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i].Index];
+                    var activationManager = entityIndexToManagers[entities[i]];
                     // Call once except if flip-flopped back to starting state
                     if (IsFirstAuthChange(Authority.NotAuthoritative, authoritiesChangedTags[i]))
                     {
@@ -130,15 +130,15 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 }
             }
 
-            public override void InvokeOnComponentUpdateCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnComponentUpdateCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
             }
 
-            public override void InvokeOnEventCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnEventCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
             }
 
-            public override void InvokeOnCommandRequestCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnCommandRequestCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 if (!CommandRequestsComponentGroups[0].IsEmptyIgnoreFilter)
                 {
@@ -146,7 +146,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                     var commandRequestLists = CommandRequestsComponentGroups[0].GetComponentDataArray<CommandRequests.Cmd>();
                     for (var i = 0; i < entities.Length; i++)
                     {
-                        var injectableStore = entityIndexToInjectableStore[entities[i].Index];
+                        var injectableStore = entityIndexToInjectableStore[entities[i]];
                         if (!injectableStore.TryGetInjectablesForComponent(commandRequestHandlerInjectableId, out var commandRequestHandlers))
                         {
                             continue;
@@ -164,12 +164,12 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
 
             }
 
-            public override void InvokeOnCommandResponseCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnCommandResponseCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 // TODO UTY-542 Command Response handlers
             }
 
-            public override void InvokeOnAuthorityGainedCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityGainedCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 if (AuthorityGainedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -182,7 +182,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 // Call once on all entities unless they flip-flopped back into the state they started in
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i].Index];
+                    var injectableStore = entityIndexToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -198,7 +198,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 }
             }
 
-            public override void InvokeOnAuthorityLostCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityLostCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 if (AuthorityLostComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -211,7 +211,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 // Call once on all entities unless they flip-flopped back into the state they started in
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i].Index];
+                    var injectableStore = entityIndexToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -239,7 +239,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 return false;
             }
 
-            public override void InvokeOnAuthorityLossImminentCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityLossImminentCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 if (AuthorityLossImminentComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -251,7 +251,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 // Call once on all entities
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i].Index];
+                    var injectableStore = entityIndexToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEventsGameObjectComponentDispatcher.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEventsGameObjectComponentDispatcher.cs
@@ -59,7 +59,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
             private const uint componentId = 1004;
             private static readonly InjectableId readerWriterInjectableId = new InjectableId(InjectableType.ReaderWriter, componentId);
 
-            public override void MarkComponentsAddedForActivation(Dictionary<int, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkComponentsAddedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
             {
                 if (ComponentAddedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -69,12 +69,12 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 var entities = ComponentAddedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i].Index];
+                    var activationManager = entityIndexToManagers[entities[i]];
                     activationManager.AddComponent(componentId);
                 }
             }
 
-            public override void MarkComponentsRemovedForDeactivation(Dictionary<int, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkComponentsRemovedForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
             {
                 if (ComponentRemovedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -84,12 +84,12 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 var entities = ComponentRemovedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i].Index];
+                    var activationManager = entityIndexToManagers[entities[i]];
                     activationManager.RemoveComponent(componentId);
                 }
             }
 
-            public override void MarkAuthorityGainedForActivation(Dictionary<int, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkAuthorityGainedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
             {
                 if (AuthorityGainedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -100,7 +100,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 var entities = AuthorityGainedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i].Index];
+                    var activationManager = entityIndexToManagers[entities[i]];
                     // Call once except if flip-flopped back to starting state
                     if (IsFirstAuthChange(Authority.Authoritative, authoritiesChangedTags[i]))
                     {
@@ -109,7 +109,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 }
             }
 
-            public override void MarkAuthorityLostForDeactivation(Dictionary<int, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkAuthorityLostForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
             {
                 if (AuthorityLostComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -120,7 +120,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 var entities = AuthorityLostComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i].Index];
+                    var activationManager = entityIndexToManagers[entities[i]];
                     // Call once except if flip-flopped back to starting state
                     if (IsFirstAuthChange(Authority.NotAuthoritative, authoritiesChangedTags[i]))
                     {
@@ -129,11 +129,11 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 }
             }
 
-            public override void InvokeOnComponentUpdateCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnComponentUpdateCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
             }
 
-            public override void InvokeOnEventCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnEventCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 if (!EventsReceivedComponentGroups[0].IsEmptyIgnoreFilter)
                 {
@@ -141,7 +141,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                     var eventLists = EventsReceivedComponentGroups[0].GetComponentDataArray<ReceivedEvents.Evt>();
                     for (var i = 0; i < entities.Length; i++)
                     {
-                        var injectableStore = entityIndexToInjectableStore[entities[i].Index];
+                        var injectableStore = entityIndexToInjectableStore[entities[i]];
                         if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                         {
                             continue;
@@ -161,16 +161,16 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
 
             }
 
-            public override void InvokeOnCommandRequestCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnCommandRequestCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
             }
 
-            public override void InvokeOnCommandResponseCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnCommandResponseCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 // TODO UTY-542 Command Response handlers
             }
 
-            public override void InvokeOnAuthorityGainedCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityGainedCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 if (AuthorityGainedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -183,7 +183,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 // Call once on all entities unless they flip-flopped back into the state they started in
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i].Index];
+                    var injectableStore = entityIndexToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -199,7 +199,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 }
             }
 
-            public override void InvokeOnAuthorityLostCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityLostCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 if (AuthorityLostComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -212,7 +212,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 // Call once on all entities unless they flip-flopped back into the state they started in
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i].Index];
+                    var injectableStore = entityIndexToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -240,7 +240,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 return false;
             }
 
-            public override void InvokeOnAuthorityLossImminentCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityLossImminentCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 if (AuthorityLossImminentComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -252,7 +252,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 // Call once on all entities
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i].Index];
+                    var injectableStore = entityIndexToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEventsGameObjectComponentDispatcher.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEventsGameObjectComponentDispatcher.cs
@@ -59,7 +59,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
             private const uint componentId = 1004;
             private static readonly InjectableId readerWriterInjectableId = new InjectableId(InjectableType.ReaderWriter, componentId);
 
-            public override void MarkComponentsAddedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkComponentsAddedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityToManagers)
             {
                 if (ComponentAddedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -69,12 +69,12 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 var entities = ComponentAddedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i]];
+                    var activationManager = entityToManagers[entities[i]];
                     activationManager.AddComponent(componentId);
                 }
             }
 
-            public override void MarkComponentsRemovedForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkComponentsRemovedForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityToManagers)
             {
                 if (ComponentRemovedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -84,12 +84,12 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 var entities = ComponentRemovedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i]];
+                    var activationManager = entityToManagers[entities[i]];
                     activationManager.RemoveComponent(componentId);
                 }
             }
 
-            public override void MarkAuthorityGainedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkAuthorityGainedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityToManagers)
             {
                 if (AuthorityGainedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -100,7 +100,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 var entities = AuthorityGainedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i]];
+                    var activationManager = entityToManagers[entities[i]];
                     // Call once except if flip-flopped back to starting state
                     if (IsFirstAuthChange(Authority.Authoritative, authoritiesChangedTags[i]))
                     {
@@ -109,7 +109,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 }
             }
 
-            public override void MarkAuthorityLostForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkAuthorityLostForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityToManagers)
             {
                 if (AuthorityLostComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -120,7 +120,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 var entities = AuthorityLostComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i]];
+                    var activationManager = entityToManagers[entities[i]];
                     // Call once except if flip-flopped back to starting state
                     if (IsFirstAuthChange(Authority.NotAuthoritative, authoritiesChangedTags[i]))
                     {
@@ -129,11 +129,11 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 }
             }
 
-            public override void InvokeOnComponentUpdateCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnComponentUpdateCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
             }
 
-            public override void InvokeOnEventCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnEventCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 if (!EventsReceivedComponentGroups[0].IsEmptyIgnoreFilter)
                 {
@@ -141,7 +141,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                     var eventLists = EventsReceivedComponentGroups[0].GetComponentDataArray<ReceivedEvents.Evt>();
                     for (var i = 0; i < entities.Length; i++)
                     {
-                        var injectableStore = entityIndexToInjectableStore[entities[i]];
+                        var injectableStore = entityToInjectableStore[entities[i]];
                         if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                         {
                             continue;
@@ -161,16 +161,16 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
 
             }
 
-            public override void InvokeOnCommandRequestCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnCommandRequestCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
             }
 
-            public override void InvokeOnCommandResponseCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnCommandResponseCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 // TODO UTY-542 Command Response handlers
             }
 
-            public override void InvokeOnAuthorityGainedCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityGainedCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 if (AuthorityGainedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -183,7 +183,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 // Call once on all entities unless they flip-flopped back into the state they started in
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i]];
+                    var injectableStore = entityToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -199,7 +199,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 }
             }
 
-            public override void InvokeOnAuthorityLostCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityLostCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 if (AuthorityLostComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -212,7 +212,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 // Call once on all entities unless they flip-flopped back into the state they started in
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i]];
+                    var injectableStore = entityToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -240,7 +240,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 return false;
             }
 
-            public override void InvokeOnAuthorityLossImminentCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityLossImminentCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 if (AuthorityLossImminentComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -252,7 +252,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 // Call once on all entities
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i]];
+                    var injectableStore = entityToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentGameObjectComponentDispatcher.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentGameObjectComponentDispatcher.cs
@@ -64,7 +64,7 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
             private static readonly InjectableId readerWriterInjectableId = new InjectableId(InjectableType.ReaderWriter, componentId);
             private static readonly InjectableId commandRequestHandlerInjectableId = new InjectableId(InjectableType.CommandRequestHandler, componentId);
 
-            public override void MarkComponentsAddedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkComponentsAddedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityToManagers)
             {
                 if (ComponentAddedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -74,12 +74,12 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                 var entities = ComponentAddedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i]];
+                    var activationManager = entityToManagers[entities[i]];
                     activationManager.AddComponent(componentId);
                 }
             }
 
-            public override void MarkComponentsRemovedForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkComponentsRemovedForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityToManagers)
             {
                 if (ComponentRemovedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -89,12 +89,12 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                 var entities = ComponentRemovedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i]];
+                    var activationManager = entityToManagers[entities[i]];
                     activationManager.RemoveComponent(componentId);
                 }
             }
 
-            public override void MarkAuthorityGainedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkAuthorityGainedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityToManagers)
             {
                 if (AuthorityGainedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -105,7 +105,7 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                 var entities = AuthorityGainedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i]];
+                    var activationManager = entityToManagers[entities[i]];
                     // Call once except if flip-flopped back to starting state
                     if (IsFirstAuthChange(Authority.Authoritative, authoritiesChangedTags[i]))
                     {
@@ -114,7 +114,7 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                 }
             }
 
-            public override void MarkAuthorityLostForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkAuthorityLostForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityToManagers)
             {
                 if (AuthorityLostComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -125,7 +125,7 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                 var entities = AuthorityLostComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i]];
+                    var activationManager = entityToManagers[entities[i]];
                     // Call once except if flip-flopped back to starting state
                     if (IsFirstAuthChange(Authority.NotAuthoritative, authoritiesChangedTags[i]))
                     {
@@ -134,7 +134,7 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                 }
             }
 
-            public override void InvokeOnComponentUpdateCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnComponentUpdateCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 if (ComponentsUpdatedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -145,7 +145,7 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                 var updateLists = ComponentsUpdatedComponentGroup.GetComponentDataArray<Generated.Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReceivedUpdates>();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i]];
+                    var injectableStore = entityToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -162,7 +162,7 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                 }
             }
 
-            public override void InvokeOnEventCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnEventCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 if (!EventsReceivedComponentGroups[0].IsEmptyIgnoreFilter)
                 {
@@ -170,7 +170,7 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                     var eventLists = EventsReceivedComponentGroups[0].GetComponentDataArray<ReceivedEvents.FirstEvent>();
                     for (var i = 0; i < entities.Length; i++)
                     {
-                        var injectableStore = entityIndexToInjectableStore[entities[i]];
+                        var injectableStore = entityToInjectableStore[entities[i]];
                         if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                         {
                             continue;
@@ -194,7 +194,7 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                     var eventLists = EventsReceivedComponentGroups[1].GetComponentDataArray<ReceivedEvents.SecondEvent>();
                     for (var i = 0; i < entities.Length; i++)
                     {
-                        var injectableStore = entityIndexToInjectableStore[entities[i]];
+                        var injectableStore = entityToInjectableStore[entities[i]];
                         if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                         {
                             continue;
@@ -214,7 +214,7 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
 
             }
 
-            public override void InvokeOnCommandRequestCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnCommandRequestCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 if (!CommandRequestsComponentGroups[0].IsEmptyIgnoreFilter)
                 {
@@ -222,7 +222,7 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                     var commandRequestLists = CommandRequestsComponentGroups[0].GetComponentDataArray<CommandRequests.FirstCommand>();
                     for (var i = 0; i < entities.Length; i++)
                     {
-                        var injectableStore = entityIndexToInjectableStore[entities[i]];
+                        var injectableStore = entityToInjectableStore[entities[i]];
                         if (!injectableStore.TryGetInjectablesForComponent(commandRequestHandlerInjectableId, out var commandRequestHandlers))
                         {
                             continue;
@@ -244,7 +244,7 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                     var commandRequestLists = CommandRequestsComponentGroups[1].GetComponentDataArray<CommandRequests.SecondCommand>();
                     for (var i = 0; i < entities.Length; i++)
                     {
-                        var injectableStore = entityIndexToInjectableStore[entities[i]];
+                        var injectableStore = entityToInjectableStore[entities[i]];
                         if (!injectableStore.TryGetInjectablesForComponent(commandRequestHandlerInjectableId, out var commandRequestHandlers))
                         {
                             continue;
@@ -262,12 +262,12 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
 
             }
 
-            public override void InvokeOnCommandResponseCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnCommandResponseCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 // TODO UTY-542 Command Response handlers
             }
 
-            public override void InvokeOnAuthorityGainedCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityGainedCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 if (AuthorityGainedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -280,7 +280,7 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                 // Call once on all entities unless they flip-flopped back into the state they started in
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i]];
+                    var injectableStore = entityToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -296,7 +296,7 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                 }
             }
 
-            public override void InvokeOnAuthorityLostCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityLostCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 if (AuthorityLostComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -309,7 +309,7 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                 // Call once on all entities unless they flip-flopped back into the state they started in
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i]];
+                    var injectableStore = entityToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -337,7 +337,7 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                 return false;
             }
 
-            public override void InvokeOnAuthorityLossImminentCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityLossImminentCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 if (AuthorityLossImminentComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -349,7 +349,7 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                 // Call once on all entities
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i]];
+                    var injectableStore = entityToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentGameObjectComponentDispatcher.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentGameObjectComponentDispatcher.cs
@@ -64,7 +64,7 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
             private static readonly InjectableId readerWriterInjectableId = new InjectableId(InjectableType.ReaderWriter, componentId);
             private static readonly InjectableId commandRequestHandlerInjectableId = new InjectableId(InjectableType.CommandRequestHandler, componentId);
 
-            public override void MarkComponentsAddedForActivation(Dictionary<int, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkComponentsAddedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
             {
                 if (ComponentAddedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -74,12 +74,12 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                 var entities = ComponentAddedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i].Index];
+                    var activationManager = entityIndexToManagers[entities[i]];
                     activationManager.AddComponent(componentId);
                 }
             }
 
-            public override void MarkComponentsRemovedForDeactivation(Dictionary<int, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkComponentsRemovedForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
             {
                 if (ComponentRemovedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -89,12 +89,12 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                 var entities = ComponentRemovedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i].Index];
+                    var activationManager = entityIndexToManagers[entities[i]];
                     activationManager.RemoveComponent(componentId);
                 }
             }
 
-            public override void MarkAuthorityGainedForActivation(Dictionary<int, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkAuthorityGainedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
             {
                 if (AuthorityGainedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -105,7 +105,7 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                 var entities = AuthorityGainedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i].Index];
+                    var activationManager = entityIndexToManagers[entities[i]];
                     // Call once except if flip-flopped back to starting state
                     if (IsFirstAuthChange(Authority.Authoritative, authoritiesChangedTags[i]))
                     {
@@ -114,7 +114,7 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                 }
             }
 
-            public override void MarkAuthorityLostForDeactivation(Dictionary<int, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkAuthorityLostForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
             {
                 if (AuthorityLostComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -125,7 +125,7 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                 var entities = AuthorityLostComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i].Index];
+                    var activationManager = entityIndexToManagers[entities[i]];
                     // Call once except if flip-flopped back to starting state
                     if (IsFirstAuthChange(Authority.NotAuthoritative, authoritiesChangedTags[i]))
                     {
@@ -134,7 +134,7 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                 }
             }
 
-            public override void InvokeOnComponentUpdateCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnComponentUpdateCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 if (ComponentsUpdatedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -145,7 +145,7 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                 var updateLists = ComponentsUpdatedComponentGroup.GetComponentDataArray<Generated.Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.ReceivedUpdates>();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i].Index];
+                    var injectableStore = entityIndexToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -162,7 +162,7 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                 }
             }
 
-            public override void InvokeOnEventCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnEventCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 if (!EventsReceivedComponentGroups[0].IsEmptyIgnoreFilter)
                 {
@@ -170,7 +170,7 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                     var eventLists = EventsReceivedComponentGroups[0].GetComponentDataArray<ReceivedEvents.FirstEvent>();
                     for (var i = 0; i < entities.Length; i++)
                     {
-                        var injectableStore = entityIndexToInjectableStore[entities[i].Index];
+                        var injectableStore = entityIndexToInjectableStore[entities[i]];
                         if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                         {
                             continue;
@@ -194,7 +194,7 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                     var eventLists = EventsReceivedComponentGroups[1].GetComponentDataArray<ReceivedEvents.SecondEvent>();
                     for (var i = 0; i < entities.Length; i++)
                     {
-                        var injectableStore = entityIndexToInjectableStore[entities[i].Index];
+                        var injectableStore = entityIndexToInjectableStore[entities[i]];
                         if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                         {
                             continue;
@@ -214,7 +214,7 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
 
             }
 
-            public override void InvokeOnCommandRequestCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnCommandRequestCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 if (!CommandRequestsComponentGroups[0].IsEmptyIgnoreFilter)
                 {
@@ -222,7 +222,7 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                     var commandRequestLists = CommandRequestsComponentGroups[0].GetComponentDataArray<CommandRequests.FirstCommand>();
                     for (var i = 0; i < entities.Length; i++)
                     {
-                        var injectableStore = entityIndexToInjectableStore[entities[i].Index];
+                        var injectableStore = entityIndexToInjectableStore[entities[i]];
                         if (!injectableStore.TryGetInjectablesForComponent(commandRequestHandlerInjectableId, out var commandRequestHandlers))
                         {
                             continue;
@@ -244,7 +244,7 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                     var commandRequestLists = CommandRequestsComponentGroups[1].GetComponentDataArray<CommandRequests.SecondCommand>();
                     for (var i = 0; i < entities.Length; i++)
                     {
-                        var injectableStore = entityIndexToInjectableStore[entities[i].Index];
+                        var injectableStore = entityIndexToInjectableStore[entities[i]];
                         if (!injectableStore.TryGetInjectablesForComponent(commandRequestHandlerInjectableId, out var commandRequestHandlers))
                         {
                             continue;
@@ -262,12 +262,12 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
 
             }
 
-            public override void InvokeOnCommandResponseCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnCommandResponseCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 // TODO UTY-542 Command Response handlers
             }
 
-            public override void InvokeOnAuthorityGainedCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityGainedCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 if (AuthorityGainedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -280,7 +280,7 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                 // Call once on all entities unless they flip-flopped back into the state they started in
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i].Index];
+                    var injectableStore = entityIndexToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -296,7 +296,7 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                 }
             }
 
-            public override void InvokeOnAuthorityLostCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityLostCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 if (AuthorityLostComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -309,7 +309,7 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                 // Call once on all entities unless they flip-flopped back into the state they started in
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i].Index];
+                    var injectableStore = entityIndexToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -337,7 +337,7 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                 return false;
             }
 
-            public override void InvokeOnAuthorityLossImminentCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityLossImminentCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 if (AuthorityLossImminentComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -349,7 +349,7 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                 // Call once on all entities
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i].Index];
+                    var injectableStore = entityIndexToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;

--- a/workers/unity/Assets/Playground/Scripts/EntityInitialization/GameObjectInitializationSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/EntityInitialization/GameObjectInitializationSystem.cs
@@ -40,7 +40,7 @@ namespace Playground
         private ViewCommandBuffer viewCommandBuffer;
         private EntityGameObjectCreator entityGameObjectCreator;
         private EntityGameObjectLinker entityGameObjectLinker;
-        private readonly Dictionary<int, GameObject> entityGameObjectCache = new Dictionary<int, GameObject>();
+        private readonly Dictionary<Entity, GameObject> entityGameObjectCache = new Dictionary<Entity, GameObject>();
 
         protected override void OnCreateManager(int capacity)
         {
@@ -87,7 +87,7 @@ namespace Playground
 
                 var requiresSpatialOSBehaviourManagerComponent = new RequiresMonoBehaviourActivationManager();
 
-                entityGameObjectCache[entity.Index] = gameObject;
+                entityGameObjectCache.Add(entity, gameObject);
                 var gameObjectReferenceHandleComponent = new GameObjectReferenceHandle();
 
                 PostUpdateCommands.AddComponent(addedEntitiesData.Entities[i], gameObjectReferenceHandleComponent);
@@ -103,17 +103,17 @@ namespace Playground
             for (var i = 0; i < removedEntitiesData.Length; i++)
             {
                 var entity = removedEntitiesData.Entities[i];
-                var entityIndex = entity.Index;
 
-                if (!entityGameObjectCache.TryGetValue(entityIndex, out var gameObject))
+                if (!entityGameObjectCache.TryGetValue(entity, out var gameObject))
                 {
                     worker.LogDispatcher.HandleLog(LogType.Error, new LogEvent(
                             "GameObject corresponding to removed entity not found.")
-                        .WithField("EntityIndex", entityIndex));
+                        .WithField("EntityIndex", entity.Index)
+                        .WithField("EntityVersion", entity.Version));
                     continue;
                 }
 
-                entityGameObjectCache.Remove(entityIndex);
+                entityGameObjectCache.Remove(entity);
                 UnityObjectDestroyer.Destroy(gameObject);
                 PostUpdateCommands.RemoveComponent<GameObjectReferenceHandle>(entity);
             }

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/GameObjectComponentDispatcherBase.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/GameObjectComponentDispatcherBase.cs
@@ -24,20 +24,20 @@ namespace Improbable.Gdk.Core.GameObjectRepresentation
         public ComponentGroup[] CommandRequestsComponentGroups { get; set; }
 
         public abstract void MarkComponentsAddedForActivation
-            (Dictionary<int, MonoBehaviourActivationManager> entityIndexToManagers);
+            (Dictionary<Entity, MonoBehaviourActivationManager> entityIndexToManagers);
         public abstract void MarkComponentsRemovedForDeactivation
-            (Dictionary<int, MonoBehaviourActivationManager> entityIndexToManagers);
+            (Dictionary<Entity, MonoBehaviourActivationManager> entityIndexToManagers);
         public abstract void MarkAuthorityGainedForActivation
-            (Dictionary<int, MonoBehaviourActivationManager> entityIndexToManagers);
+            (Dictionary<Entity, MonoBehaviourActivationManager> entityIndexToManagers);
         public abstract void MarkAuthorityLostForDeactivation
-            (Dictionary<int, MonoBehaviourActivationManager> entityIndexToManagers);
+            (Dictionary<Entity, MonoBehaviourActivationManager> entityIndexToManagers);
 
-        public abstract void InvokeOnComponentUpdateCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore);
-        public abstract void InvokeOnEventCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore);
-        public abstract void InvokeOnCommandRequestCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore);
-        public abstract void InvokeOnCommandResponseCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore);
-        public abstract void InvokeOnAuthorityGainedCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore);
-        public abstract void InvokeOnAuthorityLostCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore);
-        public abstract void InvokeOnAuthorityLossImminentCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore);
+        public abstract void InvokeOnComponentUpdateCallbacks(Dictionary<Entity, InjectableStore> entityIndexToInjectableStore);
+        public abstract void InvokeOnEventCallbacks(Dictionary<Entity, InjectableStore> entityIndexToInjectableStore);
+        public abstract void InvokeOnCommandRequestCallbacks(Dictionary<Entity, InjectableStore> entityIndexToInjectableStore);
+        public abstract void InvokeOnCommandResponseCallbacks(Dictionary<Entity, InjectableStore> entityIndexToInjectableStore);
+        public abstract void InvokeOnAuthorityGainedCallbacks(Dictionary<Entity, InjectableStore> entityIndexToInjectableStore);
+        public abstract void InvokeOnAuthorityLostCallbacks(Dictionary<Entity, InjectableStore> entityIndexToInjectableStore);
+        public abstract void InvokeOnAuthorityLossImminentCallbacks(Dictionary<Entity, InjectableStore> entityIndexToInjectableStore);
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/GameObjectDispatcherSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/GameObjectDispatcherSystem.cs
@@ -106,47 +106,47 @@ namespace Improbable.Gdk.Core.GameObjectRepresentation
         {
             foreach (var gameObjectComponentDispatcher in GameObjectComponentDispatchers)
             {
-                gameObjectComponentDispatcher.MarkComponentsRemovedForDeactivation(entityIndexToActivationManager);
-                gameObjectComponentDispatcher.MarkAuthorityLostForDeactivation(entityIndexToActivationManager);
+                gameObjectComponentDispatcher.MarkComponentsRemovedForDeactivation(entityToActivationManager);
+                gameObjectComponentDispatcher.MarkAuthorityLostForDeactivation(entityToActivationManager);
             }
 
-            foreach (var indexManagerPair in entityIndexToActivationManager)
+            foreach (var indexManagerPair in entityToActivationManager)
             {
                 indexManagerPair.Value.DisableSpatialOSBehaviours();
             }
 
             foreach (var gameObjectComponentDispatcher in GameObjectComponentDispatchers)
             {
-                gameObjectComponentDispatcher.InvokeOnAuthorityLostCallbacks(entityIndexToReaderWriterStore);
+                gameObjectComponentDispatcher.InvokeOnAuthorityLostCallbacks(entityToReaderWriterStore);
             }
 
             foreach (var gameObjectComponentDispatcher in GameObjectComponentDispatchers)
             {
-                gameObjectComponentDispatcher.InvokeOnComponentUpdateCallbacks(entityIndexToReaderWriterStore);
-                gameObjectComponentDispatcher.InvokeOnEventCallbacks(entityIndexToReaderWriterStore);
+                gameObjectComponentDispatcher.InvokeOnComponentUpdateCallbacks(entityToReaderWriterStore);
+                gameObjectComponentDispatcher.InvokeOnEventCallbacks(entityToReaderWriterStore);
             }
 
             foreach (var gameObjectComponentDispatcher in GameObjectComponentDispatchers)
             {
-                gameObjectComponentDispatcher.InvokeOnAuthorityGainedCallbacks(entityIndexToReaderWriterStore);
+                gameObjectComponentDispatcher.InvokeOnAuthorityGainedCallbacks(entityToReaderWriterStore);
             }
 
             foreach (var gameObjectComponentDispatcher in GameObjectComponentDispatchers)
             {
-                gameObjectComponentDispatcher.MarkAuthorityGainedForActivation(entityIndexToActivationManager);
-                gameObjectComponentDispatcher.MarkComponentsAddedForActivation(entityIndexToActivationManager);
+                gameObjectComponentDispatcher.MarkAuthorityGainedForActivation(entityToActivationManager);
+                gameObjectComponentDispatcher.MarkComponentsAddedForActivation(entityToActivationManager);
             }
 
-            foreach (var indexManagerPair in entityIndexToActivationManager)
+            foreach (var indexManagerPair in entityToActivationManager)
             {
                 indexManagerPair.Value.EnableSpatialOSBehaviours();
             }
 
             foreach (var gameObjectComponentDispatcher in GameObjectComponentDispatchers)
             {
-                gameObjectComponentDispatcher.InvokeOnAuthorityLossImminentCallbacks(entityIndexToReaderWriterStore);
-                gameObjectComponentDispatcher.InvokeOnCommandRequestCallbacks(entityIndexToReaderWriterStore);
-                gameObjectComponentDispatcher.InvokeOnCommandResponseCallbacks(entityIndexToReaderWriterStore);
+                gameObjectComponentDispatcher.InvokeOnAuthorityLossImminentCallbacks(entityToReaderWriterStore);
+                gameObjectComponentDispatcher.InvokeOnCommandRequestCallbacks(entityToReaderWriterStore);
+                gameObjectComponentDispatcher.InvokeOnCommandResponseCallbacks(entityToReaderWriterStore);
             }
         }
 
@@ -166,7 +166,7 @@ namespace Improbable.Gdk.Core.GameObjectRepresentation
 
         public void CreateActivationManagerAndReaderWriterStore(Entity entity)
         {
-            if (entityIndexToActivationManager.ContainsKey(entity))
+            if (entityToActivationManager.ContainsKey(entity))
             {
                 throw new ActivationManagerAlreadyExistsException($"MonoBehaviourActivationManager already exists for entity {entity.Index}.");
             }

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/GameObjectDispatcherSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/GameObjectDispatcherSystem.cs
@@ -12,9 +12,9 @@ namespace Improbable.Gdk.Core.GameObjectRepresentation
     [UpdateInGroup(typeof(SpatialOSReceiveGroup.GameObjectReceiveGroup))]
     internal class GameObjectDispatcherSystem : ComponentSystem
     {
-        private readonly Dictionary<Entity, MonoBehaviourActivationManager> entityIndexToActivationManager =
+        private readonly Dictionary<Entity, MonoBehaviourActivationManager> entityToActivationManager =
             new Dictionary<Entity, MonoBehaviourActivationManager>();
-        private readonly Dictionary<Entity, InjectableStore> entityIndexToReaderWriterStore =
+        private readonly Dictionary<Entity, InjectableStore> entityToReaderWriterStore =
             new Dictionary<Entity, InjectableStore>();
 
         public readonly List<GameObjectComponentDispatcherBase> GameObjectComponentDispatchers =
@@ -25,13 +25,13 @@ namespace Improbable.Gdk.Core.GameObjectRepresentation
 
         internal void RemoveActivationManagerAndReaderWriterStore(Entity entity)
         {
-            if (!entityIndexToActivationManager.ContainsKey(entity))
+            if (!entityToActivationManager.ContainsKey(entity))
             {
-                throw new ActivationManagerNotFoundException($"MonoBehaviourActivationManager not found for entityIndex {entity.Index}.");
+                throw new ActivationManagerNotFoundException($"MonoBehaviourActivationManager not found for entity {entity.Index}.");
             }
 
-            entityIndexToActivationManager.Remove(entity);
-            entityIndexToReaderWriterStore.Remove(entity);
+            entityToActivationManager.Remove(entity);
+            entityToReaderWriterStore.Remove(entity);
         }
 
         protected override void OnCreateManager(int capacity)
@@ -168,14 +168,14 @@ namespace Improbable.Gdk.Core.GameObjectRepresentation
         {
             if (entityIndexToActivationManager.ContainsKey(entity))
             {
-                throw new ActivationManagerAlreadyExistsException($"MonoBehaviourActivationManager already exists for entityIndex {entity.Index}.");
+                throw new ActivationManagerAlreadyExistsException($"MonoBehaviourActivationManager already exists for entity {entity.Index}.");
             }
 
             var gameObject = EntityManager.GetComponentObject<GameObjectReference>(entity).GameObject;
             var store = new InjectableStore();
-            entityIndexToReaderWriterStore[entity] = store;
+            entityToReaderWriterStore.Add(entity, store);
             var manager = new MonoBehaviourActivationManager(gameObject, injector, store, logger);
-            entityIndexToActivationManager[entity] = manager;
+            entityToActivationManager.Add(entity, manager);
         }
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/GameObjectDispatcherSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/GameObjectDispatcherSystem.cs
@@ -12,10 +12,10 @@ namespace Improbable.Gdk.Core.GameObjectRepresentation
     [UpdateInGroup(typeof(SpatialOSReceiveGroup.GameObjectReceiveGroup))]
     internal class GameObjectDispatcherSystem : ComponentSystem
     {
-        private readonly Dictionary<int, MonoBehaviourActivationManager> entityIndexToActivationManager =
-            new Dictionary<int, MonoBehaviourActivationManager>();
-        private readonly Dictionary<int, InjectableStore> entityIndexToReaderWriterStore =
-            new Dictionary<int, InjectableStore>();
+        private readonly Dictionary<Entity, MonoBehaviourActivationManager> entityIndexToActivationManager =
+            new Dictionary<Entity, MonoBehaviourActivationManager>();
+        private readonly Dictionary<Entity, InjectableStore> entityIndexToReaderWriterStore =
+            new Dictionary<Entity, InjectableStore>();
 
         public readonly List<GameObjectComponentDispatcherBase> GameObjectComponentDispatchers =
             new List<GameObjectComponentDispatcherBase>();
@@ -23,15 +23,15 @@ namespace Improbable.Gdk.Core.GameObjectRepresentation
         private RequiredFieldInjector injector;
         private ILogDispatcher logger;
 
-        internal void RemoveActivationManagerAndReaderWriterStore(int entityIndex)
+        internal void RemoveActivationManagerAndReaderWriterStore(Entity entity)
         {
-            if (!entityIndexToActivationManager.ContainsKey(entityIndex))
+            if (!entityIndexToActivationManager.ContainsKey(entity))
             {
-                throw new ActivationManagerNotFoundException($"MonoBehaviourActivationManager not found for entityIndex {entityIndex}.");
+                throw new ActivationManagerNotFoundException($"MonoBehaviourActivationManager not found for entityIndex {entity.Index}.");
             }
 
-            entityIndexToActivationManager.Remove(entityIndex);
-            entityIndexToReaderWriterStore.Remove(entityIndex);
+            entityIndexToActivationManager.Remove(entity);
+            entityIndexToReaderWriterStore.Remove(entity);
         }
 
         protected override void OnCreateManager(int capacity)
@@ -166,16 +166,16 @@ namespace Improbable.Gdk.Core.GameObjectRepresentation
 
         public void CreateActivationManagerAndReaderWriterStore(Entity entity)
         {
-            if (entityIndexToActivationManager.ContainsKey(entity.Index))
+            if (entityIndexToActivationManager.ContainsKey(entity))
             {
                 throw new ActivationManagerAlreadyExistsException($"MonoBehaviourActivationManager already exists for entityIndex {entity.Index}.");
             }
 
             var gameObject = EntityManager.GetComponentObject<GameObjectReference>(entity).GameObject;
             var store = new InjectableStore();
-            entityIndexToReaderWriterStore[entity.Index] = store;
+            entityIndexToReaderWriterStore[entity] = store;
             var manager = new MonoBehaviourActivationManager(gameObject, injector, store, logger);
-            entityIndexToActivationManager[entity.Index] = manager;
+            entityIndexToActivationManager[entity] = manager;
         }
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/Injection/MonoBehaviourActivationManagerInitializationSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/Injection/MonoBehaviourActivationManagerInitializationSystem.cs
@@ -49,8 +49,8 @@ namespace Improbable.Gdk.Core.GameObjectRepresentation
 
             for (var i = 0; i < removedEntitiesData.Length; i++)
             {
-                var entityIndex = removedEntitiesData.Entities[i].Index;
-                gameObjectDispatcherSystem.RemoveActivationManagerAndReaderWriterStore(entityIndex);
+                var entity = removedEntitiesData.Entities[i];
+                gameObjectDispatcherSystem.RemoveActivationManagerAndReaderWriterStore(entity);
             }
         }
     }

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityGameObjectComponentDispatcherGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityGameObjectComponentDispatcherGenerator.tt
@@ -78,7 +78,7 @@ namespace <#= qualifiedNamespace #>
             private static readonly InjectableId commandRequestHandlerInjectableId = new InjectableId(InjectableType.CommandRequestHandler, componentId);
 <# } #>
 
-            public override void MarkComponentsAddedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkComponentsAddedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityToManagers)
             {
                 if (ComponentAddedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -88,12 +88,12 @@ namespace <#= qualifiedNamespace #>
                 var entities = ComponentAddedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i]];
+                    var activationManager = entityToManagers[entities[i]];
                     activationManager.AddComponent(componentId);
                 }
             }
 
-            public override void MarkComponentsRemovedForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkComponentsRemovedForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityToManagers)
             {
                 if (ComponentRemovedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -103,12 +103,12 @@ namespace <#= qualifiedNamespace #>
                 var entities = ComponentRemovedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i]];
+                    var activationManager = entityToManagers[entities[i]];
                     activationManager.RemoveComponent(componentId);
                 }
             }
 
-            public override void MarkAuthorityGainedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkAuthorityGainedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityToManagers)
             {
                 if (AuthorityGainedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -119,7 +119,7 @@ namespace <#= qualifiedNamespace #>
                 var entities = AuthorityGainedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i]];
+                    var activationManager = entityToManagers[entities[i]];
                     // Call once except if flip-flopped back to starting state
                     if (IsFirstAuthChange(Authority.Authoritative, authoritiesChangedTags[i]))
                     {
@@ -128,7 +128,7 @@ namespace <#= qualifiedNamespace #>
                 }
             }
 
-            public override void MarkAuthorityLostForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkAuthorityLostForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityToManagers)
             {
                 if (AuthorityLostComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -139,7 +139,7 @@ namespace <#= qualifiedNamespace #>
                 var entities = AuthorityLostComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i]];
+                    var activationManager = entityToManagers[entities[i]];
                     // Call once except if flip-flopped back to starting state
                     if (IsFirstAuthChange(Authority.NotAuthoritative, authoritiesChangedTags[i]))
                     {
@@ -148,7 +148,7 @@ namespace <#= qualifiedNamespace #>
                 }
             }
 
-            public override void InvokeOnComponentUpdateCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnComponentUpdateCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
 <# if (fieldDetailsList.Count > 0) { #>
                 if (ComponentsUpdatedComponentGroup.IsEmptyIgnoreFilter)
@@ -160,7 +160,7 @@ namespace <#= qualifiedNamespace #>
                 var updateLists = ComponentsUpdatedComponentGroup.GetComponentDataArray<<#= componentNamespace #>.ReceivedUpdates>();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i]];
+                    var injectableStore = entityToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -178,7 +178,7 @@ namespace <#= qualifiedNamespace #>
 <# } #>
             }
 
-            public override void InvokeOnEventCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnEventCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
 <# for (var j = 0; j < eventDetailsList.Count; j++) { #>
                 if (!EventsReceivedComponentGroups[<#= j #>].IsEmptyIgnoreFilter)
@@ -187,7 +187,7 @@ namespace <#= qualifiedNamespace #>
                     var eventLists = EventsReceivedComponentGroups[<#= j #>].GetComponentDataArray<ReceivedEvents.<#= eventDetailsList[j].EventName #>>();
                     for (var i = 0; i < entities.Length; i++)
                     {
-                        var injectableStore = entityIndexToInjectableStore[entities[i]];
+                        var injectableStore = entityToInjectableStore[entities[i]];
                         if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                         {
                             continue;
@@ -208,7 +208,7 @@ namespace <#= qualifiedNamespace #>
 <# } #>
             }
 
-            public override void InvokeOnCommandRequestCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnCommandRequestCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
 <# for (var j = 0; j < commandDetailsList.Count; j++) { #>
                 if (!CommandRequestsComponentGroups[<#= j #>].IsEmptyIgnoreFilter)
@@ -217,7 +217,7 @@ namespace <#= qualifiedNamespace #>
                     var commandRequestLists = CommandRequestsComponentGroups[<#= j #>].GetComponentDataArray<CommandRequests.<#= commandDetailsList[j].CommandName #>>();
                     for (var i = 0; i < entities.Length; i++)
                     {
-                        var injectableStore = entityIndexToInjectableStore[entities[i]];
+                        var injectableStore = entityToInjectableStore[entities[i]];
                         if (!injectableStore.TryGetInjectablesForComponent(commandRequestHandlerInjectableId, out var commandRequestHandlers))
                         {
                             continue;
@@ -236,12 +236,12 @@ namespace <#= qualifiedNamespace #>
 <# } #>
             }
 
-            public override void InvokeOnCommandResponseCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnCommandResponseCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 // TODO UTY-542 Command Response handlers
             }
 
-            public override void InvokeOnAuthorityGainedCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityGainedCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 if (AuthorityGainedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -254,7 +254,7 @@ namespace <#= qualifiedNamespace #>
                 // Call once on all entities unless they flip-flopped back into the state they started in
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i]];
+                    var injectableStore = entityToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -270,7 +270,7 @@ namespace <#= qualifiedNamespace #>
                 }
             }
 
-            public override void InvokeOnAuthorityLostCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityLostCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 if (AuthorityLostComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -283,7 +283,7 @@ namespace <#= qualifiedNamespace #>
                 // Call once on all entities unless they flip-flopped back into the state they started in
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i]];
+                    var injectableStore = entityToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -311,7 +311,7 @@ namespace <#= qualifiedNamespace #>
                 return false;
             }
 
-            public override void InvokeOnAuthorityLossImminentCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityLossImminentCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityToInjectableStore)
             {
                 if (AuthorityLossImminentComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -323,7 +323,7 @@ namespace <#= qualifiedNamespace #>
                 // Call once on all entities
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i]];
+                    var injectableStore = entityToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityGameObjectComponentDispatcherGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityGameObjectComponentDispatcherGenerator.tt
@@ -78,7 +78,7 @@ namespace <#= qualifiedNamespace #>
             private static readonly InjectableId commandRequestHandlerInjectableId = new InjectableId(InjectableType.CommandRequestHandler, componentId);
 <# } #>
 
-            public override void MarkComponentsAddedForActivation(Dictionary<int, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkComponentsAddedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
             {
                 if (ComponentAddedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -88,12 +88,12 @@ namespace <#= qualifiedNamespace #>
                 var entities = ComponentAddedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i].Index];
+                    var activationManager = entityIndexToManagers[entities[i]];
                     activationManager.AddComponent(componentId);
                 }
             }
 
-            public override void MarkComponentsRemovedForDeactivation(Dictionary<int, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkComponentsRemovedForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
             {
                 if (ComponentRemovedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -103,12 +103,12 @@ namespace <#= qualifiedNamespace #>
                 var entities = ComponentRemovedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i].Index];
+                    var activationManager = entityIndexToManagers[entities[i]];
                     activationManager.RemoveComponent(componentId);
                 }
             }
 
-            public override void MarkAuthorityGainedForActivation(Dictionary<int, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkAuthorityGainedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
             {
                 if (AuthorityGainedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -119,7 +119,7 @@ namespace <#= qualifiedNamespace #>
                 var entities = AuthorityGainedComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i].Index];
+                    var activationManager = entityIndexToManagers[entities[i]];
                     // Call once except if flip-flopped back to starting state
                     if (IsFirstAuthChange(Authority.Authoritative, authoritiesChangedTags[i]))
                     {
@@ -128,7 +128,7 @@ namespace <#= qualifiedNamespace #>
                 }
             }
 
-            public override void MarkAuthorityLostForDeactivation(Dictionary<int, MonoBehaviourActivationManager> entityIndexToManagers)
+            public override void MarkAuthorityLostForDeactivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityIndexToManagers)
             {
                 if (AuthorityLostComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -139,7 +139,7 @@ namespace <#= qualifiedNamespace #>
                 var entities = AuthorityLostComponentGroup.GetEntityArray();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var activationManager = entityIndexToManagers[entities[i].Index];
+                    var activationManager = entityIndexToManagers[entities[i]];
                     // Call once except if flip-flopped back to starting state
                     if (IsFirstAuthChange(Authority.NotAuthoritative, authoritiesChangedTags[i]))
                     {
@@ -148,7 +148,7 @@ namespace <#= qualifiedNamespace #>
                 }
             }
 
-            public override void InvokeOnComponentUpdateCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnComponentUpdateCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
 <# if (fieldDetailsList.Count > 0) { #>
                 if (ComponentsUpdatedComponentGroup.IsEmptyIgnoreFilter)
@@ -160,7 +160,7 @@ namespace <#= qualifiedNamespace #>
                 var updateLists = ComponentsUpdatedComponentGroup.GetComponentDataArray<<#= componentNamespace #>.ReceivedUpdates>();
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i].Index];
+                    var injectableStore = entityIndexToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -178,7 +178,7 @@ namespace <#= qualifiedNamespace #>
 <# } #>
             }
 
-            public override void InvokeOnEventCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnEventCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
 <# for (var j = 0; j < eventDetailsList.Count; j++) { #>
                 if (!EventsReceivedComponentGroups[<#= j #>].IsEmptyIgnoreFilter)
@@ -187,7 +187,7 @@ namespace <#= qualifiedNamespace #>
                     var eventLists = EventsReceivedComponentGroups[<#= j #>].GetComponentDataArray<ReceivedEvents.<#= eventDetailsList[j].EventName #>>();
                     for (var i = 0; i < entities.Length; i++)
                     {
-                        var injectableStore = entityIndexToInjectableStore[entities[i].Index];
+                        var injectableStore = entityIndexToInjectableStore[entities[i]];
                         if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                         {
                             continue;
@@ -208,7 +208,7 @@ namespace <#= qualifiedNamespace #>
 <# } #>
             }
 
-            public override void InvokeOnCommandRequestCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnCommandRequestCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
 <# for (var j = 0; j < commandDetailsList.Count; j++) { #>
                 if (!CommandRequestsComponentGroups[<#= j #>].IsEmptyIgnoreFilter)
@@ -217,7 +217,7 @@ namespace <#= qualifiedNamespace #>
                     var commandRequestLists = CommandRequestsComponentGroups[<#= j #>].GetComponentDataArray<CommandRequests.<#= commandDetailsList[j].CommandName #>>();
                     for (var i = 0; i < entities.Length; i++)
                     {
-                        var injectableStore = entityIndexToInjectableStore[entities[i].Index];
+                        var injectableStore = entityIndexToInjectableStore[entities[i]];
                         if (!injectableStore.TryGetInjectablesForComponent(commandRequestHandlerInjectableId, out var commandRequestHandlers))
                         {
                             continue;
@@ -236,12 +236,12 @@ namespace <#= qualifiedNamespace #>
 <# } #>
             }
 
-            public override void InvokeOnCommandResponseCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnCommandResponseCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 // TODO UTY-542 Command Response handlers
             }
 
-            public override void InvokeOnAuthorityGainedCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityGainedCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 if (AuthorityGainedComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -254,7 +254,7 @@ namespace <#= qualifiedNamespace #>
                 // Call once on all entities unless they flip-flopped back into the state they started in
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i].Index];
+                    var injectableStore = entityIndexToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -270,7 +270,7 @@ namespace <#= qualifiedNamespace #>
                 }
             }
 
-            public override void InvokeOnAuthorityLostCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityLostCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 if (AuthorityLostComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -283,7 +283,7 @@ namespace <#= qualifiedNamespace #>
                 // Call once on all entities unless they flip-flopped back into the state they started in
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i].Index];
+                    var injectableStore = entityIndexToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;
@@ -311,7 +311,7 @@ namespace <#= qualifiedNamespace #>
                 return false;
             }
 
-            public override void InvokeOnAuthorityLossImminentCallbacks(Dictionary<int, InjectableStore> entityIndexToInjectableStore)
+            public override void InvokeOnAuthorityLossImminentCallbacks(Dictionary<Unity.Entities.Entity, InjectableStore> entityIndexToInjectableStore)
             {
                 if (AuthorityLossImminentComponentGroup.IsEmptyIgnoreFilter)
                 {
@@ -323,7 +323,7 @@ namespace <#= qualifiedNamespace #>
                 // Call once on all entities
                 for (var i = 0; i < entities.Length; i++)
                 {
-                    var injectableStore = entityIndexToInjectableStore[entities[i].Index];
+                    var injectableStore = entityIndexToInjectableStore[entities[i]];
                     if (!injectableStore.TryGetInjectablesForComponent(readerWriterInjectableId, out var readersWriters))
                     {
                         continue;


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
We have been using the entity index instead of the entity to identify entities in our game object representation module. This is not unique (you need the index and the version) and caused some interesting bugs.

 #### Tests
Ran it locally and checked whether the error still appeared. Now you can build out the gamelogic worker and connect/disconnect the client as often as you want without it throwing errors.

#### Documentation
internal implementation

#### Primary reviewers
@JonasImprobable @zeroZshadow 