### PR TITLE
fixing reconnect and ensuring that worker type is set

### DIFF
--- a/workers/unity/Assets/Playground/Scripts/Worker/WorkerConnectorBase.cs
+++ b/workers/unity/Assets/Playground/Scripts/Worker/WorkerConnectorBase.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using Improbable.Gdk.Core;
 using Improbable.Worker.Core;
@@ -67,16 +66,15 @@ namespace Playground
                 ConnectionDelegate connectionDelegate;
                 if (ShouldUseLocator())
                 {
-                    var config = GetLocatorConfig(workerType);
                     connectionDelegate = async () =>
-                        await Worker.CreateWorkerAsync(config, SelectDeploymentName, logger, origin)
+                        await Worker.CreateWorkerAsync(GetLocatorConfig(workerType), SelectDeploymentName, logger, origin)
                             .ConfigureAwait(false);
                 }
                 else
                 {
-                    var config = GetReceptionistConfig(workerType);
                     connectionDelegate = async () =>
-                        await Worker.CreateWorkerAsync(config, logger, origin).ConfigureAwait(false);
+                        await Worker.CreateWorkerAsync(GetReceptionistConfig(workerType), logger, origin)
+                            .ConfigureAwait(false);
                 }
 
                 var worker = await ConnectWithRetries(connectionDelegate, MaxConnectionAttempts, logger, workerType);
@@ -122,6 +120,7 @@ namespace Playground
                 var commandLineArguments = Environment.GetCommandLineArgs();
                 var commandLineArgs = CommandLineUtility.ParseCommandLineArgs(commandLineArguments);
                 config = ReceptionistConfig.CreateConnectionConfigFromCommandLine(commandLineArgs);
+                config.WorkerType = workerType;
                 config.UseExternalIp = UseExternalIp;
                 if (!commandLineArgs.ContainsKey(RuntimeConfigNames.WorkerId))
                 {


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Reconnecting was not always working, because the worker id got reused and it was only possible to locally connect an external worker by running `spatial local worker launch UnityClient default` as the worker type was otherwise not set.

#### Tests
tested it locally by testing whether reconnection attempts were now not failing due to reusing the worker id and checking that the worker type is always set (e.g. by directly starting the executable instead of using the spatial command)

#### Documentation
none needed

#### Primary reviewers
@samiwh 