### PR TITLE
Move dependencies from manifest to the core package

### DIFF
--- a/workers/unity/Packages/com.improbable.gdk.core/package.json
+++ b/workers/unity/Packages/com.improbable.gdk.core/package.json
@@ -5,6 +5,9 @@
     "unity": "2018.2",
     "description": "SpatialOS GDK Core Module. THIS IS NOT MADE BY UNITY. IGNORE THE AUTHOR FIELD",
     "dependencies": {
-        "com.improbable.gdk.legacy": "0.0.1"
+        "com.improbable.gdk.legacy": "0.0.1",
+        "com.unity.burst": "0.2.4-preview.26",
+    	"com.unity.entities": "0.0.12-preview.11",
+    	"com.unity.incrementalcompiler": "0.0.42-preview.20"
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.core/package.json
+++ b/workers/unity/Packages/com.improbable.gdk.core/package.json
@@ -7,7 +7,7 @@
     "dependencies": {
         "com.improbable.gdk.legacy": "0.0.1",
         "com.unity.burst": "0.2.4-preview.26",
-    	"com.unity.entities": "0.0.12-preview.11",
-    	"com.unity.incrementalcompiler": "0.0.42-preview.20"
+        "com.unity.entities": "0.0.12-preview.11",
+        "com.unity.incrementalcompiler": "0.0.42-preview.20"
     }
 }

--- a/workers/unity/Packages/manifest.json
+++ b/workers/unity/Packages/manifest.json
@@ -6,9 +6,6 @@
     "com.improbable.gdk.testutils": "file:com.improbable.gdk.testutils",
     "com.improbable.gdk.tools": "file:com.improbable.gdk.tools",
     "com.improbable.gdk.transformsynchronization": "file:com.improbable.gdk.transformsynchronization",
-    "com.unity.burst": "0.2.4-preview.26",
-    "com.unity.entities": "0.0.12-preview.11",
-    "com.unity.incrementalcompiler": "0.0.42-preview.20",
     "com.unity.package-manager-ui": "1.9.11",
     "com.unity.modules.physics": "1.0.0",
     "com.unity.modules.ui": "1.0.0"


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Moved all our dependencies to core except for the dependencies on built-in modules or, if they are not needed for the GDK (e.g. package manager ui).
It doesn't seem possible to move the dependencies on built-in modules to a different package as they will still be disabled.

#### Tests
Checked that everything still compiles

#### Documentation
none

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.