### PR TITLE
Clients retry getting a player. Workers connecting one at a time is enforced

### DIFF
--- a/workers/unity/Assets/Playground/Scripts/Worker/ClientWorkerConnector.cs
+++ b/workers/unity/Assets/Playground/Scripts/Worker/ClientWorkerConnector.cs
@@ -7,9 +7,6 @@ public class ClientWorkerConnector : WorkerConnectorBase
 {
     private async void Start()
     {
-        // Array covariance means the explicit cast isn't strictly needed but it is slightly safer
-        RequiredWorkerConnection = FindObjectsOfType<GameLogicWorkerConnector>()
-            .Select(c => (WorkerConnectorBase) c).ToArray();
         await Connect(WorkerUtils.UnityClient, new ForwardingDispatcher()).ConfigureAwait(false);
     }
 

--- a/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Components/ShouldRequestPlayerTag.cs
+++ b/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Components/ShouldRequestPlayerTag.cs
@@ -1,0 +1,9 @@
+﻿using Improbable.Gdk.Core;
+using Unity.Entities;
+
+namespace Improbable.Gdk.PlayerLifecycle
+{
+    public struct ShouldRequestPlayerTag : IComponentData
+    {
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Components/ShouldRequestPlayerTag.cs.meta
+++ b/workers/unity/Packages/com.improbable.gdk.playerlifecycle/Components/ShouldRequestPlayerTag.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8f062a09edd202040993450f8da2647a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Gets rid of two races (and technically adds another)
Removes the issues with workers starting at the same time of out of sequence.
Technically adds the two player race in but only in the case where a create player request is received, the worker receives it, sends the create entity command, then loses authority, then tries to respond.
(It only retries on an AuthorityLost failure)

Please add yourself as a reviewer if you have opinions.