### PR TITLE
Add tags properly

### DIFF
--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveBlittableSingularTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveBlittableSingularTranslation.cs
@@ -48,7 +48,7 @@ namespace Generated.Improbable.Gdk.Tests
                 var data = Generated.Improbable.Gdk.Tests.ExhaustiveBlittableSingular.Serialization.Deserialize(op.Data.SchemaData.Value.GetFields(), World);
                 data.DirtyBit = false;
                 entityManager.AddComponentData(entity, data);
-                entityManager.AddComponentData(entity, new NotAuthoritative<Generated.Improbable.Gdk.Tests.ExhaustiveBlittableSingular.Component>());
+                entityManager.AddComponent(entity, ComponentType.Create<NotAuthoritative<Generated.Improbable.Gdk.Tests.ExhaustiveBlittableSingular.Component>>());
 
                 var update = new Generated.Improbable.Gdk.Tests.ExhaustiveBlittableSingular.Update
                 {
@@ -88,7 +88,7 @@ namespace Generated.Improbable.Gdk.Tests
                 }
                 else if (!entityManager.HasComponent<ComponentAdded<Generated.Improbable.Gdk.Tests.ExhaustiveBlittableSingular.Component>>(entity))
                 {
-                    entityManager.AddComponentData(entity, new ComponentAdded<Generated.Improbable.Gdk.Tests.ExhaustiveBlittableSingular.Component>());
+                    entityManager.AddComponent(entity, ComponentType.Create<ComponentAdded<Generated.Improbable.Gdk.Tests.ExhaustiveBlittableSingular.Component>>());
                 }
                 else
                 {
@@ -115,7 +115,7 @@ namespace Generated.Improbable.Gdk.Tests
                 }
                 else if (!entityManager.HasComponent<ComponentRemoved<Generated.Improbable.Gdk.Tests.ExhaustiveBlittableSingular.Component>>(entity))
                 {
-                    entityManager.AddComponentData(entity, new ComponentRemoved<Generated.Improbable.Gdk.Tests.ExhaustiveBlittableSingular.Component>());
+                    entityManager.AddComponent(entity, ComponentType.Create<ComponentRemoved<Generated.Improbable.Gdk.Tests.ExhaustiveBlittableSingular.Component>>());
                 }
                 else
                 {
@@ -228,7 +228,7 @@ namespace Generated.Improbable.Gdk.Tests
                         }
 
                         entityManager.RemoveComponent<NotAuthoritative<Generated.Improbable.Gdk.Tests.ExhaustiveBlittableSingular.Component>>(entity);
-                        entityManager.AddComponentData(entity, new Authoritative<Generated.Improbable.Gdk.Tests.ExhaustiveBlittableSingular.Component>());
+                        entityManager.AddComponent(entity, ComponentType.Create<Authoritative<Generated.Improbable.Gdk.Tests.ExhaustiveBlittableSingular.Component>>());
 
                         // Add event senders
                         break;
@@ -239,7 +239,7 @@ namespace Generated.Improbable.Gdk.Tests
                             return;
                         }
 
-                        entityManager.AddComponentData(entity, new AuthorityLossImminent<Generated.Improbable.Gdk.Tests.ExhaustiveBlittableSingular.Component>());
+                        entityManager.AddComponent(entity, ComponentType.Create<AuthorityLossImminent<Generated.Improbable.Gdk.Tests.ExhaustiveBlittableSingular.Component>>());
                         break;
                     case Authority.NotAuthoritative:
                         if (!entityManager.HasComponent<Authoritative<Generated.Improbable.Gdk.Tests.ExhaustiveBlittableSingular.Component>>(entity))
@@ -254,7 +254,7 @@ namespace Generated.Improbable.Gdk.Tests
                         }
 
                         entityManager.RemoveComponent<Authoritative<Generated.Improbable.Gdk.Tests.ExhaustiveBlittableSingular.Component>>(entity);
-                        entityManager.AddComponentData(entity, new NotAuthoritative<Generated.Improbable.Gdk.Tests.ExhaustiveBlittableSingular.Component>());
+                        entityManager.AddComponent(entity, ComponentType.Create<NotAuthoritative<Generated.Improbable.Gdk.Tests.ExhaustiveBlittableSingular.Component>>());
 
                         // Remove event senders
                         break;

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKeyTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKeyTranslation.cs
@@ -65,7 +65,7 @@ namespace Generated.Improbable.Gdk.Tests
                 var data = Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.Serialization.Deserialize(op.Data.SchemaData.Value.GetFields(), World);
                 data.DirtyBit = false;
                 entityManager.AddComponentData(entity, data);
-                entityManager.AddComponentData(entity, new NotAuthoritative<Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.Component>());
+                entityManager.AddComponent(entity, ComponentType.Create<NotAuthoritative<Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.Component>>());
 
                 var update = new Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.Update
                 {
@@ -107,7 +107,7 @@ namespace Generated.Improbable.Gdk.Tests
                 }
                 else if (!entityManager.HasComponent<ComponentAdded<Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.Component>>(entity))
                 {
-                    entityManager.AddComponentData(entity, new ComponentAdded<Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.Component>());
+                    entityManager.AddComponent(entity, ComponentType.Create<ComponentAdded<Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.Component>>());
                 }
                 else
                 {
@@ -153,7 +153,7 @@ namespace Generated.Improbable.Gdk.Tests
                 }
                 else if (!entityManager.HasComponent<ComponentRemoved<Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.Component>>(entity))
                 {
-                    entityManager.AddComponentData(entity, new ComponentRemoved<Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.Component>());
+                    entityManager.AddComponent(entity, ComponentType.Create<ComponentRemoved<Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.Component>>());
                 }
                 else
                 {
@@ -266,7 +266,7 @@ namespace Generated.Improbable.Gdk.Tests
                         }
 
                         entityManager.RemoveComponent<NotAuthoritative<Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.Component>>(entity);
