### PR TITLE
Make GDK Tool Paths Configurable

### DIFF
--- a/workers/unity/Assets/Config.meta
+++ b/workers/unity/Assets/Config.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e9c4a76541cea6940b37775b43b6377e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Assets/Config/GdkToolsConfiguration.asset
+++ b/workers/unity/Assets/Config/GdkToolsConfiguration.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 79cf5b51897b27648a440611e3d87060, type: 3}
+  m_Name: GdkToolsConfiguration
+  m_EditorClassIdentifier: 
+  SchemaStdLibDir: ../../build/dependencies/schema/standard_library
+  SchemaSourceDirs:
+  - ../../schema
+  CodegenOutputDir: Assets/Generated/Source

--- a/workers/unity/Assets/Config/GdkToolsConfiguration.asset.meta
+++ b/workers/unity/Assets/Config/GdkToolsConfiguration.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e8a8bc237771adf4e91bfc069af56f69
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/com.improbable.gdk.tools/.DownloadCoreSdk/Program.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.DownloadCoreSdk/Program.cs
@@ -11,7 +11,7 @@ namespace Improbable
     {
         private static void Main(string[] args)
         {
-            if (args.Length != 2)
+            if (args.Length != 3)
             {
                 Console.Error.WriteLine("Usage: <path_to_spatial> <coresdk_version>");
                 Environment.Exit(1);
@@ -19,10 +19,10 @@ namespace Improbable
 
             var spatialPath = args[0];
             var coreSdkVersion = args[1];
+            var schemaStdLibDir = Path.GetFullPath(args[2]);
             var nativeDependenciesPath = Path.GetFullPath("./Assets/Plugins/Improbable/Core");
             var managedDependenciesPath = Path.GetFullPath("./Assets/Plugins/Improbable/Sdk");
             var tempPath = Path.GetFullPath($"./build/CoreSdk/{coreSdkVersion}");
-            var spatialProjectPath = Path.GetFullPath("../../");
 
             var packages = new List<Package>
             {
@@ -30,7 +30,7 @@ namespace Improbable
                 new Package(tempPath, "worker_sdk", "c-dynamic-x86_64-gcc_libstdcpp-linux", $"{nativeDependenciesPath}/Linux/x86_64", new List<string> {"include"}),
                 new Package(tempPath, "worker_sdk", "c-bundle-x86_64-clang_libcpp-macos", $"{nativeDependenciesPath}/OSX", new List<string> {"include"}),
                 new Package(tempPath, "worker_sdk", "csharp_core", $"{managedDependenciesPath}/OSX"),
-                new Package(tempPath, "schema", "standard_library", $"{spatialProjectPath}/build/dependencies/schema/standard_library"),
+                new Package(tempPath, "schema", "standard_library", schemaStdLibDir),
                 new Package(tempPath, "tools", "schema_compiler-x86_64-win32", $"{tempPath}/schema_compiler", null, OSPlatform.Windows),
                 new Package(tempPath, "tools", "schema_compiler-x86_64-macos", $"{tempPath}/schema_compiler", null, OSPlatform.OSX),
                 new Package(tempPath, "tools", "schema_compiler-x86_64-linux", $"{tempPath}/schema_compiler", null, OSPlatform.Linux),

--- a/workers/unity/Packages/com.improbable.gdk.tools/.DownloadCoreSdk/Program.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.DownloadCoreSdk/Program.cs
@@ -13,7 +13,7 @@ namespace Improbable
         {
             if (args.Length != 3)
             {
-                Console.Error.WriteLine("Usage: <path_to_spatial> <coresdk_version>");
+                Console.Error.WriteLine("Usage: <path_to_spatial> <coresdk_version> <path_to_schema_std_lib_directory>");
                 Environment.Exit(1);
             }
 

--- a/workers/unity/Packages/com.improbable.gdk.tools/DownloadCoreSdk.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/DownloadCoreSdk.cs
@@ -116,8 +116,7 @@ namespace Improbable.Gdk.Tools
 
                 using (new ShowProgressBarScope($"Installing SpatialOS libraries, version {Common.CoreSdkVersion}..."))
                 {
-                    exitCode = RedirectedProcess.Run(Common.DotNetBinary, "run", "-p", $"\"{ProjectPath}\"", "--",
-                        $"\"{Common.SpatialBinary}\"", $"\"{Common.CoreSdkVersion}\"");
+                    exitCode = RedirectedProcess.Run(Common.DotNetBinary, ConstructArguments());
                     if (exitCode != 0)
                     {
                         Debug.LogError($"Failed to download SpatialOS Core Sdk version {Common.CoreSdkVersion}.");
@@ -134,6 +133,15 @@ namespace Improbable.Gdk.Tools
             }
 
             return exitCode == 0 ? DownloadResult.Success : DownloadResult.Error;
+        }
+
+        internal static string[] ConstructArguments()
+        {
+            var baseArgs = new List<string> { "run", "-p", $"\"{ProjectPath}\"", "--", $"\"{Common.SpatialBinary}\"", $"\"{Common.CoreSdkVersion}\"" };
+            var toolsConfig = ScriptableGdkToolsConfiguration.GetOrCreateInstance();
+            baseArgs.Add($"\"{toolsConfig.SchemaStdLibDir}\"");
+
+            return baseArgs.ToArray();
         }
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.tools/DownloadCoreSdk.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/DownloadCoreSdk.cs
@@ -48,6 +48,7 @@ namespace Improbable.Gdk.Tools
             }
             catch
             {
+                // Nothing to handle if this fails - no need to abort the process.
             }
         }
 
@@ -135,11 +136,20 @@ namespace Improbable.Gdk.Tools
             return exitCode == 0 ? DownloadResult.Success : DownloadResult.Error;
         }
 
-        internal static string[] ConstructArguments()
+        private static string[] ConstructArguments()
         {
-            var baseArgs = new List<string> { "run", "-p", $"\"{ProjectPath}\"", "--", $"\"{Common.SpatialBinary}\"", $"\"{Common.CoreSdkVersion}\"" };
             var toolsConfig = ScriptableGdkToolsConfiguration.GetOrCreateInstance();
-            baseArgs.Add($"\"{toolsConfig.SchemaStdLibDir}\"");
+
+            var baseArgs = new List<string>
+            {
+                "run",
+                "-p",
+                $"\"{ProjectPath}\"",
+                "--",
+                $"\"{Common.SpatialBinary}\"",
+                $"\"{Common.CoreSdkVersion}\"",
+                $"\"{toolsConfig.SchemaStdLibDir}\""
+            };
 
             return baseArgs.ToArray();
         }

--- a/workers/unity/Packages/com.improbable.gdk.tools/GdkToolsConfigurationEditorExtensions.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/GdkToolsConfigurationEditorExtensions.cs
@@ -1,49 +1,33 @@
-﻿using UnityEditor;
+﻿using System;
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEngine;
+using Object = UnityEngine.Object;
 
 namespace Improbable.Gdk.Tools
 {
-    /// <summary>
-    ///     An editor window that allows you to configure the GDK Tools.
-    ///     Adds a menu item to Improbable/Configure Tools which opens this menu.
-    /// </summary>
-    public class GdkToolsConfigurationWindow : EditorWindow
-    {
-        private const string WindowTitle = "Gdk Tools Config";
-        private const string MenuItemTitle = "Improbable/Configure Tools";
-        private const int MenuItemPriority = 70;
-
-        private ScriptableGdkToolsConfiguration toolsConfig;
-
-        [MenuItem(MenuItemTitle, false, MenuItemPriority)]
-        public static void ShowWindow()
-        {
-            GetWindow<GdkToolsConfigurationWindow>(false, WindowTitle, true);
-        }
-
-        public void OnGUI()
-        {
-            OneTimeInit();
-            toolsConfig.OnGUI();
-        }
-
-        private void OneTimeInit()
-        {
-            if (toolsConfig != null)
-            {
-                return;
-            }
-
-            toolsConfig = ScriptableGdkToolsConfiguration.GetOrCreateInstance();
-        }
-    }
-
     /// <summary>
     ///     Defines a custom inspector window that allows you to configure the GDK Tools.
     /// </summary>
     [CustomEditor(typeof(ScriptableGdkToolsConfiguration))]
     public class GdkToolsConfigurationInspector : Editor
     {
+        internal const string SchemaStdLibDirLabel = "Schema Standard Library Directory";
+        internal const string CodegenOutputDirLabel = "Code Generator Output Directory";
+        internal const string SchemaSourceDirsLabel = "Schema Source Directories";
+
+        private const string CodeGeneratorLabel = "Code Generator Options";
+        private const string DownloadCoreSdkLabel = "Core SDK Options";
+
+        private const string AddSchemaDirButtonText = "Add Schema Source Directory";
+        private const string RemoveSchemaDirButtonText = "Remove";
+
+        private const string ResetConfigurationButtonText = "Reset GDK Tools Configuration to Default";
+
         private ScriptableGdkToolsConfiguration toolsConfig;
+        private List<string> configErrors = new List<string>();
+
+        private readonly GUIStyle errorLayoutOption = new GUIStyle();
 
         private void OnEnable()
         {
@@ -53,11 +37,116 @@ namespace Improbable.Gdk.Tools
             }
 
             toolsConfig = ScriptableGdkToolsConfiguration.GetOrCreateInstance();
+
+            errorLayoutOption.normal.textColor = Color.red;
         }
 
         public override void OnInspectorGUI()
         {
-            toolsConfig.OnGUI();
+            EditorGUI.BeginChangeCheck();
+
+            GUILayout.Label(DownloadCoreSdkLabel);
+            GUILayout.Space(5);
+            GUILayout.Label(SchemaStdLibDirLabel);
+            toolsConfig.SchemaStdLibDir = GUILayout.TextField(toolsConfig.SchemaStdLibDir);
+
+            DrawHorizontalBreak();
+
+            GUILayout.Label(CodeGeneratorLabel);
+            GUILayout.Space(5);
+            GUILayout.Label(CodegenOutputDirLabel);
+            toolsConfig.CodegenOutputDir = GUILayout.TextField(toolsConfig.CodegenOutputDir);
+
+            GUILayout.Space(5);
+            GUILayout.Label(SchemaSourceDirsLabel);
+            for (var i = 0; i < toolsConfig.SchemaSourceDirs.Count; i++)
+            {
+                using (new EditorGUILayout.HorizontalScope())
+                {
+                    using (new ObjectUndoScope(toolsConfig, "Inspector"))
+                    {
+                        toolsConfig.SchemaSourceDirs[i] = GUILayout.TextField(toolsConfig.SchemaSourceDirs[i]);
+                    }
+
+                    if (GUILayout.Button(RemoveSchemaDirButtonText, GUILayout.Width(100)))
+                    {
+                        using (new ObjectUndoScope(toolsConfig, "Inspector"))
+                        {
+                            toolsConfig.SchemaSourceDirs.RemoveAt(i);
+                        }
+                    }
+                }
+            }
+
+            if (GUILayout.Button(AddSchemaDirButtonText, GUILayout.Width(250)))
+            {
+                using (new ObjectUndoScope(toolsConfig, "Inspector"))
+                {
+                    toolsConfig.SchemaSourceDirs.Add(string.Empty);
+                }
+            }
+
+            DrawHorizontalBreak();
+
+            if (GUILayout.Button(ResetConfigurationButtonText, GUILayout.Width(250)))
+            {
+                using (new ObjectUndoScope(toolsConfig, "Inspector"))
+                {
+                    toolsConfig.ResetToDefault();
+                }
+            }
+
+            if (EditorGUI.EndChangeCheck())
+            {
+                configErrors = toolsConfig.Validate();
+            }
+
+            if (configErrors.Count <= 0)
+            {
+                return;
+            }
+
+            DrawHorizontalBreak();
+            foreach (var error in configErrors)
+            {
+                EditorGUILayout.HelpBox(error, MessageType.Error);
+            }
+        }
+
+        private void DrawHorizontalBreak()
+        {
+            GUILayout.Space(10);
+            EditorGUILayout.TextArea(string.Empty, GUI.skin.horizontalSlider);
+            GUILayout.Space(10);
+        }
+
+        private struct ObjectUndoScope : IDisposable
+        {
+            private const string NullArgumentError = "ObjectUndoScope received null as an argument for the object.";
+
+            private Object obj;
+
+            public ObjectUndoScope(Object obj, string name)
+            {
+                this.obj = obj;
+                CheckObject();
+                Undo.RecordObject(obj, name);
+            }
+
+            public void Dispose()
+            {
+                CheckObject();
+                EditorUtility.SetDirty(obj);
+                obj = null;
+            }
+
+            private void CheckObject()
+            {
+                if (obj == null)
+                {
+                    throw new ArgumentException(NullArgumentError);
+                }
+            }
         }
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.tools/GdkToolsConfigurationEditorExtensions.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/GdkToolsConfigurationEditorExtensions.cs
@@ -1,0 +1,65 @@
+﻿using UnityEditor;
+
+namespace Improbable.Gdk.Tools
+{
+    /// <summary>
+    ///     An editor window that allows you to configure the GDK Tools.
+    ///     Adds a menu item to Improbable/Configure Tools which opens this menu.
+    /// </summary>
+    public class GdkToolsConfigurationWindow : EditorWindow
+    {
+        private const string WindowTitle = "Gdk Tools Config";
+        private const string MenuItemTitle = "Improbable/Configure Tools";
+        private const int MenuItemPriority = 70;
+
+        private ScriptableGdkToolsConfiguration toolsConfig;
+
+        [MenuItem(MenuItemTitle, false, MenuItemPriority)]
+        public static void ShowWindow()
+        {
+            GetWindow<GdkToolsConfigurationWindow>(false, WindowTitle, true);
+        }
+
+        public void OnGUI()
+        {
+            OneTimeInit();
+            toolsConfig.OnGUI();
+        }
+
+        private void OneTimeInit()
+        {
+            if (toolsConfig != null)
+            {
+                return;
+            }
+
+            toolsConfig = ScriptableGdkToolsConfiguration.GetOrCreateInstance();
+        }
+    }
+
+    /// <summary>
+    ///     Defines a custom inspector window that allows you to configure the GDK Tools.
+    /// </summary>
+    [CustomEditor(typeof(ScriptableGdkToolsConfiguration))]
+    public class GdkToolsConfigurationInspector : Editor
+    {
+        private ScriptableGdkToolsConfiguration toolsConfig;
+
+        private void OnEnable()
+        {
+            if (toolsConfig != null)
+            {
+                return;
+            }
+
+            toolsConfig = ScriptableGdkToolsConfiguration.GetOrCreateInstance();
+        }
+
+        public override void OnInspectorGUI()
+        {
+            toolsConfig.OnGUI();
+        }
+    }
+}
+
+

--- a/workers/unity/Packages/com.improbable.gdk.tools/GdkToolsConfigurationEditorExtensions.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/GdkToolsConfigurationEditorExtensions.cs
@@ -40,10 +40,7 @@ namespace Improbable.Gdk.Tools
 
             errorLayoutOption.normal.textColor = Color.red;
 
-            Undo.undoRedoPerformed += () =>
-            {
-                configErrors = toolsConfig.Validate();
-            };
+            Undo.undoRedoPerformed += () => { configErrors = toolsConfig.Validate(); };
         }
 
         public override void OnInspectorGUI()
@@ -155,5 +152,3 @@ namespace Improbable.Gdk.Tools
         }
     }
 }
