### PR TITLE
Make Authority<T> less generic to make its usage less error prone.

### DIFF
--- a/workers/unity/Packages/com.improbable.gdk.core/Authority/AuthorityChanges.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Authority/AuthorityChanges.cs
@@ -1,10 +1,10 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using Improbable.Worker.Core;
 using Unity.Entities;
 
 namespace Improbable.Gdk.Core
 {
-    public struct AuthorityChanges<T> : IComponentData
+    public struct AuthorityChanges<T> : IComponentData where T : ISpatialComponentData
     {
         public uint Handle;
 

--- a/workers/unity/Packages/com.improbable.gdk.core/Authority/AuthorityChanges.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Authority/AuthorityChanges.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Improbable.Worker.Core;
 using Unity.Entities;
 

--- a/workers/unity/Packages/com.improbable.gdk.core/Authority/AuthorityComponents.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Authority/AuthorityComponents.cs
@@ -2,15 +2,15 @@ using Unity.Entities;
 
 namespace Improbable.Gdk.Core
 {
-    public struct Authoritative<T> : IComponentData
+    public struct Authoritative<T> : IComponentData where T : ISpatialComponentData
     {
     }
 
-    public struct NotAuthoritative<T> : IComponentData
+    public struct NotAuthoritative<T> : IComponentData where T : ISpatialComponentData
     {
     }
 
-    public struct AuthorityLossImminent<T> : IComponentData
+    public struct AuthorityLossImminent<T> : IComponentData where T : ISpatialComponentData
     {
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.core/Tests/Editmode/GameObjectRepresentation/Readers/ReaderWriterTestsBase.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Tests/Editmode/GameObjectRepresentation/Readers/ReaderWriterTestsBase.cs
@@ -31,8 +31,10 @@ namespace Improbable.Gdk.Core.EditmodeTests.MonoBehaviours.Readers
             world.Dispose();
         }
 
-        protected struct SomeOtherComponent : IComponentData
+        protected struct SomeOtherComponent : IComponentData, ISpatialComponentData
         {
+            public uint ComponentId { get; }
+            public BlittableBool DirtyBit { get; set; }
         }
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerHeartbeat/SendPlayerHeartbeatRequestSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Systems/PlayerHeartbeat/SendPlayerHeartbeatRequestSystem.cs
@@ -13,7 +13,7 @@ namespace Improbable.Gdk.PlayerLifecycle
         {
             public readonly int Length;
             [ReadOnly] public ComponentDataArray<PlayerHeartbeatClient.CommandSenders.PlayerHeartbeat> RequestSenders;
-            [ReadOnly] public ComponentDataArray<Authoritative<PlayerHeartbeatServer>> AuthorityMarkers;
+            [ReadOnly] public ComponentDataArray<Authoritative<PlayerHeartbeatServer.Component>> AuthorityMarkers;
             [ReadOnly] public ComponentDataArray<SpatialEntityId> SpatialEntityIds;
             public EntityArray Entities;
             public SubtractiveComponent<AwaitingHeartbeatResponseTag> NotAwaitingHeartbeatResponse;


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
The PlayerLifecycle feature module wasn't working because it was using `Authoritative<PlayerHeartbeatServer>` instead of `Authoritative<PlayerHeartbeatServer.Component>`. This is a very easy mistake to make and takes a while to debug. We should restrict the generics which can be used with `Authoritative<T>`.

#### Tests
Ran locally, player got deleted.

#### Documentation
N/A

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.