-                        entityManager.AddComponentData(entity, new Authoritative<Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.Component>());
+                        entityManager.AddComponent(entity, ComponentType.Create<Authoritative<Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.Component>>());
 
                         // Add event senders
                         break;
@@ -277,7 +277,7 @@ namespace Generated.Improbable.Gdk.Tests
                             return;
                         }
 
-                        entityManager.AddComponentData(entity, new AuthorityLossImminent<Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.Component>());
+                        entityManager.AddComponent(entity, ComponentType.Create<AuthorityLossImminent<Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.Component>>());
                         break;
                     case Authority.NotAuthoritative:
                         if (!entityManager.HasComponent<Authoritative<Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.Component>>(entity))
@@ -292,7 +292,7 @@ namespace Generated.Improbable.Gdk.Tests
                         }
 
                         entityManager.RemoveComponent<Authoritative<Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.Component>>(entity);
-                        entityManager.AddComponentData(entity, new NotAuthoritative<Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.Component>());
+                        entityManager.AddComponent(entity, ComponentType.Create<NotAuthoritative<Generated.Improbable.Gdk.Tests.ExhaustiveMapKey.Component>>());
 
                         // Remove event senders
                         break;

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValueTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValueTranslation.cs
@@ -65,7 +65,7 @@ namespace Generated.Improbable.Gdk.Tests
                 var data = Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.Serialization.Deserialize(op.Data.SchemaData.Value.GetFields(), World);
                 data.DirtyBit = false;
                 entityManager.AddComponentData(entity, data);
-                entityManager.AddComponentData(entity, new NotAuthoritative<Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.Component>());
+                entityManager.AddComponent(entity, ComponentType.Create<NotAuthoritative<Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.Component>>());
 
                 var update = new Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.Update
                 {
@@ -107,7 +107,7 @@ namespace Generated.Improbable.Gdk.Tests
                 }
                 else if (!entityManager.HasComponent<ComponentAdded<Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.Component>>(entity))
                 {
-                    entityManager.AddComponentData(entity, new ComponentAdded<Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.Component>());
+                    entityManager.AddComponent(entity, ComponentType.Create<ComponentAdded<Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.Component>>());
                 }
                 else
                 {
@@ -153,7 +153,7 @@ namespace Generated.Improbable.Gdk.Tests
                 }
                 else if (!entityManager.HasComponent<ComponentRemoved<Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.Component>>(entity))
                 {
-                    entityManager.AddComponentData(entity, new ComponentRemoved<Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.Component>());
+                    entityManager.AddComponent(entity, ComponentType.Create<ComponentRemoved<Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.Component>>());
                 }
                 else
                 {
@@ -266,7 +266,7 @@ namespace Generated.Improbable.Gdk.Tests
                         }
 
                         entityManager.RemoveComponent<NotAuthoritative<Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.Component>>(entity);
-                        entityManager.AddComponentData(entity, new Authoritative<Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.Component>());
+                        entityManager.AddComponent(entity, ComponentType.Create<Authoritative<Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.Component>>());
 
                         // Add event senders
                         break;
@@ -277,7 +277,7 @@ namespace Generated.Improbable.Gdk.Tests
                             return;
                         }
 
-                        entityManager.AddComponentData(entity, new AuthorityLossImminent<Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.Component>());
+                        entityManager.AddComponent(entity, ComponentType.Create<AuthorityLossImminent<Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.Component>>());
                         break;
                     case Authority.NotAuthoritative:
                         if (!entityManager.HasComponent<Authoritative<Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.Component>>(entity))
@@ -292,7 +292,7 @@ namespace Generated.Improbable.Gdk.Tests
                         }
 
                         entityManager.RemoveComponent<Authoritative<Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.Component>>(entity);
-                        entityManager.AddComponentData(entity, new NotAuthoritative<Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.Component>());
+                        entityManager.AddComponent(entity, ComponentType.Create<NotAuthoritative<Generated.Improbable.Gdk.Tests.ExhaustiveMapValue.Component>>());
 
                         // Remove event senders
                         break;

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptionalTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptionalTranslation.cs
@@ -65,7 +65,7 @@ namespace Generated.Improbable.Gdk.Tests
                 var data = Generated.Improbable.Gdk.Tests.ExhaustiveOptional.Serialization.Deserialize(op.Data.SchemaData.Value.GetFields(), World);
                 data.DirtyBit = false;
                 entityManager.AddComponentData(entity, data);
