### PR TITLE
Disable QOS timeout

### DIFF
--- a/default_launch.json
+++ b/default_launch.json
@@ -8,7 +8,13 @@
     "dimensions": {
       "xMeters": 5000,
       "zMeters": 5000
-    }
+    },
+    "legacy_flags": [
+      {
+        "name": "bridge_qos_max_timeout",
+        "value": "0"
+      }
+    ]
   },
   "workers": [
     {


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Disabling qos timeout for the default_launch config that should be used for `spatial local launch`.
That gets rid of the case where a worker disconnects when pausing the game and therefore causing a couple of issues.

#### Tests
tested it locally. Workers never disconnected and pausing/unpausing worked fine.
This should not be used for the cloud workflow

#### Documentation
no

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.