### PR TITLE
adding configuration for mac

### DIFF
--- a/workers/unity/spatialos.UnityClient.worker.json
+++ b/workers/unity/spatialos.UnityClient.worker.json
@@ -46,6 +46,24 @@
           "-logfile",
           "../../logs/external-default-unityclient.log"
         ]
+      },
+      "macos": {
+          "command": "open",
+          "arguments": [
+            "./build/worker/UnityClient@Mac/UnityClient@Mac.app",
+            "--args",
+            "+assemblyName",
+            "local_assembly",
+            "+workerType",
+            "UnityClient",
+            "+infraServicesUrl",
+            "http://127.0.0.1:21000",
+            "+projectName",
+            "${IMPROBABLE_PROJECT_NAME}",
+            "-logfile",
+            "../../logs/external-default-unityclient.log"
+          ]
+        }
       }
     }
   }

--- a/workers/unity/spatialos.UnityGameLogic.worker.json
+++ b/workers/unity/spatialos.UnityGameLogic.worker.json
@@ -46,6 +46,23 @@
           "-logfile",
           "../../logs/external-default-unitygamelogic.log"
         ]
+      },
+      "macos": {
+        "command": "open",
+        "arguments": [
+          "./build/worker/UnityGameLogic@Mac/UnityGameLogic@Mac.app",
+          "--args",
+          "+assemblyName",
+          "local_assembly",
+          "+workerType",
+          "UnityGameLogic",
+          "+infraServicesUrl",
+          "http://127.0.0.1:21000",
+          "+projectName",
+          "${IMPROBABLE_PROJECT_NAME}",
+          "-logfile",
+          "../../logs/external-default-unitygamelogic.log"
+        ]
       }
     }
   },
@@ -54,6 +71,29 @@
       "artifact_name": "UnityGameLogic@Windows.zip",
       "command": "UnityGameLogic@Windows.exe",
       "arguments": [
+        "+workerType",
+        "UnityGameLogic",
+        "+workerId",
+        "${IMPROBABLE_WORKER_ID}",
+        "+projectName",
+        "${IMPROBABLE_PROJECT_NAME}",
+        "+receptionistHost",
+        "${IMPROBABLE_RECEPTIONIST_HOST}",
+        "+receptionistPort",
+        "${IMPROBABLE_RECEPTIONIST_PORT}",
+        "+linkProtocol",
+        "RakNet",
+        "-batchmode",
+        "-logfile",
+        "${IMPROBABLE_LOG_FILE}"
+      ]
+    },
+    "macos": {
+      "artifact_name": "UnityGameLogic@Mac.zip",
+      "command": "open",
+      "arguments": [
+        "UnityGameLogic@Mac.app",
+        "--args",
         "+workerType",
         "UnityGameLogic",
         "+workerId",


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Adding the configuration so that we can test build out workers on mac as well

#### Tests
ran it locally by
1. running `spatial local launch` and starting it up with one UnityGameLogic worker
2. starting the client by running `spatial local worker launch UnityClient default`

#### Documentation
none needed

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.