-                entityManager.AddComponentData(entity, new NotAuthoritative<Generated.Improbable.Gdk.Tests.ExhaustiveOptional.Component>());
+                entityManager.AddComponent(entity, ComponentType.Create<NotAuthoritative<Generated.Improbable.Gdk.Tests.ExhaustiveOptional.Component>>());
 
                 var update = new Generated.Improbable.Gdk.Tests.ExhaustiveOptional.Update
                 {
@@ -107,7 +107,7 @@ namespace Generated.Improbable.Gdk.Tests
                 }
                 else if (!entityManager.HasComponent<ComponentAdded<Generated.Improbable.Gdk.Tests.ExhaustiveOptional.Component>>(entity))
                 {
-                    entityManager.AddComponentData(entity, new ComponentAdded<Generated.Improbable.Gdk.Tests.ExhaustiveOptional.Component>());
+                    entityManager.AddComponent(entity, ComponentType.Create<ComponentAdded<Generated.Improbable.Gdk.Tests.ExhaustiveOptional.Component>>());
                 }
                 else
                 {
@@ -153,7 +153,7 @@ namespace Generated.Improbable.Gdk.Tests
                 }
                 else if (!entityManager.HasComponent<ComponentRemoved<Generated.Improbable.Gdk.Tests.ExhaustiveOptional.Component>>(entity))
                 {
-                    entityManager.AddComponentData(entity, new ComponentRemoved<Generated.Improbable.Gdk.Tests.ExhaustiveOptional.Component>());
+                    entityManager.AddComponent(entity, ComponentType.Create<ComponentRemoved<Generated.Improbable.Gdk.Tests.ExhaustiveOptional.Component>>());
                 }
                 else
                 {
@@ -266,7 +266,7 @@ namespace Generated.Improbable.Gdk.Tests
                         }
 
                         entityManager.RemoveComponent<NotAuthoritative<Generated.Improbable.Gdk.Tests.ExhaustiveOptional.Component>>(entity);
-                        entityManager.AddComponentData(entity, new Authoritative<Generated.Improbable.Gdk.Tests.ExhaustiveOptional.Component>());
+                        entityManager.AddComponent(entity, ComponentType.Create<Authoritative<Generated.Improbable.Gdk.Tests.ExhaustiveOptional.Component>>());
 
                         // Add event senders
                         break;
@@ -277,7 +277,7 @@ namespace Generated.Improbable.Gdk.Tests
                             return;
                         }
 
-                        entityManager.AddComponentData(entity, new AuthorityLossImminent<Generated.Improbable.Gdk.Tests.ExhaustiveOptional.Component>());
+                        entityManager.AddComponent(entity, ComponentType.Create<AuthorityLossImminent<Generated.Improbable.Gdk.Tests.ExhaustiveOptional.Component>>());
                         break;
                     case Authority.NotAuthoritative:
                         if (!entityManager.HasComponent<Authoritative<Generated.Improbable.Gdk.Tests.ExhaustiveOptional.Component>>(entity))
@@ -292,7 +292,7 @@ namespace Generated.Improbable.Gdk.Tests
                         }
 
                         entityManager.RemoveComponent<Authoritative<Generated.Improbable.Gdk.Tests.ExhaustiveOptional.Component>>(entity);
-                        entityManager.AddComponentData(entity, new NotAuthoritative<Generated.Improbable.Gdk.Tests.ExhaustiveOptional.Component>());
+                        entityManager.AddComponent(entity, ComponentType.Create<NotAuthoritative<Generated.Improbable.Gdk.Tests.ExhaustiveOptional.Component>>());
 
                         // Remove event senders
                         break;

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeatedTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeatedTranslation.cs
@@ -65,7 +65,7 @@ namespace Generated.Improbable.Gdk.Tests
                 var data = Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.Serialization.Deserialize(op.Data.SchemaData.Value.GetFields(), World);
                 data.DirtyBit = false;
                 entityManager.AddComponentData(entity, data);
-                entityManager.AddComponentData(entity, new NotAuthoritative<Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.Component>());
+                entityManager.AddComponent(entity, ComponentType.Create<NotAuthoritative<Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.Component>>());
 
                 var update = new Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.Update
                 {
@@ -107,7 +107,7 @@ namespace Generated.Improbable.Gdk.Tests
                 }
                 else if (!entityManager.HasComponent<ComponentAdded<Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.Component>>(entity))
                 {
-                    entityManager.AddComponentData(entity, new ComponentAdded<Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.Component>());
+                    entityManager.AddComponent(entity, ComponentType.Create<ComponentAdded<Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.Component>>());
                 }
                 else
                 {
@@ -153,7 +153,7 @@ namespace Generated.Improbable.Gdk.Tests
                 }
                 else if (!entityManager.HasComponent<ComponentRemoved<Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.Component>>(entity))
                 {
-                    entityManager.AddComponentData(entity, new ComponentRemoved<Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.Component>());
+                    entityManager.AddComponent(entity, ComponentType.Create<ComponentRemoved<Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.Component>>());
                 }
                 else
                 {
@@ -266,7 +266,7 @@ namespace Generated.Improbable.Gdk.Tests
                         }
 
                         entityManager.RemoveComponent<NotAuthoritative<Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.Component>>(entity);
-                        entityManager.AddComponentData(entity, new Authoritative<Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.Component>());
+                        entityManager.AddComponent(entity, ComponentType.Create<Authoritative<Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.Component>>());
 
                         // Add event senders
                         break;
@@ -277,7 +277,7 @@ namespace Generated.Improbable.Gdk.Tests
                             return;
                         }
 
-                        entityManager.AddComponentData(entity, new AuthorityLossImminent<Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.Component>());
+                        entityManager.AddComponent(entity, ComponentType.Create<AuthorityLossImminent<Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.Component>>());
                         break;
                     case Authority.NotAuthoritative:
                         if (!entityManager.HasComponent<Authoritative<Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.Component>>(entity))