-
-

--- a/workers/unity/Packages/com.improbable.gdk.tools/GdkToolsConfigurationEditorExtensions.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/GdkToolsConfigurationEditorExtensions.cs
@@ -49,46 +49,9 @@ namespace Improbable.Gdk.Tools
 
             using (var check = new EditorGUI.ChangeCheckScope())
             {
-                GUILayout.Label(DownloadCoreSdkLabel);
-                GUILayout.Space(5);
-                GUILayout.Label(SchemaStdLibDirLabel);
-                toolsConfig.SchemaStdLibDir = GUILayout.TextField(toolsConfig.SchemaStdLibDir);
-
+                DrawCoreSdkOptions();
                 DrawHorizontalBreak();
-
-                GUILayout.Label(CodeGeneratorLabel);
-                GUILayout.Space(5);
-                GUILayout.Label(CodegenOutputDirLabel);
-                toolsConfig.CodegenOutputDir = GUILayout.TextField(toolsConfig.CodegenOutputDir);
-
-                GUILayout.Label(SchemaSourceDirsLabel);
-                for (var i = 0; i < toolsConfig.SchemaSourceDirs.Count; i++)
-                {
-                    using (new EditorGUILayout.HorizontalScope())
-                    {
-                        using (new ObjectUndoScope(toolsConfig, "Inspector"))
-                        {
-                            toolsConfig.SchemaSourceDirs[i] = GUILayout.TextField(toolsConfig.SchemaSourceDirs[i]);
-                        }
-
-                        if (GUILayout.Button(RemoveSchemaDirButtonText, GUILayout.Width(100)))
-                        {
-                            using (new ObjectUndoScope(toolsConfig, "Inspector"))
-                            {
-                                toolsConfig.SchemaSourceDirs.RemoveAt(i);
-                            }
-                        }
-                    }
-                }
-
-                if (GUILayout.Button(AddSchemaDirButtonText, GUILayout.Width(250)))
-                {
-                    using (new ObjectUndoScope(toolsConfig, "Inspector"))
-                    {
-                        toolsConfig.SchemaSourceDirs.Add(string.Empty);
-                    }
-                }
-
+                DrawCodeGenerationOptions();
                 DrawHorizontalBreak();
 
                 if (GUILayout.Button(ResetConfigurationButtonText, GUILayout.Width(250)))
@@ -114,6 +77,50 @@ namespace Improbable.Gdk.Tools
             foreach (var error in configErrors)
             {
                 EditorGUILayout.HelpBox(error, MessageType.Error);
+            }
+        }
+
+        private void DrawCoreSdkOptions()
+        {
+            GUILayout.Label(DownloadCoreSdkLabel);
+            GUILayout.Space(5);
+            GUILayout.Label(SchemaStdLibDirLabel);
+            toolsConfig.SchemaStdLibDir = GUILayout.TextField(toolsConfig.SchemaStdLibDir);
+        }
+
+        private void DrawCodeGenerationOptions()
+        {
+            GUILayout.Label(CodeGeneratorLabel);
+            GUILayout.Space(5);
+            GUILayout.Label(CodegenOutputDirLabel);
+            toolsConfig.CodegenOutputDir = GUILayout.TextField(toolsConfig.CodegenOutputDir);
+
+            GUILayout.Label(SchemaSourceDirsLabel);
+            for (var i = 0; i < toolsConfig.SchemaSourceDirs.Count; i++)
+            {
+                using (new EditorGUILayout.HorizontalScope())
+                {
+                    using (new ObjectUndoScope(toolsConfig, "Inspector"))
+                    {
+                        toolsConfig.SchemaSourceDirs[i] = GUILayout.TextField(toolsConfig.SchemaSourceDirs[i]);
+                    }
+
+                    if (GUILayout.Button(RemoveSchemaDirButtonText, GUILayout.Width(100)))
+                    {
+                        using (new ObjectUndoScope(toolsConfig, "Inspector"))
+                        {
+                            toolsConfig.SchemaSourceDirs.RemoveAt(i);
+                        }
+                    }
+                }
+            }
+
+            if (GUILayout.Button(AddSchemaDirButtonText, GUILayout.Width(250)))
+            {
+                using (new ObjectUndoScope(toolsConfig, "Inspector"))
+                {
+                    toolsConfig.SchemaSourceDirs.Add(string.Empty);
+                }
             }
         }
 

