### PR TITLE
Instantiating a prefab with broken/missing components fixed

### DIFF
--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/EntityGameObjectLinker.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/EntityGameObjectLinker.cs
@@ -27,6 +27,11 @@ namespace Improbable.Gdk.GameObjectRepresentation
             gameObjectComponentTypes.Clear();
             foreach (var component in gameObject.GetComponents<Component>())
             {
+                if (component == null)
+                {
+                    continue;
+                }
+
                 var componentType = component.GetType();
                 if (gameObjectComponentTypes.Contains(componentType))
                 {


### PR DESCRIPTION
Instantiating a prefab with broken/missing components will no longer break the GDK