@@ -292,7 +292,7 @@ namespace Generated.Improbable.Gdk.Tests
                         }
 
                         entityManager.RemoveComponent<Authoritative<Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.Component>>(entity);
-                        entityManager.AddComponentData(entity, new NotAuthoritative<Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.Component>());
+                        entityManager.AddComponent(entity, ComponentType.Create<NotAuthoritative<Generated.Improbable.Gdk.Tests.ExhaustiveRepeated.Component>>());
 
                         // Remove event senders
                         break;

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingularTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingularTranslation.cs
@@ -50,7 +50,7 @@ namespace Generated.Improbable.Gdk.Tests
                 var data = Generated.Improbable.Gdk.Tests.ExhaustiveSingular.Serialization.Deserialize(op.Data.SchemaData.Value.GetFields(), World);
                 data.DirtyBit = false;
                 entityManager.AddComponentData(entity, data);
-                entityManager.AddComponentData(entity, new NotAuthoritative<Generated.Improbable.Gdk.Tests.ExhaustiveSingular.Component>());
+                entityManager.AddComponent(entity, ComponentType.Create<NotAuthoritative<Generated.Improbable.Gdk.Tests.ExhaustiveSingular.Component>>());
 
                 var update = new Generated.Improbable.Gdk.Tests.ExhaustiveSingular.Update
                 {
@@ -92,7 +92,7 @@ namespace Generated.Improbable.Gdk.Tests
                 }
                 else if (!entityManager.HasComponent<ComponentAdded<Generated.Improbable.Gdk.Tests.ExhaustiveSingular.Component>>(entity))
                 {
-                    entityManager.AddComponentData(entity, new ComponentAdded<Generated.Improbable.Gdk.Tests.ExhaustiveSingular.Component>());
+                    entityManager.AddComponent(entity, ComponentType.Create<ComponentAdded<Generated.Improbable.Gdk.Tests.ExhaustiveSingular.Component>>());
                 }
                 else
                 {
@@ -123,7 +123,7 @@ namespace Generated.Improbable.Gdk.Tests
                 }
                 else if (!entityManager.HasComponent<ComponentRemoved<Generated.Improbable.Gdk.Tests.ExhaustiveSingular.Component>>(entity))
                 {
-                    entityManager.AddComponentData(entity, new ComponentRemoved<Generated.Improbable.Gdk.Tests.ExhaustiveSingular.Component>());
+                    entityManager.AddComponent(entity, ComponentType.Create<ComponentRemoved<Generated.Improbable.Gdk.Tests.ExhaustiveSingular.Component>>());
                 }
                 else
                 {
@@ -236,7 +236,7 @@ namespace Generated.Improbable.Gdk.Tests
                         }
 
                         entityManager.RemoveComponent<NotAuthoritative<Generated.Improbable.Gdk.Tests.ExhaustiveSingular.Component>>(entity);
-                        entityManager.AddComponentData(entity, new Authoritative<Generated.Improbable.Gdk.Tests.ExhaustiveSingular.Component>());
+                        entityManager.AddComponent(entity, ComponentType.Create<Authoritative<Generated.Improbable.Gdk.Tests.ExhaustiveSingular.Component>>());
 
                         // Add event senders
                         break;
@@ -247,7 +247,7 @@ namespace Generated.Improbable.Gdk.Tests
                             return;
                         }
 
-                        entityManager.AddComponentData(entity, new AuthorityLossImminent<Generated.Improbable.Gdk.Tests.ExhaustiveSingular.Component>());
+                        entityManager.AddComponent(entity, ComponentType.Create<AuthorityLossImminent<Generated.Improbable.Gdk.Tests.ExhaustiveSingular.Component>>());
                         break;
                     case Authority.NotAuthoritative:
                         if (!entityManager.HasComponent<Authoritative<Generated.Improbable.Gdk.Tests.ExhaustiveSingular.Component>>(entity))
@@ -262,7 +262,7 @@ namespace Generated.Improbable.Gdk.Tests
                         }
 
                         entityManager.RemoveComponent<Authoritative<Generated.Improbable.Gdk.Tests.ExhaustiveSingular.Component>>(entity);
-                        entityManager.AddComponentData(entity, new NotAuthoritative<Generated.Improbable.Gdk.Tests.ExhaustiveSingular.Component>());
+                        entityManager.AddComponent(entity, ComponentType.Create<NotAuthoritative<Generated.Improbable.Gdk.Tests.ExhaustiveSingular.Component>>());
 
                         // Remove event senders
                         break;

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/NestedComponentTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/NestedComponentTranslation.cs
@@ -48,7 +48,7 @@ namespace Generated.Improbable.Gdk.Tests
                 var data = Generated.Improbable.Gdk.Tests.NestedComponent.Serialization.Deserialize(op.Data.SchemaData.Value.GetFields(), World);
                 data.DirtyBit = false;
                 entityManager.AddComponentData(entity, data);
