### PR TITLE
Remove Offset from Client Worker

### DIFF
--- a/workers/unity/Assets/Playground/Scenes/ClientScene.unity
+++ b/workers/unity/Assets/Playground/Scenes/ClientScene.unity
@@ -257,7 +257,7 @@ Prefab:
     m_Modifications:
     - target: {fileID: 4555427980518638, guid: 5857884d058555d4282a1beb501099b9, type: 2}
       propertyPath: m_LocalPosition.x
-      value: 50
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4555427980518638, guid: 5857884d058555d4282a1beb501099b9, type: 2}
       propertyPath: m_LocalPosition.y


### PR DESCRIPTION
In the ClientWorker scene, the worker object had an offset of 50. Set this back to 0. 