### PR TITLE
Destroy game objects upon destroying the world

### DIFF
--- a/workers/unity/Assets/Playground/Scripts/EntityInitialization/EntityGameObjectCreator.cs
+++ b/workers/unity/Assets/Playground/Scripts/EntityInitialization/EntityGameObjectCreator.cs
@@ -1,8 +1,10 @@
 using System;
 using System.Collections.Generic;
+using Improbable.Gdk.Core;
 using Improbable.Worker;
 using Unity.Entities;
 using UnityEngine;
+using Object = UnityEngine.Object;
 
 namespace Playground
 {
@@ -31,9 +33,14 @@ namespace Playground
                 cachedPrefabs[prefabPath] = prefab;
             }
 
-            var gameObject = GameObject.Instantiate(prefab, position, rotation);
+            var gameObject = Object.Instantiate(prefab, position, rotation);
             gameObject.name = $"{prefab.name}(SpatialOS: {spatialEntityId}, Unity: {entity.Index}/{world.Name})";
             return gameObject;
+        }
+
+        public void DeleteGameObject(Entity entity, GameObject gameObject)
+        {
+            UnityObjectDestroyer.Destroy(gameObject);
         }
     }
 

--- a/workers/unity/Assets/Playground/Scripts/EntityInitialization/GameObjectInitializationSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/EntityInitialization/GameObjectInitializationSystem.cs
@@ -114,11 +114,23 @@ namespace Playground
                 }
 
                 entityGameObjectCache.Remove(entity);
-                UnityObjectDestroyer.Destroy(gameObject);
+                entityGameObjectCreator.DeleteGameObject(entity, gameObject);
                 PostUpdateCommands.RemoveComponent<GameObjectReferenceHandle>(entity);
             }
 
             viewCommandBuffer.FlushBuffer();
+        }
+
+        protected override void OnDestroyManager()
+        {
+            base.OnDestroyManager();
+
+            foreach (var entityToGameObject in entityGameObjectCache)
+            {
+                entityGameObjectCreator.
+                    DeleteGameObject(entityToGameObject.Key, entityToGameObject.Value);
+            }
+            entityGameObjectCache.Clear();
         }
     }
 }


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Up until now we didn't clean up game objects which lead to exceptions being thrown upon disconnecting. 

#### Tests
tested it locally, errors are gone

#### Documentation
none

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.