-                entityManager.AddComponentData(entity, new NotAuthoritative<Generated.Improbable.Gdk.Tests.NestedComponent.Component>());
+                entityManager.AddComponent(entity, ComponentType.Create<NotAuthoritative<Generated.Improbable.Gdk.Tests.NestedComponent.Component>>());
 
                 var update = new Generated.Improbable.Gdk.Tests.NestedComponent.Update
                 {
@@ -74,7 +74,7 @@ namespace Generated.Improbable.Gdk.Tests
                 }
                 else if (!entityManager.HasComponent<ComponentAdded<Generated.Improbable.Gdk.Tests.NestedComponent.Component>>(entity))
                 {
-                    entityManager.AddComponentData(entity, new ComponentAdded<Generated.Improbable.Gdk.Tests.NestedComponent.Component>());
+                    entityManager.AddComponent(entity, ComponentType.Create<ComponentAdded<Generated.Improbable.Gdk.Tests.NestedComponent.Component>>());
                 }
                 else
                 {
@@ -101,7 +101,7 @@ namespace Generated.Improbable.Gdk.Tests
                 }
                 else if (!entityManager.HasComponent<ComponentRemoved<Generated.Improbable.Gdk.Tests.NestedComponent.Component>>(entity))
                 {
-                    entityManager.AddComponentData(entity, new ComponentRemoved<Generated.Improbable.Gdk.Tests.NestedComponent.Component>());
+                    entityManager.AddComponent(entity, ComponentType.Create<ComponentRemoved<Generated.Improbable.Gdk.Tests.NestedComponent.Component>>());
                 }
                 else
                 {
@@ -214,7 +214,7 @@ namespace Generated.Improbable.Gdk.Tests
                         }
 
                         entityManager.RemoveComponent<NotAuthoritative<Generated.Improbable.Gdk.Tests.NestedComponent.Component>>(entity);
-                        entityManager.AddComponentData(entity, new Authoritative<Generated.Improbable.Gdk.Tests.NestedComponent.Component>());
+                        entityManager.AddComponent(entity, ComponentType.Create<Authoritative<Generated.Improbable.Gdk.Tests.NestedComponent.Component>>());
 
                         // Add event senders
                         break;
@@ -225,7 +225,7 @@ namespace Generated.Improbable.Gdk.Tests
                             return;
                         }
 
-                        entityManager.AddComponentData(entity, new AuthorityLossImminent<Generated.Improbable.Gdk.Tests.NestedComponent.Component>());
+                        entityManager.AddComponent(entity, ComponentType.Create<AuthorityLossImminent<Generated.Improbable.Gdk.Tests.NestedComponent.Component>>());
                         break;
                     case Authority.NotAuthoritative:
                         if (!entityManager.HasComponent<Authoritative<Generated.Improbable.Gdk.Tests.NestedComponent.Component>>(entity))
@@ -240,7 +240,7 @@ namespace Generated.Improbable.Gdk.Tests
                         }
 
                         entityManager.RemoveComponent<Authoritative<Generated.Improbable.Gdk.Tests.NestedComponent.Component>>(entity);
-                        entityManager.AddComponentData(entity, new NotAuthoritative<Generated.Improbable.Gdk.Tests.NestedComponent.Component>());
+                        entityManager.AddComponent(entity, ComponentType.Create<NotAuthoritative<Generated.Improbable.Gdk.Tests.NestedComponent.Component>>());
 
                         // Remove event senders
                         break;

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/ConnectionTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/ConnectionTranslation.cs
@@ -49,7 +49,7 @@ namespace Generated.Improbable.Gdk.Tests.AlternateSchemaSyntax
                 var data = Generated.Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Serialization.Deserialize(op.Data.SchemaData.Value.GetFields(), World);
                 data.DirtyBit = false;
                 entityManager.AddComponentData(entity, data);
-                entityManager.AddComponentData(entity, new NotAuthoritative<Generated.Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>());
+                entityManager.AddComponent(entity, ComponentType.Create<NotAuthoritative<Generated.Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>>());
 
                 var update = new Generated.Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Update
                 {
@@ -74,7 +74,7 @@ namespace Generated.Improbable.Gdk.Tests.AlternateSchemaSyntax
                 }
                 else if (!entityManager.HasComponent<ComponentAdded<Generated.Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>>(entity))
                 {
-                    entityManager.AddComponentData(entity, new ComponentAdded<Generated.Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>());
+                    entityManager.AddComponent(entity, ComponentType.Create<ComponentAdded<Generated.Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>>());
                 }
                 else
                 {
@@ -101,7 +101,7 @@ namespace Generated.Improbable.Gdk.Tests.AlternateSchemaSyntax
                 }
                 else if (!entityManager.HasComponent<ComponentRemoved<Generated.Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>>(entity))
                 {
-                    entityManager.AddComponentData(entity, new ComponentRemoved<Generated.Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>());
+                    entityManager.AddComponent(entity, ComponentType.Create<ComponentRemoved<Generated.Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>>());
                 }
                 else
                 {
@@ -246,7 +246,7 @@ namespace Generated.Improbable.Gdk.Tests.AlternateSchemaSyntax
                         }
 
                         entityManager.RemoveComponent<NotAuthoritative<Generated.Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>>(entity);
-                        entityManager.AddComponentData(entity, new Authoritative<Generated.Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>());
+                        entityManager.AddComponent(entity, ComponentType.Create<Authoritative<Generated.Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>>());
 
                         // Add event senders
                         {
@@ -265,7 +265,7 @@ namespace Generated.Improbable.Gdk.Tests.AlternateSchemaSyntax
                             return;
                         }
 
-                        entityManager.AddComponentData(entity, new AuthorityLossImminent<Generated.Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>());
+                        entityManager.AddComponent(entity, ComponentType.Create<AuthorityLossImminent<Generated.Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>>());
                         break;
                     case Authority.NotAuthoritative:
                         if (!entityManager.HasComponent<Authoritative<Generated.Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>>(entity))
