### PR TITLE
fixing update order of game object initialization

### DIFF
--- a/workers/unity/Packages/com.improbable.gdk.core/Systems/UpdateGroups.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Systems/UpdateGroups.cs
@@ -13,6 +13,12 @@ namespace Improbable.Gdk.Core
 
         [UpdateInGroup(typeof(SpatialOSReceiveGroup))]
         [UpdateAfter(typeof(InternalSpatialOSReceiveGroup))]
+        public class GameObjectInitializationGroup
+        {
+        }
+
+        [UpdateInGroup(typeof(SpatialOSReceiveGroup))]
+        [UpdateAfter(typeof(GameObjectInitializationGroup))]
         public class GameObjectReceiveGroup
         {
         }

--- a/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/GameObjectInitializationSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.gameobjectcreation/GameObjectInitializationSystem.cs
@@ -15,7 +15,7 @@ namespace Improbable.Gdk.GameObjectCreation
     ///     IEntityGameObjectCreator for cleanup.
     /// </summary>
     [DisableAutoCreation]
-    [UpdateInGroup(typeof(SpatialOSReceiveGroup.GameObjectReceiveGroup))]
+    [UpdateInGroup(typeof(SpatialOSReceiveGroup.GameObjectInitializationGroup))]
     internal class GameObjectInitializationSystem : ComponentSystem
     {
         private struct InitializedEntitySystemState : ISystemStateComponentData


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
making sure that the GameObjectInitializationSystem alwazs runs before the GameObjectDispatcherSystem.

#### Tests
ran it locally. spinners are spinning

#### Documentation
none

#### Primary reviewers
@firtina-improbable 