### PR TITLE
UTY-1176: Code Generation Workflow Tweaks

### DIFF
--- a/workers/unity/Packages/com.improbable.gdk.tools/GenerateCode.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/GenerateCode.cs
@@ -20,18 +20,31 @@ namespace Improbable.Gdk.Tools
         private static readonly string SchemaCompilerRelativePath =
             $"../build/CoreSdk/{Common.CoreSdkVersion}/schema_compiler/schema_compiler";
 
+        private static readonly string StartupCodegenMarkerFile =
+            Path.GetFullPath("Temp/ImprobableCodegen.marker");
+
         /// <summary>
         ///     Ensure that code is generated on editor startup.
         /// </summary>
         static GenerateCode()
         {
-            if (EditorApplication.isPlayingOrWillChangePlaymode)
+            if (!CanGenerateOnLoad())
             {
-                // Don't generate code when entering PlayMode.
                 return;
             }
 
             EditorApplication.delayCall += Generate;
+        }
+
+        private static bool CanGenerateOnLoad()
+        {
+            if (EditorApplication.isPlayingOrWillChangePlaymode)
+            {
+                // Don't generate code when entering PlayMode.
+                return false;
+            }
+
+            return !File.Exists(StartupCodegenMarkerFile);
         }
 
         [MenuItem("SpatialOS/Generate code", false, GenerateCodePriority)]
@@ -78,11 +91,16 @@ namespace Improbable.Gdk.Tools
 
                 using (new ShowProgressBarScope("Generating code..."))
                 {
-                    var exitCode = RedirectedProcess.Run(Common.DotNetBinary, ConstructArgs(projectPath, schemaCompilerPath));
+                    var exitCode = RedirectedProcess.Run(Common.DotNetBinary,
+                        ConstructArgs(projectPath, schemaCompilerPath));
 
                     if (exitCode != 0)
                     {
                         Debug.LogError("Failed to generate code.");
+                    }
+                    else
+                    {
+                        File.WriteAllText(StartupCodegenMarkerFile, string.Empty);
                     }
                 }
 

--- a/workers/unity/Packages/com.improbable.gdk.tools/GenerateCode.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/GenerateCode.cs
@@ -21,7 +21,7 @@ namespace Improbable.Gdk.Tools
             $"../build/CoreSdk/{Common.CoreSdkVersion}/schema_compiler/schema_compiler";
 
         private static readonly string StartupCodegenMarkerFile =
-            Path.GetFullPath("Temp/ImprobableCodegen.marker");
+            Path.GetFullPath(Path.Combine("Temp", "ImprobableCodegen.marker"));
 
         /// <summary>
         ///     Ensure that code is generated on editor startup.


### PR DESCRIPTION
#### Description
Added a marker file to `Temp` to indicate auto codegen has run already. This should stop the constant popups every recompile.

This gets removed when Unity closes so it will always generate when first started.
#### Tests
Tested workflow locally - worked nicely.
#### Documentation
N/A 
#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
@jared-improbable 