@@ -280,7 +280,7 @@ namespace Generated.Improbable.Gdk.Tests.AlternateSchemaSyntax
                         }
 
                         entityManager.RemoveComponent<Authoritative<Generated.Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>>(entity);
-                        entityManager.AddComponentData(entity, new NotAuthoritative<Generated.Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>());
+                        entityManager.AddComponent(entity, ComponentType.Create<NotAuthoritative<Generated.Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>>());
 
                         // Remove event senders
                         {

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentTranslation.cs
@@ -62,7 +62,7 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
                 var data = Generated.Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Serialization.Deserialize(op.Data.SchemaData.Value.GetFields(), World);
                 data.DirtyBit = false;
                 entityManager.AddComponentData(entity, data);
-                entityManager.AddComponentData(entity, new NotAuthoritative<Generated.Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>());
+                entityManager.AddComponent(entity, ComponentType.Create<NotAuthoritative<Generated.Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>>());
 
                 var update = new Generated.Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Update
                 {
@@ -92,7 +92,7 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
                 }
                 else if (!entityManager.HasComponent<ComponentAdded<Generated.Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>>(entity))
                 {
-                    entityManager.AddComponentData(entity, new ComponentAdded<Generated.Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>());
+                    entityManager.AddComponent(entity, ComponentType.Create<ComponentAdded<Generated.Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>>());
                 }
                 else
                 {
@@ -119,7 +119,7 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
                 }
                 else if (!entityManager.HasComponent<ComponentRemoved<Generated.Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>>(entity))
                 {
-                    entityManager.AddComponentData(entity, new ComponentRemoved<Generated.Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>());
+                    entityManager.AddComponent(entity, ComponentType.Create<ComponentRemoved<Generated.Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>>());
                 }
                 else
                 {
@@ -333,7 +333,7 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
                         }
 
                         entityManager.RemoveComponent<NotAuthoritative<Generated.Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>>(entity);
-                        entityManager.AddComponentData(entity, new Authoritative<Generated.Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>());
+                        entityManager.AddComponent(entity, ComponentType.Create<Authoritative<Generated.Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>>());
 
                         // Add event senders
                         {
@@ -360,7 +360,7 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
                             return;
                         }
 
-                        entityManager.AddComponentData(entity, new AuthorityLossImminent<Generated.Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>());
+                        entityManager.AddComponent(entity, ComponentType.Create<AuthorityLossImminent<Generated.Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>>());
                         break;
                     case Authority.NotAuthoritative:
                         if (!entityManager.HasComponent<Authoritative<Generated.Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>>(entity))
@@ -375,7 +375,7 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
                         }
 
                         entityManager.RemoveComponent<Authoritative<Generated.Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>>(entity);
-                        entityManager.AddComponentData(entity, new NotAuthoritative<Generated.Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>());
+                        entityManager.AddComponent(entity, ComponentType.Create<NotAuthoritative<Generated.Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>>());
 
                         // Remove event senders
                         {

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsTranslation.cs
@@ -48,7 +48,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 var data = Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Serialization.Deserialize(op.Data.SchemaData.Value.GetFields(), World);
                 data.DirtyBit = false;
                 entityManager.AddComponentData(entity, data);
-                entityManager.AddComponentData(entity, new NotAuthoritative<Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>());
+                entityManager.AddComponent(entity, ComponentType.Create<NotAuthoritative<Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>>());
 
                 var update = new Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Update
                 {
@@ -73,7 +73,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 }
                 else if (!entityManager.HasComponent<ComponentAdded<Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>>(entity))
                 {
-                    entityManager.AddComponentData(entity, new ComponentAdded<Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>());
+                    entityManager.AddComponent(entity, ComponentType.Create<ComponentAdded<Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>>());
                 }
                 else
                 {
@@ -100,7 +100,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 }
                 else if (!entityManager.HasComponent<ComponentRemoved<Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>>(entity))
                 {
-                    entityManager.AddComponentData(entity, new ComponentRemoved<Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>());
+                    entityManager.AddComponent(entity, ComponentType.Create<ComponentRemoved<Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>>());
                 }
                 else
                 {
@@ -213,7 +213,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                         }
 
                         entityManager.RemoveComponent<NotAuthoritative<Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>>(entity);
-                        entityManager.AddComponentData(entity, new Authoritative<Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>());
+                        entityManager.AddComponent(entity, ComponentType.Create<Authoritative<Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>>());
 
                         // Add event senders
                         break;
@@ -224,7 +224,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                             return;
                         }
 
-                        entityManager.AddComponentData(entity, new AuthorityLossImminent<Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>());
+                        entityManager.AddComponent(entity, ComponentType.Create<AuthorityLossImminent<Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>>());
                         break;
                     case Authority.NotAuthoritative:
                         if (!entityManager.HasComponent<Authoritative<Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>>(entity))
@@ -239,7 +239,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                         }
 
                         entityManager.RemoveComponent<Authoritative<Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>>(entity);
-                        entityManager.AddComponentData(entity, new NotAuthoritative<Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>());
+                        entityManager.AddComponent(entity, ComponentType.Create<NotAuthoritative<Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>>());
 
                         // Remove event senders
                         break;

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsTranslation.cs
@@ -54,7 +54,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 var data = Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Serialization.Deserialize(op.Data.SchemaData.Value.GetFields(), World);
                 data.DirtyBit = false;
                 entityManager.AddComponentData(entity, data);