--- a/workers/unity/Packages/com.improbable.gdk.tools/GdkToolsConfigurationEditorExtensions.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/GdkToolsConfigurationEditorExtensions.cs
@@ -39,6 +39,11 @@ namespace Improbable.Gdk.Tools
             toolsConfig = ScriptableGdkToolsConfiguration.GetOrCreateInstance();
 
             errorLayoutOption.normal.textColor = Color.red;
+
+            Undo.undoRedoPerformed += () =>
+            {
+                configErrors = toolsConfig.Validate();
+            };
         }
 
         public override void OnInspectorGUI()

--- a/workers/unity/Packages/com.improbable.gdk.tools/GdkToolsConfigurationEditorExtensions.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/GdkToolsConfigurationEditorExtensions.cs
@@ -12,17 +12,17 @@ namespace Improbable.Gdk.Tools
     [CustomEditor(typeof(ScriptableGdkToolsConfiguration))]
     public class GdkToolsConfigurationInspector : Editor
     {
-        internal const string SchemaStdLibDirLabel = "Schema Standard Library Directory";
-        internal const string CodegenOutputDirLabel = "Code Generator Output Directory";
-        internal const string SchemaSourceDirsLabel = "Schema Source Directories";
+        internal const string SchemaStdLibDirLabel = "Schema standard library directory";
+        internal const string CodegenOutputDirLabel = "Code generator output directory";
+        internal const string SchemaSourceDirsLabel = "Schema source directories";
 
-        private const string CodeGeneratorLabel = "Code Generator Options";
-        private const string DownloadCoreSdkLabel = "Core SDK Options";
+        private const string CodeGeneratorLabel = "Code generator options";
+        private const string DownloadCoreSdkLabel = "CoreSDK options";
 
-        private const string AddSchemaDirButtonText = "Add Schema Source Directory";
+        private const string AddSchemaDirButtonText = "Add schema source directory";
         private const string RemoveSchemaDirButtonText = "Remove";
 
-        private const string ResetConfigurationButtonText = "Reset GDK Tools Configuration to Default";
+        private const string ResetConfigurationButtonText = "Reset GDK tools configuration to default";
 
         private ScriptableGdkToolsConfiguration toolsConfig;
         private List<string> configErrors = new List<string>();
@@ -47,60 +47,62 @@ namespace Improbable.Gdk.Tools
         {
             EditorGUI.BeginChangeCheck();
 
-            GUILayout.Label(DownloadCoreSdkLabel);
-            GUILayout.Space(5);
-            GUILayout.Label(SchemaStdLibDirLabel);
-            toolsConfig.SchemaStdLibDir = GUILayout.TextField(toolsConfig.SchemaStdLibDir);
-
-            DrawHorizontalBreak();
-
-            GUILayout.Label(CodeGeneratorLabel);
-            GUILayout.Space(5);
-            GUILayout.Label(CodegenOutputDirLabel);
-            toolsConfig.CodegenOutputDir = GUILayout.TextField(toolsConfig.CodegenOutputDir);
-
-            GUILayout.Space(5);
-            GUILayout.Label(SchemaSourceDirsLabel);
-            for (var i = 0; i < toolsConfig.SchemaSourceDirs.Count; i++)
+            using (var check = new EditorGUI.ChangeCheckScope())
             {
-                using (new EditorGUILayout.HorizontalScope())
-                {
-                    using (new ObjectUndoScope(toolsConfig, "Inspector"))
-                    {
-                        toolsConfig.SchemaSourceDirs[i] = GUILayout.TextField(toolsConfig.SchemaSourceDirs[i]);
-                    }
+                GUILayout.Label(DownloadCoreSdkLabel);
+                GUILayout.Space(5);
+                GUILayout.Label(SchemaStdLibDirLabel);
+                toolsConfig.SchemaStdLibDir = GUILayout.TextField(toolsConfig.SchemaStdLibDir);
 
-                    if (GUILayout.Button(RemoveSchemaDirButtonText, GUILayout.Width(100)))
+                DrawHorizontalBreak();
+
+                GUILayout.Label(CodeGeneratorLabel);
+                GUILayout.Space(5);
+                GUILayout.Label(CodegenOutputDirLabel);
+                toolsConfig.CodegenOutputDir = GUILayout.TextField(toolsConfig.CodegenOutputDir);
+
+                GUILayout.Label(SchemaSourceDirsLabel);
+                for (var i = 0; i < toolsConfig.SchemaSourceDirs.Count; i++)
+                {
+                    using (new EditorGUILayout.HorizontalScope())
                     {
                         using (new ObjectUndoScope(toolsConfig, "Inspector"))
                         {
-                            toolsConfig.SchemaSourceDirs.RemoveAt(i);
+                            toolsConfig.SchemaSourceDirs[i] = GUILayout.TextField(toolsConfig.SchemaSourceDirs[i]);
+                        }
+
+                        if (GUILayout.Button(RemoveSchemaDirButtonText, GUILayout.Width(100)))
+                        {
+                            using (new ObjectUndoScope(toolsConfig, "Inspector"))
+                            {
+                                toolsConfig.SchemaSourceDirs.RemoveAt(i);
+                            }
                         }
                     }
                 }
-            }
 
-            if (GUILayout.Button(AddSchemaDirButtonText, GUILayout.Width(250)))
-            {
-                using (new ObjectUndoScope(toolsConfig, "Inspector"))
+                if (GUILayout.Button(AddSchemaDirButtonText, GUILayout.Width(250)))
                 {
-                    toolsConfig.SchemaSourceDirs.Add(string.Empty);
+                    using (new ObjectUndoScope(toolsConfig, "Inspector"))
+                    {
+                        toolsConfig.SchemaSourceDirs.Add(string.Empty);
+                    }
                 }
-            }
 
-            DrawHorizontalBreak();
+                DrawHorizontalBreak();
 
-            if (GUILayout.Button(ResetConfigurationButtonText, GUILayout.Width(250)))
-            {
-                using (new ObjectUndoScope(toolsConfig, "Inspector"))
+                if (GUILayout.Button(ResetConfigurationButtonText, GUILayout.Width(250)))
                 {
-                    toolsConfig.ResetToDefault();
+                    using (new ObjectUndoScope(toolsConfig, "Inspector"))
+                    {
+                        toolsConfig.ResetToDefault();
+                    }
                 }
-            }
 
-            if (EditorGUI.EndChangeCheck())
-            {
-                configErrors = toolsConfig.Validate();
+                if (check.changed)
+                {
+                    configErrors = toolsConfig.Validate();
+                }
             }
 
             if (configErrors.Count <= 0)
@@ -137,7 +139,6 @@ namespace Improbable.Gdk.Tools
 
             public void Dispose()
             {
-                CheckObject();
                 EditorUtility.SetDirty(obj);
                 obj = null;
             }

--- a/workers/unity/Packages/com.improbable.gdk.tools/GdkToolsConfigurationEditorExtensions.cs.meta
+++ b/workers/unity/Packages/com.improbable.gdk.tools/GdkToolsConfigurationEditorExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7a7c738a4c6819b4d8c80b01d11e7822
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/com.improbable.gdk.tools/GenerateCode.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/GenerateCode.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Mono.Cecil;
 using UnityEditor;
 using UnityEngine;
 
@@ -10,12 +11,9 @@ namespace Improbable.Gdk.Tools
     [InitializeOnLoad]
     internal static class GenerateCode
     {
-        private const string AssetsGeneratedSourceDir = "Assets/Generated/Source";
         private const string CsProjectFile = ".CodeGenerator/GdkCodeGenerator/GdkCodeGenerator.csproj";
         private const string FromGdkPackagesDir = "from_gdk_packages";
         private const string ImprobableJsonDir = "build/ImprobableJson";
-        private const string SchemaRootDir = "../../schema";
-        private const string SchemaStandardLibraryDir = "../../build/dependencies/schema/standard_library";
 
         private const int GenerateCodePriority = 38;
         private const int GenerateCodeForcePriority = 39;
@@ -56,7 +54,7 @@ namespace Improbable.Gdk.Tools
                     return;
                 }
 
-                CopySchema(SchemaRootDir);
+                CopySchema();
 
                 var projectPath = Path.GetFullPath(Path.Combine(Common.GetThisPackagePath(),
                     CsProjectFile));
@@ -81,12 +79,7 @@ namespace Improbable.Gdk.Tools
 
                 using (new ShowProgressBarScope("Generating code..."))
                 {
-                    var exitCode = RedirectedProcess.Run(Common.DotNetBinary, "run", "-p", $"\"{projectPath}\"", "--",
-                        $"--schema-path=\"{SchemaRootDir}\"",
-                        $"--schema-path={SchemaStandardLibraryDir}",
-                        $"--json-dir={ImprobableJsonDir}",
-                        $"--native-output-dir={AssetsGeneratedSourceDir}",
-                        $"--schema-compiler-path=\"{schemaCompilerPath}\"");
+                    var exitCode = RedirectedProcess.Run(Common.DotNetBinary, ConstructArgs(projectPath, schemaCompilerPath));
 
                     if (exitCode != 0)
                     {
@@ -106,6 +99,31 @@ namespace Improbable.Gdk.Tools
             }
         }
 
+        private static string[] ConstructArgs(string projectPath, string schemaCompilerPath)
+        {
+            var baseArgs = new List<string>
+            {
+                "run",
+                "-p",
+                $"\"{projectPath}\"",
+                "--",
+                $"--json-dir=\"{ImprobableJsonDir}\"",
+                $"--schema-compiler-path=\"{schemaCompilerPath}\""
+            };
+
+            var toolsConfig = ScriptableGdkToolsConfiguration.GetOrCreateInstance();
+
+            baseArgs.Add($"--native-output-dir=\"{toolsConfig.CodegenOutputDir}\"");
+            baseArgs.Add($"--schema-path=\"{toolsConfig.SchemaStdLibDir}\"");
+
+            foreach (var schemaSourceDir in toolsConfig.SchemaSourceDirs)
+            {
+                baseArgs.Add($"--schema-path=\"{schemaSourceDir}\"");
+            }
+
+            return baseArgs.ToArray();
+        }
+
         [MenuItem("SpatialOS/Generate code (force)", false, GenerateCodeForcePriority)]
         private static void ForceGenerateMenu()
         {
@@ -115,18 +133,22 @@ namespace Improbable.Gdk.Tools
 
         private static void ForceGenerate()
         {
-            if (Directory.Exists(AssetsGeneratedSourceDir))
+            var toolsConfig = ScriptableGdkToolsConfiguration.GetOrCreateInstance();
+            if (Directory.Exists(toolsConfig.CodegenOutputDir))
             {
-                Directory.Delete(AssetsGeneratedSourceDir, true);
+                Directory.Delete(toolsConfig.CodegenOutputDir, true);
             }
 
             Generate();
         }
 
-        private static void CopySchema(string schemaRoot)
+        private static void CopySchema()
         {
             try
             {
+                var toolsConfig = ScriptableGdkToolsConfiguration.GetOrCreateInstance();
+                // Safe as we validate there is at least one entry.
+                var schemaRoot = toolsConfig.SchemaSourceDirs[0];
                 CleanDestination(schemaRoot);
 
                 var packages = Common.GetManifestDependencies().Where(kv => kv.Value.StartsWith("file:"))

--- a/workers/unity/Packages/com.improbable.gdk.tools/GenerateCode.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/GenerateCode.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using Mono.Cecil;
 using UnityEditor;
 using UnityEngine;
 

--- a/workers/unity/Packages/com.improbable.gdk.tools/ScriptableGdkToolsConfiguration.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/ScriptableGdkToolsConfiguration.cs
@@ -9,33 +9,38 @@ namespace Improbable.Gdk.Tools
 {
     public class ScriptableGdkToolsConfiguration : ScriptableObject
     {
-        public string SchemaStdLibDir = DefaultValues.SchemaStdLibDir;
-        public List<string> SchemaSourceDirs = new List<string> { DefaultValues.SchemaSourceDir };
-        public string CodegenOutputDir = DefaultValues.CodegenOutputDir;
+        public string SchemaStdLibDir;
+        public List<string> SchemaSourceDirs = new List<string>();
+        public string CodegenOutputDir;
 
         private const string AssetPath = "Assets/Config/GdkToolsConfiguration.asset";
+
+        public ScriptableGdkToolsConfiguration()
+        {
+            ResetToDefault();
+        }
 
         internal List<string> Validate()
         {
             var errors = new List<string>();
             if (string.IsNullOrEmpty(SchemaStdLibDir))
             {
-                errors.Add($"{GdkToolsConfigurationInspector.SchemaStdLibDirLabel} cannot be empty!");
+                errors.Add($"{GdkToolsConfigurationInspector.SchemaStdLibDirLabel} cannot be empty.");
             }
 
             if (string.IsNullOrEmpty(CodegenOutputDir))
             {
-                errors.Add($"{GdkToolsConfigurationInspector.CodegenOutputDirLabel} cannot be empty!");
+                errors.Add($"{GdkToolsConfigurationInspector.CodegenOutputDirLabel} cannot be empty.");
             }
 
             if (SchemaSourceDirs.Any(string.IsNullOrEmpty))
             {
-                errors.Add($"Cannot have any empty entry in {GdkToolsConfigurationInspector.SchemaSourceDirsLabel}");
+                errors.Add($"Cannot have any empty entry in {GdkToolsConfigurationInspector.SchemaSourceDirsLabel}.");
             }
 
             if (SchemaSourceDirs.Count == 0)
             {
-                errors.Add($"Cannot have no entrys in {GdkToolsConfigurationInspector.SchemaSourceDirsLabel}");
+                errors.Add($"You must have at least one item in {GdkToolsConfigurationInspector.SchemaSourceDirsLabel}.");
             }
 
             return errors;

--- a/workers/unity/Packages/com.improbable.gdk.tools/ScriptableGdkToolsConfiguration.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/ScriptableGdkToolsConfiguration.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using UnityEditor;
 using UnityEngine;
@@ -12,119 +13,35 @@ namespace Improbable.Gdk.Tools
         public List<string> SchemaSourceDirs = new List<string> { DefaultValues.SchemaSourceDir };
         public string CodegenOutputDir = DefaultValues.CodegenOutputDir;
 
-        public const string AssetPath = "Assets/Config/GdkToolsConfiguration.asset";
+        private const string AssetPath = "Assets/Config/GdkToolsConfiguration.asset";
 
-        private const string DownloadCoreSdkLabel = "Core SDK Options";
-        private const string SchemaStdLibDirLabel = "Schema Standard Library Directory";
-
-        private const string CodeGeneratorLabel = "Code Generator Options";
-        private const string CodegenOutputDirLabel = "Code Generator Output Directory";
-        private const string SchemaSourceDirsLabel = "Schema Source Directories";
-
-        private const string AddSchemaDirButtonText = "Add Schema Source Directory";
-        private const string RemoveSchemaDirButtonText = "Remove";
-
-        private const string SaveConfigurationButtonText = "Save GDK Tools Configuration";
-        private const string ResetConfigurationButtonText = "Reset GDK Tools Configuration to Default";
-
-        private Vector2 scrollPosition = Vector2.zero;
-
-        public void OnGUI()
-        {
-            scrollPosition = GUILayout.BeginScrollView(scrollPosition);
-
-            GUILayout.Label(DownloadCoreSdkLabel);
-            GUILayout.Space(5);
-            GUILayout.Label(SchemaStdLibDirLabel);
-            SchemaStdLibDir = GUILayout.TextField(SchemaStdLibDir);
-
-            GUILayout.Space(10);
-            EditorGUILayout.TextArea("", GUI.skin.horizontalSlider);
-            GUILayout.Space(10);
-
-            GUILayout.Label(CodeGeneratorLabel);
-            GUILayout.Space(5);
-            GUILayout.Label(CodegenOutputDirLabel);
-            CodegenOutputDir = GUILayout.TextField(CodegenOutputDir);
-
-            GUILayout.Space(5);
-            GUILayout.Label(SchemaSourceDirsLabel);
-            for (var i = 0; i < SchemaSourceDirs.Count; i++)
-            {
-                GUILayout.BeginHorizontal();
-                SchemaSourceDirs[i] = GUILayout.TextField(SchemaSourceDirs[i]);
-
-                if (GUILayout.Button(RemoveSchemaDirButtonText, GUILayout.Width(100)))
-                {
-                    SchemaSourceDirs.RemoveAt(i);
-                }
-
-                GUILayout.EndHorizontal();
-            }
-
-            if (GUILayout.Button(AddSchemaDirButtonText, GUILayout.Width(250)))
-            {
-                SchemaSourceDirs.Add("");
-            }
-
-            GUILayout.Space(10);
-            EditorGUILayout.TextArea("", GUI.skin.horizontalSlider);
-            GUILayout.Space(10);
-
-            if (GUILayout.Button(SaveConfigurationButtonText, GUILayout.Width(250)))
-            {
-                Save();
-            }
-
-            GUILayout.Space(15);
-
-            if (GUILayout.Button(ResetConfigurationButtonText, GUILayout.Width(250)))
-            {
-                ResetToDefault();
-            }
-
-            GUILayout.EndScrollView();
-        }
-
-        private void Save()
-        {
-            Validate();
-            EditorUtility.SetDirty(this);
-            AssetDatabase.SaveAssets();
-            AssetDatabase.Refresh();
-        }
-
-        private void Validate()
+        internal List<string> Validate()
         {
             var errors = new List<string>();
-
             if (string.IsNullOrEmpty(SchemaStdLibDir))
             {
-                errors.Add($"{SchemaStdLibDirLabel} cannot be empty!");
+                errors.Add($"{GdkToolsConfigurationInspector.SchemaStdLibDirLabel} cannot be empty!");
             }
 
             if (string.IsNullOrEmpty(CodegenOutputDir))
             {
-                errors.Add($"{CodegenOutputDirLabel} cannot be empty!");
+                errors.Add($"{GdkToolsConfigurationInspector.CodegenOutputDirLabel} cannot be empty!");
             }
 
-            if (SchemaSourceDirs.Any(dir => string.IsNullOrEmpty(dir)))
+            if (SchemaSourceDirs.Any(string.IsNullOrEmpty))
             {
-                errors.Add($"Cannot have any empty entry in {SchemaSourceDirsLabel}");
+                errors.Add($"Cannot have any empty entry in {GdkToolsConfigurationInspector.SchemaSourceDirsLabel}");
             }
 
             if (SchemaSourceDirs.Count == 0)
             {
-                errors.Add($"Cannot have no entrys in {SchemaSourceDirsLabel}");
+                errors.Add($"Cannot have no entrys in {GdkToolsConfigurationInspector.SchemaSourceDirsLabel}");
             }
 
-            if (errors.Count != 0)
-            {
-                throw new InvalidOperationException("GDK Tools Configuration Validation failed with the following error(s): " + string.Join("\n", errors));
-            }
+            return errors;
         }
 
-        private void ResetToDefault()
+        internal void ResetToDefault()
         {
             SchemaStdLibDir = DefaultValues.SchemaStdLibDir;
             CodegenOutputDir = DefaultValues.CodegenOutputDir;
@@ -149,21 +66,17 @@ namespace Improbable.Gdk.Tools
 
         private static void CreateFoldersFromAssetPath(string path)
         {
-            var folders = path.Split('/');
+            var fullDir = Path.GetDirectoryName(Path.GetFullPath(path));
 
-            var prevPath = "";
-            // Ignore last element as it is the asset name.
-            for (var i = 0; i < folders.Length - 1; i++)
+            if (Directory.Exists(fullDir))
             {
-                var testPath = prevPath + (i == 0 ? "" : "/") + folders[i];
-                if (!AssetDatabase.IsValidFolder(testPath))
-                {
-                    Debug.Log($"Creating folder at: {prevPath} {folders[i]}");
-                    AssetDatabase.CreateFolder(prevPath, folders[i]);
-                }
-
-                prevPath = testPath;
+                return;
             }
+
+            Directory.CreateDirectory(fullDir);
+
+            AssetDatabase.ImportAsset(Path.GetDirectoryName(path));
+
         }
 
         private static class DefaultValues

--- a/workers/unity/Packages/com.improbable.gdk.tools/ScriptableGdkToolsConfiguration.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/ScriptableGdkToolsConfiguration.cs
@@ -1,0 +1,176 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEditor;
+using UnityEngine;
+
+namespace Improbable.Gdk.Tools
+{
+    public class ScriptableGdkToolsConfiguration : ScriptableObject
+    {
+        public string SchemaStdLibDir = DefaultValues.SchemaStdLibDir;
+        public List<string> SchemaSourceDirs = new List<string> { DefaultValues.SchemaSourceDir };
+        public string CodegenOutputDir = DefaultValues.CodegenOutputDir;
+
+        public const string AssetPath = "Assets/Config/GdkToolsConfiguration.asset";
+
+        private const string DownloadCoreSdkLabel = "Core SDK Options";
+        private const string SchemaStdLibDirLabel = "Schema Standard Library Directory";
+
+        private const string CodeGeneratorLabel = "Code Generator Options";
+        private const string CodegenOutputDirLabel = "Code Generator Output Directory";
+        private const string SchemaSourceDirsLabel = "Schema Source Directories";
+
+        private const string AddSchemaDirButtonText = "Add Schema Source Directory";
+        private const string RemoveSchemaDirButtonText = "Remove";
+
+        private const string SaveConfigurationButtonText = "Save GDK Tools Configuration";
+        private const string ResetConfigurationButtonText = "Reset GDK Tools Configuration to Default";
+
+        private Vector2 scrollPosition = Vector2.zero;
+
+        public void OnGUI()
+        {
+            scrollPosition = GUILayout.BeginScrollView(scrollPosition);
+
+            GUILayout.Label(DownloadCoreSdkLabel);
+            GUILayout.Space(5);
+            GUILayout.Label(SchemaStdLibDirLabel);
+            SchemaStdLibDir = GUILayout.TextField(SchemaStdLibDir);
+
+            GUILayout.Space(10);
+            EditorGUILayout.TextArea("", GUI.skin.horizontalSlider);
+            GUILayout.Space(10);
+
+            GUILayout.Label(CodeGeneratorLabel);
+            GUILayout.Space(5);
+            GUILayout.Label(CodegenOutputDirLabel);
+            CodegenOutputDir = GUILayout.TextField(CodegenOutputDir);
+
+            GUILayout.Space(5);
+            GUILayout.Label(SchemaSourceDirsLabel);
+            for (var i = 0; i < SchemaSourceDirs.Count; i++)
+            {
+                GUILayout.BeginHorizontal();
+                SchemaSourceDirs[i] = GUILayout.TextField(SchemaSourceDirs[i]);
+
+                if (GUILayout.Button(RemoveSchemaDirButtonText, GUILayout.Width(100)))
+                {
+                    SchemaSourceDirs.RemoveAt(i);
+                }
+
+                GUILayout.EndHorizontal();
+            }
+
+            if (GUILayout.Button(AddSchemaDirButtonText, GUILayout.Width(250)))
+            {
+                SchemaSourceDirs.Add("");
+            }
+
+            GUILayout.Space(10);
+            EditorGUILayout.TextArea("", GUI.skin.horizontalSlider);
+            GUILayout.Space(10);
+
+            if (GUILayout.Button(SaveConfigurationButtonText, GUILayout.Width(250)))
+            {
+                Save();
+            }
+
+            GUILayout.Space(15);
+
+            if (GUILayout.Button(ResetConfigurationButtonText, GUILayout.Width(250)))
+            {
+                ResetToDefault();
+            }
+
+            GUILayout.EndScrollView();
+        }
+
+        private void Save()
+        {
+            Validate();
+            EditorUtility.SetDirty(this);
+            AssetDatabase.SaveAssets();
+            AssetDatabase.Refresh();
+        }
+
+        private void Validate()
+        {
+            var errors = new List<string>();
+
+            if (string.IsNullOrEmpty(SchemaStdLibDir))
+            {
+                errors.Add($"{SchemaStdLibDirLabel} cannot be empty!");
+            }
+
+            if (string.IsNullOrEmpty(CodegenOutputDir))
+            {
+                errors.Add($"{CodegenOutputDirLabel} cannot be empty!");
+            }
+
+            if (SchemaSourceDirs.Any(dir => string.IsNullOrEmpty(dir)))
+            {
+                errors.Add($"Cannot have any empty entry in {SchemaSourceDirsLabel}");
+            }
+
+            if (SchemaSourceDirs.Count == 0)
+            {
+                errors.Add($"Cannot have no entrys in {SchemaSourceDirsLabel}");
+            }
+
+            if (errors.Count != 0)
+            {
+                throw new InvalidOperationException("GDK Tools Configuration Validation failed with the following error(s): " + string.Join("\n", errors));
+            }
+        }
+
+        private void ResetToDefault()
+        {
+            SchemaStdLibDir = DefaultValues.SchemaStdLibDir;
+            CodegenOutputDir = DefaultValues.CodegenOutputDir;
+            SchemaSourceDirs.Clear();
+            SchemaSourceDirs.Add(DefaultValues.SchemaSourceDir);
+        }
+
+        public static ScriptableGdkToolsConfiguration GetOrCreateInstance()
+        {
+            return AssetDatabase.LoadAssetAtPath<ScriptableGdkToolsConfiguration>(AssetPath) ?? CreateInstance();
+        }
+
+        private static ScriptableGdkToolsConfiguration CreateInstance()
+        {
+            var config = CreateInstance<ScriptableGdkToolsConfiguration>();
+            CreateFoldersFromAssetPath(AssetPath);
+            AssetDatabase.CreateAsset(config, AssetPath);
+            EditorUtility.SetDirty(config);
+
+            return config;
+        }
+
+        private static void CreateFoldersFromAssetPath(string path)
+        {
+            var folders = path.Split('/');
+
+            var prevPath = "";
+            // Ignore last element as it is the asset name.
+            for (var i = 0; i < folders.Length - 1; i++)
+            {
+                var testPath = prevPath + (i == 0 ? "" : "/") + folders[i];
+                if (!AssetDatabase.IsValidFolder(testPath))
+                {
+                    Debug.Log($"Creating folder at: {prevPath} {folders[i]}");
+                    AssetDatabase.CreateFolder(prevPath, folders[i]);
+                }
+
+                prevPath = testPath;
+            }
+        }
+
+        private static class DefaultValues
+        {
+            public const string SchemaStdLibDir = "../../build/dependencies/schema/standard_library";
+            public const string CodegenOutputDir = "Assets/Generated/Source";
+            public const string SchemaSourceDir = "../../schema";
+        }
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.tools/ScriptableGdkToolsConfiguration.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/ScriptableGdkToolsConfiguration.cs
@@ -76,7 +76,6 @@ namespace Improbable.Gdk.Tools
             Directory.CreateDirectory(fullDir);
 
             AssetDatabase.ImportAsset(Path.GetDirectoryName(path));
-
         }
 
         private static class DefaultValues

--- a/workers/unity/Packages/com.improbable.gdk.tools/ScriptableGdkToolsConfiguration.cs.meta
+++ b/workers/unity/Packages/com.improbable.gdk.tools/ScriptableGdkToolsConfiguration.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 79cf5b51897b27648a440611e3d87060
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
#### Description
Made the GDK Tools locations configurable. For two reasons:
1. Required for a sister test project that isn't a Worker but wants generated code to test.
2. Required for FPL in the near(?) future.

Screenshots of the configuration window:
Without errors:
![image](https://user-images.githubusercontent.com/13353733/44923475-3eec8400-ad40-11e8-9e7f-eab177eb2028.png)

With errors:
![image](https://user-images.githubusercontent.com/13353733/44923424-182e4d80-ad40-11e8-8af9-71a1eb7e20c2.png)


#### Tests
Messed around with the paths and verified that the results were as expected.
#### Documentation
N/A - Although probably should be (lower priority)
#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
@jared-improbable @jessicafalk 