### PR TITLE
UTY-329: Stop the game in the editor during compilation.

### DIFF
--- a/workers/unity/Assets/Playground/Editor/DisconnectOnCompilation.cs
+++ b/workers/unity/Assets/Playground/Editor/DisconnectOnCompilation.cs
@@ -11,11 +11,11 @@ namespace Playground.Editor
         [RuntimeInitializeOnLoadMethod]
         private static void Init()
         {
-            CompilationPipeline.assemblyCompilationStarted += CompilationPipeline_assemblyCompilationStarted;
-            CompilationPipeline.assemblyCompilationFinished += CompilationPipeline_assemblyCompilationFinished;
+            CompilationPipeline.assemblyCompilationStarted += OnCompilationStarted;
+            CompilationPipeline.assemblyCompilationFinished += OnCompilationFinished;
         }
 
-        private static void CompilationPipeline_assemblyCompilationStarted(string obj)
+        private static void OnCompilationStarted(string obj)
         {
             if (EditorApplication.isPlaying)
             {
@@ -24,7 +24,7 @@ namespace Playground.Editor
             }
         }
 
-        private static void CompilationPipeline_assemblyCompilationFinished(string arg1, CompilerMessage[] arg2)
+        private static void OnCompilationFinished(string arg1, CompilerMessage[] arg2)
         {
             if (stopped)
             {

--- a/workers/unity/Assets/Playground/Editor/DisconnectOnCompilation.cs
+++ b/workers/unity/Assets/Playground/Editor/DisconnectOnCompilation.cs
@@ -28,8 +28,17 @@ namespace Playground.Editor
         {
             if (stopped)
             {
-                EditorApplication.isPlaying = true;
                 stopped = false;
+
+                foreach (var message in compilerMessages)
+                {
+                    if (message.type == CompilerMessageType.Error)
+                    {
+                        return;
+                    }
+                }
+
+                EditorApplication.isPlaying = true;
             }
         }
     }

--- a/workers/unity/Assets/Playground/Editor/DisconnectOnCompilation.cs
+++ b/workers/unity/Assets/Playground/Editor/DisconnectOnCompilation.cs
@@ -15,7 +15,7 @@ namespace Playground.Editor
             CompilationPipeline.assemblyCompilationFinished += OnCompilationFinished;
         }
 
-        private static void OnCompilationStarted(string obj)
+        private static void OnCompilationStarted(string assemblyPath)
         {
             if (EditorApplication.isPlaying)
             {
@@ -24,7 +24,7 @@ namespace Playground.Editor
             }
         }
 
-        private static void OnCompilationFinished(string arg1, CompilerMessage[] arg2)
+        private static void OnCompilationFinished(string assemblyPath, CompilerMessage[] compilerMessages)
         {
             if (stopped)
             {

--- a/workers/unity/Assets/Playground/Editor/DisconnectOnCompilation.cs
+++ b/workers/unity/Assets/Playground/Editor/DisconnectOnCompilation.cs
@@ -1,0 +1,36 @@
+using UnityEditor;
+using UnityEditor.Compilation;
+using UnityEngine;
+
+namespace Playground.Editor
+{
+    public class DisconnectOnCompilation
+    {
+        private static bool stopped;
+
+        [RuntimeInitializeOnLoadMethod]
+        private static void Init()
+        {
+            CompilationPipeline.assemblyCompilationStarted += CompilationPipeline_assemblyCompilationStarted;
+            CompilationPipeline.assemblyCompilationFinished += CompilationPipeline_assemblyCompilationFinished;
+        }
+
+        private static void CompilationPipeline_assemblyCompilationStarted(string obj)
+        {
+            if (EditorApplication.isPlaying)
+            {
+                EditorApplication.isPlaying = false;
+                stopped = true;
+            }
+        }
+
+        private static void CompilationPipeline_assemblyCompilationFinished(string arg1, CompilerMessage[] arg2)
+        {
+            if (stopped)
+            {
+                EditorApplication.isPlaying = true;
+                stopped = false;
+            }
+        }
+    }
+}

--- a/workers/unity/Assets/Playground/Editor/DisconnectOnCompilation.cs.meta
+++ b/workers/unity/Assets/Playground/Editor/DisconnectOnCompilation.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: a30ef0727dc349fdb02d7668d19db938
+timeCreated: 1536084733


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Editor hangs frequently if code compiles while the editor is playing and connected to Spatial.

#### Tests
Ran locally and the game restarted after compilation as expected.

#### Documentation
N/A

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
@jessicafalk @samiwh 