-                entityManager.AddComponentData(entity, new NotAuthoritative<Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>());
+                entityManager.AddComponent(entity, ComponentType.Create<NotAuthoritative<Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>>());
 
                 var update = new Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Update
                 {
@@ -79,7 +79,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 }
                 else if (!entityManager.HasComponent<ComponentAdded<Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>>(entity))
                 {
-                    entityManager.AddComponentData(entity, new ComponentAdded<Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>());
+                    entityManager.AddComponent(entity, ComponentType.Create<ComponentAdded<Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>>());
                 }
                 else
                 {
@@ -106,7 +106,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 }
                 else if (!entityManager.HasComponent<ComponentRemoved<Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>>(entity))
                 {
-                    entityManager.AddComponentData(entity, new ComponentRemoved<Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>());
+                    entityManager.AddComponent(entity, ComponentType.Create<ComponentRemoved<Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>>());
                 }
                 else
                 {
@@ -238,7 +238,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                         }
 
                         entityManager.RemoveComponent<NotAuthoritative<Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>>(entity);
-                        entityManager.AddComponentData(entity, new Authoritative<Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>());
+                        entityManager.AddComponent(entity, ComponentType.Create<Authoritative<Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>>());
 
                         // Add event senders
                         break;
@@ -249,7 +249,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                             return;
                         }
 
-                        entityManager.AddComponentData(entity, new AuthorityLossImminent<Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>());
+                        entityManager.AddComponent(entity, ComponentType.Create<AuthorityLossImminent<Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>>());
                         break;
                     case Authority.NotAuthoritative:
                         if (!entityManager.HasComponent<Authoritative<Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>>(entity))
@@ -264,7 +264,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                         }
 
                         entityManager.RemoveComponent<Authoritative<Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>>(entity);
-                        entityManager.AddComponentData(entity, new NotAuthoritative<Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>());
+                        entityManager.AddComponent(entity, ComponentType.Create<NotAuthoritative<Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>>());
 
                         // Remove event senders
                         break;

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEventsTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEventsTranslation.cs
@@ -49,7 +49,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 var data = Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Serialization.Deserialize(op.Data.SchemaData.Value.GetFields(), World);
                 data.DirtyBit = false;
                 entityManager.AddComponentData(entity, data);
-                entityManager.AddComponentData(entity, new NotAuthoritative<Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>());
+                entityManager.AddComponent(entity, ComponentType.Create<NotAuthoritative<Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>>());
 
                 var update = new Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Update
                 {
@@ -74,7 +74,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 }
                 else if (!entityManager.HasComponent<ComponentAdded<Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>>(entity))
                 {
-                    entityManager.AddComponentData(entity, new ComponentAdded<Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>());
+                    entityManager.AddComponent(entity, ComponentType.Create<ComponentAdded<Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>>());
                 }
                 else
                 {
@@ -101,7 +101,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 }
                 else if (!entityManager.HasComponent<ComponentRemoved<Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>>(entity))
                 {
-                    entityManager.AddComponentData(entity, new ComponentRemoved<Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>());
+                    entityManager.AddComponent(entity, ComponentType.Create<ComponentRemoved<Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>>());
                 }
                 else
                 {
@@ -246,7 +246,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                         }
 
                         entityManager.RemoveComponent<NotAuthoritative<Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>>(entity);
-                        entityManager.AddComponentData(entity, new Authoritative<Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>());
+                        entityManager.AddComponent(entity, ComponentType.Create<Authoritative<Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>>());
 
                         // Add event senders
                         {
@@ -265,7 +265,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                             return;
                         }
 
-                        entityManager.AddComponentData(entity, new AuthorityLossImminent<Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>());
+                        entityManager.AddComponent(entity, ComponentType.Create<AuthorityLossImminent<Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>>());
                         break;
                     case Authority.NotAuthoritative:
                         if (!entityManager.HasComponent<Authoritative<Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>>(entity))
@@ -280,7 +280,7 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                         }
 
                         entityManager.RemoveComponent<Authoritative<Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>>(entity);
-                        entityManager.AddComponentData(entity, new NotAuthoritative<Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>());
+                        entityManager.AddComponent(entity, ComponentType.Create<NotAuthoritative<Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>>());
 
                         // Remove event senders
                         {

--- a/workers/unity/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentTranslation.cs
+++ b/workers/unity/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentTranslation.cs
@@ -66,7 +66,7 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                 var data = Generated.Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Serialization.Deserialize(op.Data.SchemaData.Value.GetFields(), World);
                 data.DirtyBit = false;
                 entityManager.AddComponentData(entity, data);
-                entityManager.AddComponentData(entity, new NotAuthoritative<Generated.Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>());
+                entityManager.AddComponent(entity, ComponentType.Create<NotAuthoritative<Generated.Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>>());
 
                 var update = new Generated.Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Update
                 {
@@ -100,7 +100,7 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                 }
                 else if (!entityManager.HasComponent<ComponentAdded<Generated.Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>>(entity))
                 {
-                    entityManager.AddComponentData(entity, new ComponentAdded<Generated.Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>());
+                    entityManager.AddComponent(entity, ComponentType.Create<ComponentAdded<Generated.Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>>());
                 }
                 else
                 {
@@ -133,7 +133,7 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                 }
                 else if (!entityManager.HasComponent<ComponentRemoved<Generated.Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>>(entity))
                 {
-                    entityManager.AddComponentData(entity, new ComponentRemoved<Generated.Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>());
+                    entityManager.AddComponent(entity, ComponentType.Create<ComponentRemoved<Generated.Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>>());
                 }
                 else
                 {
@@ -347,7 +347,7 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                         }
 
                         entityManager.RemoveComponent<NotAuthoritative<Generated.Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>>(entity);
-                        entityManager.AddComponentData(entity, new Authoritative<Generated.Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>());
+                        entityManager.AddComponent(entity, ComponentType.Create<Authoritative<Generated.Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>>());
 
                         // Add event senders
                         {
@@ -374,7 +374,7 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                             return;
                         }
 
-                        entityManager.AddComponentData(entity, new AuthorityLossImminent<Generated.Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>());
+                        entityManager.AddComponent(entity, ComponentType.Create<AuthorityLossImminent<Generated.Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>>());
                         break;
                     case Authority.NotAuthoritative:
                         if (!entityManager.HasComponent<Authoritative<Generated.Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>>(entity))
@@ -389,7 +389,7 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                         }
 
                         entityManager.RemoveComponent<Authoritative<Generated.Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>>(entity);
