### PR TITLE
UTY-1143: Make Monobehaviour Base Classes Public

### DIFF
--- a/workers/unity/Packages/com.improbable.gdk.core/AssemblyInfo.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/AssemblyInfo.cs
@@ -1,4 +1,3 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Improbable.Gdk.Core.EditmodeTests")]
-﻿[assembly: InternalsVisibleTo("Improbable.Gdk.Generated")]

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/GameObjectComponentDispatcherBase.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/GameObjectComponentDispatcherBase.cs
@@ -3,7 +3,7 @@ using Unity.Entities;
 
 namespace Improbable.Gdk.Core.GameObjectRepresentation
 {
-    internal abstract class GameObjectComponentDispatcherBase
+    public abstract class GameObjectComponentDispatcherBase
     {
         public abstract ComponentType[] ComponentAddedComponentTypes { get; }
         public ComponentGroup ComponentAddedComponentGroup { get; set; }

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/Injection/IInjectableCreator.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/Injection/IInjectableCreator.cs
@@ -5,7 +5,7 @@ namespace Improbable.Gdk.Core.GameObjectRepresentation
     /// <summary>
     ///     Interface for objects creating a particular type of IInjectable, to be used by the InjectableFactory.
     /// </summary>
-    internal interface IInjectableCreator
+    public interface IInjectableCreator
     {
         IInjectable CreateInjectable(Entity entity, EntityManager entityManager, ILogDispatcher logDispatcher);
     }

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/Injection/InjectableStore.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/Injection/InjectableStore.cs
@@ -8,7 +8,7 @@ namespace Improbable.Gdk.Core.GameObjectRepresentation
     ///     MonoBehaviour as dictated by the MonoBehaviourActivationManager, and querying by InjectableId for use
     ///     by the GameObjectComponentDispatchers.
     /// </summary>
-    internal class InjectableStore
+    public class InjectableStore
     {
         private readonly Dictionary<MonoBehaviour, Dictionary<InjectableId, IInjectable[]>> injectablesForBehaviours
             = new Dictionary<MonoBehaviour, Dictionary<InjectableId, IInjectable[]>>();

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/Injection/InjectionConditionAttribute.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/Injection/InjectionConditionAttribute.cs
@@ -5,7 +5,7 @@ namespace Improbable.Gdk.Core.GameObjectRepresentation
     /// <summary>
     ///     Used to denote when a specific IInjectable type is ready to be created.
     /// </summary>
-    internal enum InjectionCondition
+    public enum InjectionCondition
     {
         RequireNothing,
         RequireComponentPresent,
@@ -15,7 +15,7 @@ namespace Improbable.Gdk.Core.GameObjectRepresentation
     /// <summary>
     ///     For tagging specific IInjectable types with the appropriate InjectionCondition.
     /// </summary>
-    internal class InjectionConditionAttribute : Attribute
+    public class InjectionConditionAttribute : Attribute
     {
         public readonly InjectionCondition condition;
 

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/Injection/MonoBehaviourActivationManager.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/Injection/MonoBehaviourActivationManager.cs
@@ -12,7 +12,7 @@ namespace Improbable.Gdk.Core.GameObjectRepresentation
     ///     are enabled , calling into the RequiredFieldInjector for injection, storing the created Injectables in the
     ///     given ReaderWriterStore.
     /// </summary>
-    internal class MonoBehaviourActivationManager
+    public class MonoBehaviourActivationManager
     {
         private readonly Entity entity;
         private readonly EntityId spatialId;

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/Injection/RequiredFieldInjector.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/Injection/RequiredFieldInjector.cs
@@ -10,7 +10,7 @@ namespace Improbable.Gdk.Core.GameObjectRepresentation
     /// <summary>
     ///     Retrieves fields with [Require] tags from MonoBehaviours and handles injection into them.
     /// </summary>
-    internal class RequiredFieldInjector
+    public class RequiredFieldInjector
     {
         private readonly Dictionary<Type, Dictionary<InjectableId, FieldInfo[]>> fieldInfoCache
             = new Dictionary<Type, Dictionary<InjectableId, FieldInfo[]>>();

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/ReadersWriters/GameObjectDelegates.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/ReadersWriters/GameObjectDelegates.cs
@@ -20,7 +20,7 @@ namespace Improbable.Gdk.Core.GameObjectRepresentation
         /// <param name="callbacks">The callbacks.</param>
         /// <param name="logDispatcher">The logging dispatcher that will be receiving the exceptions.</param>
         /// <typeparam name="TPayload">The payload type.</typeparam>
-        internal static void DispatchWithErrorHandling<TPayload>(
+        public static void DispatchWithErrorHandling<TPayload>(
             TPayload payload,
             List<Action<TPayload>> callbacks,
             ILogDispatcher logDispatcher)

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/ReadersWriters/ReaderWriterBase.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/ReadersWriters/ReaderWriterBase.cs
@@ -8,7 +8,7 @@ using Entity = Unity.Entities.Entity;
 
 namespace Improbable.Gdk.Core.GameObjectRepresentation
 {
-    internal abstract class ReaderWriterBase<TSpatialComponentData, TComponentUpdate>
+    public abstract class ReaderWriterBase<TSpatialComponentData, TComponentUpdate>
         : IWriter<TSpatialComponentData, TComponentUpdate>
         where TSpatialComponentData : struct, ISpatialComponentData, IComponentData
         where TComponentUpdate : ISpatialComponentUpdate


### PR DESCRIPTION
#### Description
Previously, the Monobehaviour base classes were internal and `AssemblyInfo.cs` exposed the internals of `Gdk.Core` to `Gdk.Generated`. However, this enforces a naming convention of generated code and creates a pseudo-dependency.

This PR address that by making things public and removing the exposing.

#### Tests
Ran playground + ran tests
#### Documentation
N/A
#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
@MPeti01 @JonasImprobable 