### PR TITLE
adding more osx specific paths

### DIFF
--- a/workers/unity/Packages/com.improbable.gdk.tools/Common.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/Common.cs
@@ -85,6 +85,11 @@ namespace Improbable.Gdk.Tools
             }
         }
 
+        private static string[] GetCommonMacPaths()
+        {
+            return new[] { UsrLocalBinDir, UsrLocalShareDir };
+        }
+
         /// <summary>
         ///     Tries to find the full path to a binary in the system PATH.
         ///     On MacOS, also looks in `/usr/local/bin` because applications launched from the Finder
@@ -97,7 +102,7 @@ namespace Improbable.Gdk.Tools
             var pathValue = Environment.GetEnvironmentVariable("PATH");
             if (pathValue == null)
             {
-                Debug.LogError($"PATH has not been specified in the system environment.");
+                Debug.LogError("PATH has not been specified in the system environment.");
                 return string.Empty;
             }
 
@@ -115,16 +120,11 @@ namespace Improbable.Gdk.Tools
 
             if (Application.platform == RuntimePlatform.OSXEditor)
             {
-                if (!splitPath.Contains(UsrLocalBinDir))
+                var macPaths = GetCommonMacPaths();
+                splitPath = splitPath.Union(macPaths).ToArray();
+                foreach (var macPath in macPaths)
                 {
-                    var usrLocalBinPaths = new[] { UsrLocalBinDir, Path.Combine(UsrLocalBinDir, binarybaseName) };
-                    splitPath = splitPath.Union(usrLocalBinPaths).ToArray();
-                }
-
-                if (!splitPath.Contains(UsrLocalShareDir))
-                {
-                    var usrLocalSharePaths = new[] { UsrLocalShareDir, Path.Combine(UsrLocalShareDir, binarybaseName) };
-                    splitPath = splitPath.Union(usrLocalSharePaths).ToArray();
+                    splitPath = splitPath.Union(new[] { Path.Combine(macPath, binarybaseName) }).ToArray();
                 }
             }
 

--- a/workers/unity/Packages/com.improbable.gdk.tools/Common.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/Common.cs
@@ -32,6 +32,8 @@ namespace Improbable.Gdk.Tools
         private const string UsrLocalBinDir = "/usr/local/bin";
         private const string UsrLocalShareDir = "/usr/local/share";
 
+        private static readonly string[] MacPaths = { UsrLocalBinDir, UsrLocalShareDir };
+
 
         static Common()
         {
@@ -85,11 +87,6 @@ namespace Improbable.Gdk.Tools
             }
         }
 
-        private static string[] GetCommonMacPaths()
-        {
-            return new[] { UsrLocalBinDir, UsrLocalShareDir };
-        }
-
         /// <summary>
         ///     Tries to find the full path to a binary in the system PATH.
         ///     On MacOS, also looks in `/usr/local/bin` because applications launched from the Finder
@@ -120,11 +117,12 @@ namespace Improbable.Gdk.Tools
 
             if (Application.platform == RuntimePlatform.OSXEditor)
             {
-                var macPaths = GetCommonMacPaths();
-                splitPath = splitPath.Union(macPaths).ToArray();
-                foreach (var macPath in macPaths)
+                foreach (var macPath in MacPaths)
                 {
-                    splitPath = splitPath.Union(new[] { Path.Combine(macPath, binarybaseName) }).ToArray();
+                    if (!splitPath.Contains(macPath))
+                    {
+                        splitPath = splitPath.Union(new[] { macPath, Path.Combine(macPath, binarybaseName) }).ToArray();                        
+                    }
                 }
             }
 

--- a/workers/unity/Packages/com.improbable.gdk.tools/DownloadCoreSdk.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/DownloadCoreSdk.cs
@@ -105,7 +105,7 @@ namespace Improbable.Gdk.Tools
         /// <summary>
         ///     Downloads and extracts the Core Sdk and associated libraries and tools.
         /// </summary>
-        internal static DownloadResult Download()
+        private static DownloadResult Download()
         {
             RemoveMarkerFile();
 


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
because on my mac dotnet is installed in `/usr/local/share/dotnet/dotnet`... and the given error messages didn't really help with debugging.

#### Tests
it managed to download the libraries.

#### Documentation
none needed

#### Primary reviewers
@jared-improbable 