-                        entityManager.AddComponentData(entity, new NotAuthoritative<Generated.Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>());
+                        entityManager.AddComponent(entity, ComponentType.Create<NotAuthoritative<Generated.Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>>());
 
                         // Remove event senders
                         {

--- a/workers/unity/Packages/com.improbable.gdk.core/Systems/SpatialOSReceiveSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Systems/SpatialOSReceiveSystem.cs
@@ -93,7 +93,7 @@ namespace Improbable.Gdk.Core
             {
                 EntityId = entityId
             });
-            EntityManager.AddComponentData(entity, new NewlyAddedSpatialOSEntity());
+            EntityManager.AddComponent(entity, ComponentType.Create<NewlyAddedSpatialOSEntity>());
 
             foreach (var AddCommandCompoent in AddAllCommandComponents)
             {

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityComponentConversionGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityComponentConversionGenerator.tt
@@ -76,7 +76,7 @@ namespace <#= qualifiedNamespace #>
                 var data = <#= componentNamespace #>.Serialization.Deserialize(op.Data.SchemaData.Value.GetFields(), World);
                 data.DirtyBit = false;
                 entityManager.AddComponentData(entity, data);
-                entityManager.AddComponentData(entity, new NotAuthoritative<<#= componentNamespace #>.Component>());
+                entityManager.AddComponent(entity, ComponentType.Create<NotAuthoritative<<#= componentNamespace #>.Component>>());
 
                 var update = new <#= componentNamespace #>.Update
                 {
@@ -104,7 +104,7 @@ namespace <#= qualifiedNamespace #>
                 }
                 else if (!entityManager.HasComponent<ComponentAdded<<#= componentNamespace #>.Component>>(entity))
                 {
-                    entityManager.AddComponentData(entity, new ComponentAdded<<#= componentNamespace #>.Component>());
+                    entityManager.AddComponent(entity, ComponentType.Create<ComponentAdded<<#= componentNamespace #>.Component>>());
                 }
                 else
                 {
@@ -140,7 +140,7 @@ namespace <#= qualifiedNamespace #>
                 }
                 else if (!entityManager.HasComponent<ComponentRemoved<<#= componentNamespace #>.Component>>(entity))
                 {
-                    entityManager.AddComponentData(entity, new ComponentRemoved<<#= componentNamespace #>.Component>());
+                    entityManager.AddComponent(entity, ComponentType.Create<ComponentRemoved<<#= componentNamespace #>.Component>>());
                 }
                 else
                 {
@@ -314,7 +314,7 @@ namespace <#= qualifiedNamespace #>
                         }
 
                         entityManager.RemoveComponent<NotAuthoritative<<#= componentNamespace #>.Component>>(entity);
-                        entityManager.AddComponentData(entity, new Authoritative<<#= componentNamespace #>.Component>());
+                        entityManager.AddComponent(entity, ComponentType.Create<Authoritative<<#= componentNamespace #>.Component>>());
 
                         // Add event senders
 <# foreach (var eventDetail in eventDetailsList) { #>
@@ -335,7 +335,7 @@ namespace <#= qualifiedNamespace #>
                             return;
                         }
 
-                        entityManager.AddComponentData(entity, new AuthorityLossImminent<<#= componentNamespace #>.Component>());
+                        entityManager.AddComponent(entity, ComponentType.Create<AuthorityLossImminent<<#= componentNamespace #>.Component>>());
                         break;
                     case Authority.NotAuthoritative:
                         if (!entityManager.HasComponent<Authoritative<<#= componentNamespace #>.Component>>(entity))
@@ -350,7 +350,7 @@ namespace <#= qualifiedNamespace #>
                         }
 
                         entityManager.RemoveComponent<Authoritative<<#= componentNamespace #>.Component>>(entity);
-                        entityManager.AddComponentData(entity, new NotAuthoritative<<#= componentNamespace #>.Component>());
+                        entityManager.AddComponent(entity, ComponentType.Create<NotAuthoritative<<#= componentNamespace #>.Component>>());
 
                         // Remove event senders
 <# foreach (var eventDetail in eventDetailsList) { #>


### PR DESCRIPTION
#### Description
Starting entities preview 12, unity will be strict in disallowing empty `IComponentData` tags to be added through `EntityManager.AddComponentData`
This change fixes the these in advance.

The upgrade itself is blocked on a bug fix that is required for adding tags through the EntityCommandBuffers.