### PR TITLE
Convert command sending to use archetype chunks

### DIFF
--- a/test-project/Assets/Generated/Improbable.Gdk.Generated.asmdef
+++ b/test-project/Assets/Generated/Improbable.Gdk.Generated.asmdef
@@ -1,9 +1,10 @@
 ﻿{
 	"name": "Improbable.Gdk.Generated",
 	"references": [
-		"Unity.Entities", 
-		"Unity.Mathematics", 
-		"Unity.Entities.Hybrid", 
+	    "Unity.Collections",
+		"Unity.Entities",
+		"Unity.Mathematics",
+		"Unity.Entities.Hybrid",
 		"Improbable.Gdk.Core"
 	]
 }

--- a/test-project/Assets/Generated/Improbable.Gdk.Generated.asmdef
+++ b/test-project/Assets/Generated/Improbable.Gdk.Generated.asmdef
@@ -1,10 +1,10 @@
 ﻿{
-	"name": "Improbable.Gdk.Generated",
-	"references": [
-	    "Unity.Collections",
-		"Unity.Entities",
-		"Unity.Mathematics",
-		"Unity.Entities.Hybrid",
-		"Improbable.Gdk.Core"
-	]
+    "name": "Improbable.Gdk.Generated",
+    "references": [
+        "Unity.Collections",
+        "Unity.Entities",
+        "Unity.Mathematics",
+        "Unity.Entities.Hybrid",
+        "Improbable.Gdk.Core"
+    ]
 }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveBlittableSingularTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveBlittableSingularTranslation.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using UnityEngine;
 using Unity.Mathematics;
 using Unity.Entities;
+using Unity.Collections;
 using Improbable.Worker.Core;
 using Improbable.Gdk.Core;
 using Improbable.Gdk.Core.CodegenAdapters;
@@ -319,9 +320,10 @@ namespace Generated.Improbable.Gdk.Tests
                 ComponentType.ReadOnly<SpatialEntityId>()
             };
 
-            public override ComponentType[] CommandTypes => new ComponentType[] {
-            };
 
+            private EntityArchetypeQuery[] CommandQueries =
+            {
+            };
 
             public ComponentReplicator(EntityManager entityManager, Unity.Entities.World world) : base(entityManager)
             {
@@ -352,10 +354,10 @@ namespace Generated.Improbable.Gdk.Tests
                 }
             }
 
-            public override void SendCommands(List<ComponentGroup> commandComponentGroups, global::Improbable.Worker.Core.Connection connection)
+            public override void SendCommands(SpatialOSSendSystem sendSystem, global::Improbable.Worker.Core.Connection connection)
             {
+                var entityType = sendSystem.GetArchetypeChunkEntityType();
             }
-
         }
 
         internal class ComponentCleanup : ComponentCleanupHandler

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKeyTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKeyTranslation.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using UnityEngine;
 using Unity.Mathematics;
 using Unity.Entities;
+using Unity.Collections;
 using Improbable.Worker.Core;
 using Improbable.Gdk.Core;
 using Improbable.Gdk.Core.CodegenAdapters;
@@ -357,9 +358,10 @@ namespace Generated.Improbable.Gdk.Tests
                 ComponentType.ReadOnly<SpatialEntityId>()
             };
 
-            public override ComponentType[] CommandTypes => new ComponentType[] {
-            };
 
+            private EntityArchetypeQuery[] CommandQueries =
+            {
+            };
 
             public ComponentReplicator(EntityManager entityManager, Unity.Entities.World world) : base(entityManager)
             {
@@ -390,10 +392,10 @@ namespace Generated.Improbable.Gdk.Tests
                 }
             }
 
-            public override void SendCommands(List<ComponentGroup> commandComponentGroups, global::Improbable.Worker.Core.Connection connection)
+            public override void SendCommands(SpatialOSSendSystem sendSystem, global::Improbable.Worker.Core.Connection connection)
             {
+                var entityType = sendSystem.GetArchetypeChunkEntityType();
             }
-
         }
 
         internal class ComponentCleanup : ComponentCleanupHandler

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValueTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValueTranslation.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using UnityEngine;
 using Unity.Mathematics;
 using Unity.Entities;
+using Unity.Collections;
 using Improbable.Worker.Core;
 using Improbable.Gdk.Core;
 using Improbable.Gdk.Core.CodegenAdapters;
@@ -357,9 +358,10 @@ namespace Generated.Improbable.Gdk.Tests
                 ComponentType.ReadOnly<SpatialEntityId>()
             };
 
-            public override ComponentType[] CommandTypes => new ComponentType[] {
-            };
 
+            private EntityArchetypeQuery[] CommandQueries =
+            {
+            };
 
             public ComponentReplicator(EntityManager entityManager, Unity.Entities.World world) : base(entityManager)
             {
@@ -390,10 +392,10 @@ namespace Generated.Improbable.Gdk.Tests
                 }
             }
 
-            public override void SendCommands(List<ComponentGroup> commandComponentGroups, global::Improbable.Worker.Core.Connection connection)
+            public override void SendCommands(SpatialOSSendSystem sendSystem, global::Improbable.Worker.Core.Connection connection)
             {
+                var entityType = sendSystem.GetArchetypeChunkEntityType();
             }
-
         }
 
         internal class ComponentCleanup : ComponentCleanupHandler

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptionalTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptionalTranslation.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using UnityEngine;
 using Unity.Mathematics;
 using Unity.Entities;
+using Unity.Collections;
 using Improbable.Worker.Core;
 using Improbable.Gdk.Core;
 using Improbable.Gdk.Core.CodegenAdapters;
@@ -357,9 +358,10 @@ namespace Generated.Improbable.Gdk.Tests
                 ComponentType.ReadOnly<SpatialEntityId>()
             };
 
-            public override ComponentType[] CommandTypes => new ComponentType[] {
-            };
 
+            private EntityArchetypeQuery[] CommandQueries =
+            {
+            };
 
             public ComponentReplicator(EntityManager entityManager, Unity.Entities.World world) : base(entityManager)
             {
@@ -390,10 +392,10 @@ namespace Generated.Improbable.Gdk.Tests
                 }
             }
 
-            public override void SendCommands(List<ComponentGroup> commandComponentGroups, global::Improbable.Worker.Core.Connection connection)
+            public override void SendCommands(SpatialOSSendSystem sendSystem, global::Improbable.Worker.Core.Connection connection)
             {
+                var entityType = sendSystem.GetArchetypeChunkEntityType();
             }
-
         }
 
         internal class ComponentCleanup : ComponentCleanupHandler

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeatedTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeatedTranslation.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using UnityEngine;
 using Unity.Mathematics;
 using Unity.Entities;
+using Unity.Collections;
 using Improbable.Worker.Core;
 using Improbable.Gdk.Core;
 using Improbable.Gdk.Core.CodegenAdapters;
@@ -357,9 +358,10 @@ namespace Generated.Improbable.Gdk.Tests
                 ComponentType.ReadOnly<SpatialEntityId>()
             };
 
-            public override ComponentType[] CommandTypes => new ComponentType[] {
-            };
 
+            private EntityArchetypeQuery[] CommandQueries =
+            {
+            };
 
             public ComponentReplicator(EntityManager entityManager, Unity.Entities.World world) : base(entityManager)
             {
@@ -390,10 +392,10 @@ namespace Generated.Improbable.Gdk.Tests
                 }
             }
 
-            public override void SendCommands(List<ComponentGroup> commandComponentGroups, global::Improbable.Worker.Core.Connection connection)
+            public override void SendCommands(SpatialOSSendSystem sendSystem, global::Improbable.Worker.Core.Connection connection)
             {
+                var entityType = sendSystem.GetArchetypeChunkEntityType();
             }
-
         }
 
         internal class ComponentCleanup : ComponentCleanupHandler

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingularTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingularTranslation.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using UnityEngine;
 using Unity.Mathematics;
 using Unity.Entities;
+using Unity.Collections;
 using Improbable.Worker.Core;
 using Improbable.Gdk.Core;
 using Improbable.Gdk.Core.CodegenAdapters;
@@ -327,9 +328,10 @@ namespace Generated.Improbable.Gdk.Tests
                 ComponentType.ReadOnly<SpatialEntityId>()
             };
 
-            public override ComponentType[] CommandTypes => new ComponentType[] {
-            };
 
+            private EntityArchetypeQuery[] CommandQueries =
+            {
+            };
 
             public ComponentReplicator(EntityManager entityManager, Unity.Entities.World world) : base(entityManager)
             {
@@ -360,10 +362,10 @@ namespace Generated.Improbable.Gdk.Tests
                 }
             }
 
-            public override void SendCommands(List<ComponentGroup> commandComponentGroups, global::Improbable.Worker.Core.Connection connection)
+            public override void SendCommands(SpatialOSSendSystem sendSystem, global::Improbable.Worker.Core.Connection connection)
             {
+                var entityType = sendSystem.GetArchetypeChunkEntityType();
             }
-
         }
 
         internal class ComponentCleanup : ComponentCleanupHandler

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/NestedComponentTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/NestedComponentTranslation.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using UnityEngine;
 using Unity.Mathematics;
 using Unity.Entities;
+using Unity.Collections;
 using Improbable.Worker.Core;
 using Improbable.Gdk.Core;
 using Improbable.Gdk.Core.CodegenAdapters;
@@ -305,9 +306,10 @@ namespace Generated.Improbable.Gdk.Tests
                 ComponentType.ReadOnly<SpatialEntityId>()
             };
 
-            public override ComponentType[] CommandTypes => new ComponentType[] {
-            };
 
+            private EntityArchetypeQuery[] CommandQueries =
+            {
+            };
 
             public ComponentReplicator(EntityManager entityManager, Unity.Entities.World world) : base(entityManager)
             {
@@ -338,10 +340,10 @@ namespace Generated.Improbable.Gdk.Tests
                 }
             }
 
-            public override void SendCommands(List<ComponentGroup> commandComponentGroups, global::Improbable.Worker.Core.Connection connection)
+            public override void SendCommands(SpatialOSSendSystem sendSystem, global::Improbable.Worker.Core.Connection connection)
             {
+                var entityType = sendSystem.GetArchetypeChunkEntityType();
             }
-
         }
 
         internal class ComponentCleanup : ComponentCleanupHandler

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/ConnectionTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/ConnectionTranslation.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using UnityEngine;
 using Unity.Mathematics;
 using Unity.Entities;
+using Unity.Collections;
 using Improbable.Worker.Core;
 using Improbable.Gdk.Core;
 using Improbable.Gdk.Core.CodegenAdapters;
@@ -351,9 +352,10 @@ namespace Generated.Improbable.Gdk.Tests.AlternateSchemaSyntax
                 ComponentType.ReadOnly<SpatialEntityId>()
             };
 
-            public override ComponentType[] CommandTypes => new ComponentType[] {
-            };
 
+            private EntityArchetypeQuery[] CommandQueries =
+            {
+            };
 
             public ComponentReplicator(EntityManager entityManager, Unity.Entities.World world) : base(entityManager)
             {
@@ -400,10 +402,10 @@ namespace Generated.Improbable.Gdk.Tests.AlternateSchemaSyntax
                 }
             }
 
-            public override void SendCommands(List<ComponentGroup> commandComponentGroups, global::Improbable.Worker.Core.Connection connection)
+            public override void SendCommands(SpatialOSSendSystem sendSystem, global::Improbable.Worker.Core.Connection connection)
             {
+                var entityType = sendSystem.GetArchetypeChunkEntityType();
             }
-
         }
 
         internal class ComponentCleanup : ComponentCleanupHandler

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentTranslation.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using UnityEngine;
 using Unity.Mathematics;
 using Unity.Entities;
+using Unity.Collections;
 using Improbable.Worker.Core;
 using Improbable.Gdk.Core;
 using Improbable.Gdk.Core.CodegenAdapters;
@@ -608,15 +609,32 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
                 ComponentType.ReadOnly<SpatialEntityId>()
             };
 
-            public override ComponentType[] CommandTypes => new ComponentType[] {
-                ComponentType.ReadOnly<Generated.Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.CommandSenders.FirstCommand>(),
-                ComponentType.ReadOnly<Generated.Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.CommandResponders.FirstCommand>(),
-                ComponentType.ReadOnly<Generated.Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.CommandSenders.SecondCommand>(),
-                ComponentType.ReadOnly<Generated.Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.CommandResponders.SecondCommand>(),
-            };
-
             private CommandStorages.FirstCommand firstCommandStorage;
             private CommandStorages.SecondCommand secondCommandStorage;
+
+            private EntityArchetypeQuery[] CommandQueries =
+            {
+                new EntityArchetypeQuery()
+                {
+                    All = new[]
+                    {
+                        ComponentType.Create<CommandRequests.FirstCommand>(),
+                        ComponentType.Create<CommandResponses.FirstCommand>(),
+                    },
+                    Any = Array.Empty<ComponentType>(),
+                    None = Array.Empty<ComponentType>(),
+                },
+                new EntityArchetypeQuery()
+                {
+                    All = new[]
+                    {
+                        ComponentType.Create<CommandRequests.SecondCommand>(),
+                        ComponentType.Create<CommandResponses.SecondCommand>(),
+                    },
+                    Any = Array.Empty<ComponentType>(),
+                    None = Array.Empty<ComponentType>(),
+                },
+            };
 
             public ComponentReplicator(EntityManager entityManager, Unity.Entities.World world) : base(entityManager)
             {
@@ -679,156 +697,128 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
                 }
             }
 
-            public override void SendCommands(List<ComponentGroup> commandComponentGroups, global::Improbable.Worker.Core.Connection connection)
+            public override void SendCommands(SpatialOSSendSystem sendSystem, global::Improbable.Worker.Core.Connection connection)
             {
-                if (!commandComponentGroups[0].IsEmptyIgnoreFilter)
+                var entityType = sendSystem.GetArchetypeChunkEntityType();
                 {
-                    var componentGroup = commandComponentGroups[0];
-                    var commandSenderDataArray = componentGroup.GetComponentDataArray<Generated.Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.CommandSenders.FirstCommand>();
-                    var entityArray = componentGroup.GetEntityArray();
+                    var senderType = sendSystem.GetArchetypeChunkComponentType<Generated.Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.CommandSenders.FirstCommand>(true);
+                    var responderType = sendSystem.GetArchetypeChunkComponentType<Generated.Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.CommandResponders.FirstCommand>(true);
 
-                    for (var j = 0; j < commandSenderDataArray.Length; j++)
+                    var chunks = EntityManager.CreateArchetypeChunkArray(CommandQueries[0], Allocator.TempJob);
+                    foreach (var chunk in chunks)
                     {
-                        var requests = commandSenderDataArray[j].RequestsToSend;
-                        var count = requests.Count;
-
-                        // Skip processing requests if that are none.
-                        if (count == 0)
+                        var entities = chunk.GetNativeArray(entityType);
+                        var senders = chunk.GetNativeArray(senderType);
+                        var responders = chunk.GetNativeArray(responderType);
+                        for (var i = 0; i < senders.Length; i++)
                         {
-                            continue;
-                        }
-
-                        for (var k = 0; k < count; k++)
-                        {
-                            var wrappedCommandRequest = requests[k];
-
-                            var schemaCommandRequest = new global::Improbable.Worker.Core.SchemaCommandRequest(ComponentId, 1);
-                            global::Generated.Improbable.Gdk.Tests.BlittableTypes.FirstCommandRequest.Serialization.Serialize(wrappedCommandRequest.Payload, schemaCommandRequest.GetObject());
-
-                            var requestId = connection.SendCommandRequest(wrappedCommandRequest.TargetEntityId,
-                                new global::Improbable.Worker.Core.CommandRequest(schemaCommandRequest),
-                                wrappedCommandRequest.TimeoutMillis,
-                                wrappedCommandRequest.AllowShortCircuiting ? ShortCircuitParameters : null);
-
-                            firstCommandStorage.CommandRequestsInFlight[requestId.Id] =
-                                new CommandRequestStore<global::Generated.Improbable.Gdk.Tests.BlittableTypes.FirstCommandRequest>(entityArray[j], wrappedCommandRequest.Payload, wrappedCommandRequest.Context, wrappedCommandRequest.RequestId);
-                        }
-
-                        requests.Clear();
-                    }
-                }
-                if (!commandComponentGroups[1].IsEmptyIgnoreFilter)
-                {
-                    var componentGroup = commandComponentGroups[1];
-                    var commandResponderDataArray = componentGroup.GetComponentDataArray<Generated.Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.CommandResponders.FirstCommand>();
-
-                    for (var j = 0; j < commandResponderDataArray.Length; j++)
-                    {
-                        var responses = commandResponderDataArray[j].ResponsesToSend;
-                        var count = responses.Count;
-
-                        // Skip processing responses if that are none.
-                        if (count == 0)
-                        {
-                            continue;
-                        }
-
-                        for (var k = 0; k < count; k++)
-                        {
-                            var wrappedCommandResponse = responses[k];
-                            var requestId = new global::Improbable.Worker.Core.RequestId<IncomingCommandRequest>(wrappedCommandResponse.RequestId);
-
-                            if (wrappedCommandResponse.FailureMessage != null)
+                            var requests = senders[i].RequestsToSend;
+                            var responses = responders[i].ResponsesToSend;
+                            if (requests.Count > 0)
                             {
-                                // Send a command failure if the string is non-null.
-                                connection.SendCommandFailure(requestId, wrappedCommandResponse.FailureMessage);
-                                continue;
+                                foreach (var request in requests)
+                                {
+                                    var schemaCommandRequest = new global::Improbable.Worker.Core.SchemaCommandRequest(ComponentId, 1);
+                                    global::Generated.Improbable.Gdk.Tests.BlittableTypes.FirstCommandRequest.Serialization.Serialize(request.Payload, schemaCommandRequest.GetObject());
+
+                                    var requestId = connection.SendCommandRequest(request.TargetEntityId,
+                                        new global::Improbable.Worker.Core.CommandRequest(schemaCommandRequest),
+                                        request.TimeoutMillis,
+                                        request.AllowShortCircuiting ? ShortCircuitParameters : null);
+
+                                    firstCommandStorage.CommandRequestsInFlight[requestId.Id] =
+                                        new CommandRequestStore<global::Generated.Improbable.Gdk.Tests.BlittableTypes.FirstCommandRequest>(entities[i], request.Payload, request.Context, request.RequestId);
+                                }
+
+                                requests.Clear();
                             }
 
-                            var schemaCommandResponse = new global::Improbable.Worker.Core.SchemaCommandResponse(ComponentId, 1);
-                            global::Generated.Improbable.Gdk.Tests.BlittableTypes.FirstCommandResponse.Serialization.Serialize(wrappedCommandResponse.Payload.Value, schemaCommandResponse.GetObject());
-
-                            connection.SendCommandResponse(requestId, new global::Improbable.Worker.Core.CommandResponse(schemaCommandResponse));
-                        }
-
-                        responses.Clear();
-                    }
-                }
-                if (!commandComponentGroups[2].IsEmptyIgnoreFilter)
-                {
-                    var componentGroup = commandComponentGroups[2];
-                    var commandSenderDataArray = componentGroup.GetComponentDataArray<Generated.Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.CommandSenders.SecondCommand>();
-                    var entityArray = componentGroup.GetEntityArray();
-
-                    for (var j = 0; j < commandSenderDataArray.Length; j++)
-                    {
-                        var requests = commandSenderDataArray[j].RequestsToSend;
-                        var count = requests.Count;
-
-                        // Skip processing requests if that are none.
-                        if (count == 0)
-                        {
-                            continue;
-                        }
-
-                        for (var k = 0; k < count; k++)
-                        {
-                            var wrappedCommandRequest = requests[k];
-
-                            var schemaCommandRequest = new global::Improbable.Worker.Core.SchemaCommandRequest(ComponentId, 2);
-                            global::Generated.Improbable.Gdk.Tests.BlittableTypes.SecondCommandRequest.Serialization.Serialize(wrappedCommandRequest.Payload, schemaCommandRequest.GetObject());
-
-                            var requestId = connection.SendCommandRequest(wrappedCommandRequest.TargetEntityId,
-                                new global::Improbable.Worker.Core.CommandRequest(schemaCommandRequest),
-                                wrappedCommandRequest.TimeoutMillis,
-                                wrappedCommandRequest.AllowShortCircuiting ? ShortCircuitParameters : null);
-
-                            secondCommandStorage.CommandRequestsInFlight[requestId.Id] =
-                                new CommandRequestStore<global::Generated.Improbable.Gdk.Tests.BlittableTypes.SecondCommandRequest>(entityArray[j], wrappedCommandRequest.Payload, wrappedCommandRequest.Context, wrappedCommandRequest.RequestId);
-                        }
-
-                        requests.Clear();
-                    }
-                }
-                if (!commandComponentGroups[3].IsEmptyIgnoreFilter)
-                {
-                    var componentGroup = commandComponentGroups[3];
-                    var commandResponderDataArray = componentGroup.GetComponentDataArray<Generated.Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.CommandResponders.SecondCommand>();
-
-                    for (var j = 0; j < commandResponderDataArray.Length; j++)
-                    {
-                        var responses = commandResponderDataArray[j].ResponsesToSend;
-                        var count = responses.Count;
-
-                        // Skip processing responses if that are none.
-                        if (count == 0)
-                        {
-                            continue;
-                        }
-
-                        for (var k = 0; k < count; k++)
-                        {
-                            var wrappedCommandResponse = responses[k];
-                            var requestId = new global::Improbable.Worker.Core.RequestId<IncomingCommandRequest>(wrappedCommandResponse.RequestId);
-
-                            if (wrappedCommandResponse.FailureMessage != null)
+                            if (responses.Count > 0)
                             {
-                                // Send a command failure if the string is non-null.
-                                connection.SendCommandFailure(requestId, wrappedCommandResponse.FailureMessage);
-                                continue;
+                                foreach (var response in responses)
+                                {
+                                    var requestId = new global::Improbable.Worker.Core.RequestId<IncomingCommandRequest>(response.RequestId);
+
+                                    if (response.FailureMessage != null)
+                                    {
+                                        // Send a command failure if the string is non-null.
+                                        connection.SendCommandFailure(requestId, response.FailureMessage);
+                                        continue;
+                                    }
+
+                                    var schemaCommandResponse = new global::Improbable.Worker.Core.SchemaCommandResponse(ComponentId, 1);
+                                    global::Generated.Improbable.Gdk.Tests.BlittableTypes.FirstCommandResponse.Serialization.Serialize(response.Payload.Value, schemaCommandResponse.GetObject());
+
+                                    connection.SendCommandResponse(requestId, new global::Improbable.Worker.Core.CommandResponse(schemaCommandResponse));
+                                }
+
+                                responses.Clear();
+                            }
+                        }
+                    }
+
+                    chunks.Dispose();
+                }
+                {
+                    var senderType = sendSystem.GetArchetypeChunkComponentType<Generated.Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.CommandSenders.SecondCommand>(true);
+                    var responderType = sendSystem.GetArchetypeChunkComponentType<Generated.Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.CommandResponders.SecondCommand>(true);
+
+                    var chunks = EntityManager.CreateArchetypeChunkArray(CommandQueries[1], Allocator.TempJob);
+                    foreach (var chunk in chunks)
+                    {
+                        var entities = chunk.GetNativeArray(entityType);
+                        var senders = chunk.GetNativeArray(senderType);
+                        var responders = chunk.GetNativeArray(responderType);
+                        for (var i = 0; i < senders.Length; i++)
+                        {
+                            var requests = senders[i].RequestsToSend;
+                            var responses = responders[i].ResponsesToSend;
+                            if (requests.Count > 0)
+                            {
+                                foreach (var request in requests)
+                                {
+                                    var schemaCommandRequest = new global::Improbable.Worker.Core.SchemaCommandRequest(ComponentId, 2);
+                                    global::Generated.Improbable.Gdk.Tests.BlittableTypes.SecondCommandRequest.Serialization.Serialize(request.Payload, schemaCommandRequest.GetObject());
+
+                                    var requestId = connection.SendCommandRequest(request.TargetEntityId,
+                                        new global::Improbable.Worker.Core.CommandRequest(schemaCommandRequest),
+                                        request.TimeoutMillis,
+                                        request.AllowShortCircuiting ? ShortCircuitParameters : null);
+
+                                    secondCommandStorage.CommandRequestsInFlight[requestId.Id] =
+                                        new CommandRequestStore<global::Generated.Improbable.Gdk.Tests.BlittableTypes.SecondCommandRequest>(entities[i], request.Payload, request.Context, request.RequestId);
+                                }
+
+                                requests.Clear();
                             }
 
-                            var schemaCommandResponse = new global::Improbable.Worker.Core.SchemaCommandResponse(ComponentId, 2);
-                            global::Generated.Improbable.Gdk.Tests.BlittableTypes.SecondCommandResponse.Serialization.Serialize(wrappedCommandResponse.Payload.Value, schemaCommandResponse.GetObject());
+                            if (responses.Count > 0)
+                            {
+                                foreach (var response in responses)
+                                {
+                                    var requestId = new global::Improbable.Worker.Core.RequestId<IncomingCommandRequest>(response.RequestId);
 
-                            connection.SendCommandResponse(requestId, new global::Improbable.Worker.Core.CommandResponse(schemaCommandResponse));
+                                    if (response.FailureMessage != null)
+                                    {
+                                        // Send a command failure if the string is non-null.
+                                        connection.SendCommandFailure(requestId, response.FailureMessage);
+                                        continue;
+                                    }
+
+                                    var schemaCommandResponse = new global::Improbable.Worker.Core.SchemaCommandResponse(ComponentId, 2);
+                                    global::Generated.Improbable.Gdk.Tests.BlittableTypes.SecondCommandResponse.Serialization.Serialize(response.Payload.Value, schemaCommandResponse.GetObject());
+
+                                    connection.SendCommandResponse(requestId, new global::Improbable.Worker.Core.CommandResponse(schemaCommandResponse));
+                                }
+
+                                responses.Clear();
+                            }
                         }
-
-                        responses.Clear();
                     }
+
+                    chunks.Dispose();
                 }
             }
-
         }
 
         internal class ComponentCleanup : ComponentCleanupHandler

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentTranslation.cs
@@ -618,8 +618,8 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
                 {
                     All = new[]
                     {
-                        ComponentType.Create<CommandRequests.FirstCommand>(),
-                        ComponentType.Create<CommandResponses.FirstCommand>(),
+                        ComponentType.Create<Generated.Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.CommandSenders.FirstCommand>(),
+                        ComponentType.Create<Generated.Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.CommandResponders.FirstCommand>(),
                     },
                     Any = Array.Empty<ComponentType>(),
                     None = Array.Empty<ComponentType>(),
@@ -628,8 +628,8 @@ namespace Generated.Improbable.Gdk.Tests.BlittableTypes
                 {
                     All = new[]
                     {
-                        ComponentType.Create<CommandRequests.SecondCommand>(),
-                        ComponentType.Create<CommandResponses.SecondCommand>(),
+                        ComponentType.Create<Generated.Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.CommandSenders.SecondCommand>(),
+                        ComponentType.Create<Generated.Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.CommandResponders.SecondCommand>(),
                     },
                     Any = Array.Empty<ComponentType>(),
                     None = Array.Empty<ComponentType>(),

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsTranslation.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using UnityEngine;
 using Unity.Mathematics;
 using Unity.Entities;
+using Unity.Collections;
 using Improbable.Worker.Core;
 using Improbable.Gdk.Core;
 using Improbable.Gdk.Core.CodegenAdapters;
@@ -304,9 +305,10 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 ComponentType.ReadOnly<SpatialEntityId>()
             };
 
-            public override ComponentType[] CommandTypes => new ComponentType[] {
-            };
 
+            private EntityArchetypeQuery[] CommandQueries =
+            {
+            };
 
             public ComponentReplicator(EntityManager entityManager, Unity.Entities.World world) : base(entityManager)
             {
@@ -337,10 +339,10 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 }
             }
 
-            public override void SendCommands(List<ComponentGroup> commandComponentGroups, global::Improbable.Worker.Core.Connection connection)
+            public override void SendCommands(SpatialOSSendSystem sendSystem, global::Improbable.Worker.Core.Connection connection)
             {
+                var entityType = sendSystem.GetArchetypeChunkEntityType();
             }
-
         }
 
         internal class ComponentCleanup : ComponentCleanupHandler

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsTranslation.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using UnityEngine;
 using Unity.Mathematics;
 using Unity.Entities;
+using Unity.Collections;
 using Improbable.Worker.Core;
 using Improbable.Gdk.Core;
 using Improbable.Gdk.Core.CodegenAdapters;
@@ -407,12 +408,21 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 ComponentType.ReadOnly<SpatialEntityId>()
             };
 
-            public override ComponentType[] CommandTypes => new ComponentType[] {
-                ComponentType.ReadOnly<Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.CommandSenders.Cmd>(),
-                ComponentType.ReadOnly<Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.CommandResponders.Cmd>(),
-            };
-
             private CommandStorages.Cmd cmdStorage;
+
+            private EntityArchetypeQuery[] CommandQueries =
+            {
+                new EntityArchetypeQuery()
+                {
+                    All = new[]
+                    {
+                        ComponentType.Create<CommandRequests.Cmd>(),
+                        ComponentType.Create<CommandResponses.Cmd>(),
+                    },
+                    Any = Array.Empty<ComponentType>(),
+                    None = Array.Empty<ComponentType>(),
+                },
+            };
 
             public ComponentReplicator(EntityManager entityManager, Unity.Entities.World world) : base(entityManager)
             {
@@ -444,83 +454,69 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 }
             }
 
-            public override void SendCommands(List<ComponentGroup> commandComponentGroups, global::Improbable.Worker.Core.Connection connection)
+            public override void SendCommands(SpatialOSSendSystem sendSystem, global::Improbable.Worker.Core.Connection connection)
             {
-                if (!commandComponentGroups[0].IsEmptyIgnoreFilter)
+                var entityType = sendSystem.GetArchetypeChunkEntityType();
                 {
-                    var componentGroup = commandComponentGroups[0];
-                    var commandSenderDataArray = componentGroup.GetComponentDataArray<Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.CommandSenders.Cmd>();
-                    var entityArray = componentGroup.GetEntityArray();
+                    var senderType = sendSystem.GetArchetypeChunkComponentType<Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.CommandSenders.Cmd>(true);
+                    var responderType = sendSystem.GetArchetypeChunkComponentType<Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.CommandResponders.Cmd>(true);
 
-                    for (var j = 0; j < commandSenderDataArray.Length; j++)
+                    var chunks = EntityManager.CreateArchetypeChunkArray(CommandQueries[0], Allocator.TempJob);
+                    foreach (var chunk in chunks)
                     {
-                        var requests = commandSenderDataArray[j].RequestsToSend;
-                        var count = requests.Count;
-
-                        // Skip processing requests if that are none.
-                        if (count == 0)
+                        var entities = chunk.GetNativeArray(entityType);
+                        var senders = chunk.GetNativeArray(senderType);
+                        var responders = chunk.GetNativeArray(responderType);
+                        for (var i = 0; i < senders.Length; i++)
                         {
-                            continue;
-                        }
-
-                        for (var k = 0; k < count; k++)
-                        {
-                            var wrappedCommandRequest = requests[k];
-
-                            var schemaCommandRequest = new global::Improbable.Worker.Core.SchemaCommandRequest(ComponentId, 1);
-                            global::Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.Empty.Serialization.Serialize(wrappedCommandRequest.Payload, schemaCommandRequest.GetObject());
-
-                            var requestId = connection.SendCommandRequest(wrappedCommandRequest.TargetEntityId,
-                                new global::Improbable.Worker.Core.CommandRequest(schemaCommandRequest),
-                                wrappedCommandRequest.TimeoutMillis,
-                                wrappedCommandRequest.AllowShortCircuiting ? ShortCircuitParameters : null);
-
-                            cmdStorage.CommandRequestsInFlight[requestId.Id] =
-                                new CommandRequestStore<global::Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.Empty>(entityArray[j], wrappedCommandRequest.Payload, wrappedCommandRequest.Context, wrappedCommandRequest.RequestId);
-                        }
-
-                        requests.Clear();
-                    }
-                }
-                if (!commandComponentGroups[1].IsEmptyIgnoreFilter)
-                {
-                    var componentGroup = commandComponentGroups[1];
-                    var commandResponderDataArray = componentGroup.GetComponentDataArray<Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.CommandResponders.Cmd>();
-
-                    for (var j = 0; j < commandResponderDataArray.Length; j++)
-                    {
-                        var responses = commandResponderDataArray[j].ResponsesToSend;
-                        var count = responses.Count;
-
-                        // Skip processing responses if that are none.
-                        if (count == 0)
-                        {
-                            continue;
-                        }
-
-                        for (var k = 0; k < count; k++)
-                        {
-                            var wrappedCommandResponse = responses[k];
-                            var requestId = new global::Improbable.Worker.Core.RequestId<IncomingCommandRequest>(wrappedCommandResponse.RequestId);
-
-                            if (wrappedCommandResponse.FailureMessage != null)
+                            var requests = senders[i].RequestsToSend;
+                            var responses = responders[i].ResponsesToSend;
+                            if (requests.Count > 0)
                             {
-                                // Send a command failure if the string is non-null.
-                                connection.SendCommandFailure(requestId, wrappedCommandResponse.FailureMessage);
-                                continue;
+                                foreach (var request in requests)
+                                {
+                                    var schemaCommandRequest = new global::Improbable.Worker.Core.SchemaCommandRequest(ComponentId, 1);
+                                    global::Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.Empty.Serialization.Serialize(request.Payload, schemaCommandRequest.GetObject());
+
+                                    var requestId = connection.SendCommandRequest(request.TargetEntityId,
+                                        new global::Improbable.Worker.Core.CommandRequest(schemaCommandRequest),
+                                        request.TimeoutMillis,
+                                        request.AllowShortCircuiting ? ShortCircuitParameters : null);
+
+                                    cmdStorage.CommandRequestsInFlight[requestId.Id] =
+                                        new CommandRequestStore<global::Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.Empty>(entities[i], request.Payload, request.Context, request.RequestId);
+                                }
+
+                                requests.Clear();
                             }
 
-                            var schemaCommandResponse = new global::Improbable.Worker.Core.SchemaCommandResponse(ComponentId, 1);
-                            global::Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.Empty.Serialization.Serialize(wrappedCommandResponse.Payload.Value, schemaCommandResponse.GetObject());
+                            if (responses.Count > 0)
+                            {
+                                foreach (var response in responses)
+                                {
+                                    var requestId = new global::Improbable.Worker.Core.RequestId<IncomingCommandRequest>(response.RequestId);
 
-                            connection.SendCommandResponse(requestId, new global::Improbable.Worker.Core.CommandResponse(schemaCommandResponse));
+                                    if (response.FailureMessage != null)
+                                    {
+                                        // Send a command failure if the string is non-null.
+                                        connection.SendCommandFailure(requestId, response.FailureMessage);
+                                        continue;
+                                    }
+
+                                    var schemaCommandResponse = new global::Improbable.Worker.Core.SchemaCommandResponse(ComponentId, 1);
+                                    global::Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.Empty.Serialization.Serialize(response.Payload.Value, schemaCommandResponse.GetObject());
+
+                                    connection.SendCommandResponse(requestId, new global::Improbable.Worker.Core.CommandResponse(schemaCommandResponse));
+                                }
+
+                                responses.Clear();
+                            }
                         }
-
-                        responses.Clear();
                     }
+
+                    chunks.Dispose();
                 }
             }
-
         }
 
         internal class ComponentCleanup : ComponentCleanupHandler

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsTranslation.cs
@@ -416,8 +416,8 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 {
                     All = new[]
                     {
-                        ComponentType.Create<CommandRequests.Cmd>(),
-                        ComponentType.Create<CommandResponses.Cmd>(),
+                        ComponentType.Create<Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.CommandSenders.Cmd>(),
+                        ComponentType.Create<Generated.Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.CommandResponders.Cmd>(),
                     },
                     Any = Array.Empty<ComponentType>(),
                     None = Array.Empty<ComponentType>(),

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEventsTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEventsTranslation.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using UnityEngine;
 using Unity.Mathematics;
 using Unity.Entities;
+using Unity.Collections;
 using Improbable.Worker.Core;
 using Improbable.Gdk.Core;
 using Improbable.Gdk.Core.CodegenAdapters;
@@ -351,9 +352,10 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 ComponentType.ReadOnly<SpatialEntityId>()
             };
 
-            public override ComponentType[] CommandTypes => new ComponentType[] {
-            };
 
+            private EntityArchetypeQuery[] CommandQueries =
+            {
+            };
 
             public ComponentReplicator(EntityManager entityManager, Unity.Entities.World world) : base(entityManager)
             {
@@ -400,10 +402,10 @@ namespace Generated.Improbable.Gdk.Tests.ComponentsWithNoFields
                 }
             }
 
-            public override void SendCommands(List<ComponentGroup> commandComponentGroups, global::Improbable.Worker.Core.Connection connection)
+            public override void SendCommands(SpatialOSSendSystem sendSystem, global::Improbable.Worker.Core.Connection connection)
             {
+                var entityType = sendSystem.GetArchetypeChunkEntityType();
             }
-
         }
 
         internal class ComponentCleanup : ComponentCleanupHandler

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentTranslation.cs
@@ -632,8 +632,8 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                 {
                     All = new[]
                     {
-                        ComponentType.Create<CommandRequests.FirstCommand>(),
-                        ComponentType.Create<CommandResponses.FirstCommand>(),
+                        ComponentType.Create<Generated.Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.CommandSenders.FirstCommand>(),
+                        ComponentType.Create<Generated.Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.CommandResponders.FirstCommand>(),
                     },
                     Any = Array.Empty<ComponentType>(),
                     None = Array.Empty<ComponentType>(),
@@ -642,8 +642,8 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                 {
                     All = new[]
                     {
-                        ComponentType.Create<CommandRequests.SecondCommand>(),
-                        ComponentType.Create<CommandResponses.SecondCommand>(),
+                        ComponentType.Create<Generated.Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.CommandSenders.SecondCommand>(),
+                        ComponentType.Create<Generated.Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.CommandResponders.SecondCommand>(),
                     },
                     Any = Array.Empty<ComponentType>(),
                     None = Array.Empty<ComponentType>(),

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentTranslation.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using UnityEngine;
 using Unity.Mathematics;
 using Unity.Entities;
+using Unity.Collections;
 using Improbable.Worker.Core;
 using Improbable.Gdk.Core;
 using Improbable.Gdk.Core.CodegenAdapters;
@@ -622,15 +623,32 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                 ComponentType.ReadOnly<SpatialEntityId>()
             };
 
-            public override ComponentType[] CommandTypes => new ComponentType[] {
-                ComponentType.ReadOnly<Generated.Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.CommandSenders.FirstCommand>(),
-                ComponentType.ReadOnly<Generated.Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.CommandResponders.FirstCommand>(),
-                ComponentType.ReadOnly<Generated.Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.CommandSenders.SecondCommand>(),
-                ComponentType.ReadOnly<Generated.Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.CommandResponders.SecondCommand>(),
-            };
-
             private CommandStorages.FirstCommand firstCommandStorage;
             private CommandStorages.SecondCommand secondCommandStorage;
+
+            private EntityArchetypeQuery[] CommandQueries =
+            {
+                new EntityArchetypeQuery()
+                {
+                    All = new[]
+                    {
+                        ComponentType.Create<CommandRequests.FirstCommand>(),
+                        ComponentType.Create<CommandResponses.FirstCommand>(),
+                    },
+                    Any = Array.Empty<ComponentType>(),
+                    None = Array.Empty<ComponentType>(),
+                },
+                new EntityArchetypeQuery()
+                {
+                    All = new[]
+                    {
+                        ComponentType.Create<CommandRequests.SecondCommand>(),
+                        ComponentType.Create<CommandResponses.SecondCommand>(),
+                    },
+                    Any = Array.Empty<ComponentType>(),
+                    None = Array.Empty<ComponentType>(),
+                },
+            };
 
             public ComponentReplicator(EntityManager entityManager, Unity.Entities.World world) : base(entityManager)
             {
@@ -693,156 +711,128 @@ namespace Generated.Improbable.Gdk.Tests.NonblittableTypes
                 }
             }
 
-            public override void SendCommands(List<ComponentGroup> commandComponentGroups, global::Improbable.Worker.Core.Connection connection)
+            public override void SendCommands(SpatialOSSendSystem sendSystem, global::Improbable.Worker.Core.Connection connection)
             {
-                if (!commandComponentGroups[0].IsEmptyIgnoreFilter)
+                var entityType = sendSystem.GetArchetypeChunkEntityType();
                 {
-                    var componentGroup = commandComponentGroups[0];
-                    var commandSenderDataArray = componentGroup.GetComponentDataArray<Generated.Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.CommandSenders.FirstCommand>();
-                    var entityArray = componentGroup.GetEntityArray();
+                    var senderType = sendSystem.GetArchetypeChunkComponentType<Generated.Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.CommandSenders.FirstCommand>(true);
+                    var responderType = sendSystem.GetArchetypeChunkComponentType<Generated.Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.CommandResponders.FirstCommand>(true);
 
-                    for (var j = 0; j < commandSenderDataArray.Length; j++)
+                    var chunks = EntityManager.CreateArchetypeChunkArray(CommandQueries[0], Allocator.TempJob);
+                    foreach (var chunk in chunks)
                     {
-                        var requests = commandSenderDataArray[j].RequestsToSend;
-                        var count = requests.Count;
-
-                        // Skip processing requests if that are none.
-                        if (count == 0)
+                        var entities = chunk.GetNativeArray(entityType);
+                        var senders = chunk.GetNativeArray(senderType);
+                        var responders = chunk.GetNativeArray(responderType);
+                        for (var i = 0; i < senders.Length; i++)
                         {
-                            continue;
-                        }
-
-                        for (var k = 0; k < count; k++)
-                        {
-                            var wrappedCommandRequest = requests[k];
-
-                            var schemaCommandRequest = new global::Improbable.Worker.Core.SchemaCommandRequest(ComponentId, 1);
-                            global::Generated.Improbable.Gdk.Tests.NonblittableTypes.FirstCommandRequest.Serialization.Serialize(wrappedCommandRequest.Payload, schemaCommandRequest.GetObject());
-
-                            var requestId = connection.SendCommandRequest(wrappedCommandRequest.TargetEntityId,
-                                new global::Improbable.Worker.Core.CommandRequest(schemaCommandRequest),
-                                wrappedCommandRequest.TimeoutMillis,
-                                wrappedCommandRequest.AllowShortCircuiting ? ShortCircuitParameters : null);
-
-                            firstCommandStorage.CommandRequestsInFlight[requestId.Id] =
-                                new CommandRequestStore<global::Generated.Improbable.Gdk.Tests.NonblittableTypes.FirstCommandRequest>(entityArray[j], wrappedCommandRequest.Payload, wrappedCommandRequest.Context, wrappedCommandRequest.RequestId);
-                        }
-
-                        requests.Clear();
-                    }
-                }
-                if (!commandComponentGroups[1].IsEmptyIgnoreFilter)
-                {
-                    var componentGroup = commandComponentGroups[1];
-                    var commandResponderDataArray = componentGroup.GetComponentDataArray<Generated.Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.CommandResponders.FirstCommand>();
-
-                    for (var j = 0; j < commandResponderDataArray.Length; j++)
-                    {
-                        var responses = commandResponderDataArray[j].ResponsesToSend;
-                        var count = responses.Count;
-
-                        // Skip processing responses if that are none.
-                        if (count == 0)
-                        {
-                            continue;
-                        }
-
-                        for (var k = 0; k < count; k++)
-                        {
-                            var wrappedCommandResponse = responses[k];
-                            var requestId = new global::Improbable.Worker.Core.RequestId<IncomingCommandRequest>(wrappedCommandResponse.RequestId);
-
-                            if (wrappedCommandResponse.FailureMessage != null)
+                            var requests = senders[i].RequestsToSend;
+                            var responses = responders[i].ResponsesToSend;
+                            if (requests.Count > 0)
                             {
-                                // Send a command failure if the string is non-null.
-                                connection.SendCommandFailure(requestId, wrappedCommandResponse.FailureMessage);
-                                continue;
+                                foreach (var request in requests)
+                                {
+                                    var schemaCommandRequest = new global::Improbable.Worker.Core.SchemaCommandRequest(ComponentId, 1);
+                                    global::Generated.Improbable.Gdk.Tests.NonblittableTypes.FirstCommandRequest.Serialization.Serialize(request.Payload, schemaCommandRequest.GetObject());
+
+                                    var requestId = connection.SendCommandRequest(request.TargetEntityId,
+                                        new global::Improbable.Worker.Core.CommandRequest(schemaCommandRequest),
+                                        request.TimeoutMillis,
+                                        request.AllowShortCircuiting ? ShortCircuitParameters : null);
+
+                                    firstCommandStorage.CommandRequestsInFlight[requestId.Id] =
+                                        new CommandRequestStore<global::Generated.Improbable.Gdk.Tests.NonblittableTypes.FirstCommandRequest>(entities[i], request.Payload, request.Context, request.RequestId);
+                                }
+
+                                requests.Clear();
                             }
 
-                            var schemaCommandResponse = new global::Improbable.Worker.Core.SchemaCommandResponse(ComponentId, 1);
-                            global::Generated.Improbable.Gdk.Tests.NonblittableTypes.FirstCommandResponse.Serialization.Serialize(wrappedCommandResponse.Payload.Value, schemaCommandResponse.GetObject());
-
-                            connection.SendCommandResponse(requestId, new global::Improbable.Worker.Core.CommandResponse(schemaCommandResponse));
-                        }
-
-                        responses.Clear();
-                    }
-                }
-                if (!commandComponentGroups[2].IsEmptyIgnoreFilter)
-                {
-                    var componentGroup = commandComponentGroups[2];
-                    var commandSenderDataArray = componentGroup.GetComponentDataArray<Generated.Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.CommandSenders.SecondCommand>();
-                    var entityArray = componentGroup.GetEntityArray();
-
-                    for (var j = 0; j < commandSenderDataArray.Length; j++)
-                    {
-                        var requests = commandSenderDataArray[j].RequestsToSend;
-                        var count = requests.Count;
-
-                        // Skip processing requests if that are none.
-                        if (count == 0)
-                        {
-                            continue;
-                        }
-
-                        for (var k = 0; k < count; k++)
-                        {
-                            var wrappedCommandRequest = requests[k];
-
-                            var schemaCommandRequest = new global::Improbable.Worker.Core.SchemaCommandRequest(ComponentId, 2);
-                            global::Generated.Improbable.Gdk.Tests.NonblittableTypes.SecondCommandRequest.Serialization.Serialize(wrappedCommandRequest.Payload, schemaCommandRequest.GetObject());
-
-                            var requestId = connection.SendCommandRequest(wrappedCommandRequest.TargetEntityId,
-                                new global::Improbable.Worker.Core.CommandRequest(schemaCommandRequest),
-                                wrappedCommandRequest.TimeoutMillis,
-                                wrappedCommandRequest.AllowShortCircuiting ? ShortCircuitParameters : null);
-
-                            secondCommandStorage.CommandRequestsInFlight[requestId.Id] =
-                                new CommandRequestStore<global::Generated.Improbable.Gdk.Tests.NonblittableTypes.SecondCommandRequest>(entityArray[j], wrappedCommandRequest.Payload, wrappedCommandRequest.Context, wrappedCommandRequest.RequestId);
-                        }
-
-                        requests.Clear();
-                    }
-                }
-                if (!commandComponentGroups[3].IsEmptyIgnoreFilter)
-                {
-                    var componentGroup = commandComponentGroups[3];
-                    var commandResponderDataArray = componentGroup.GetComponentDataArray<Generated.Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.CommandResponders.SecondCommand>();
-
-                    for (var j = 0; j < commandResponderDataArray.Length; j++)
-                    {
-                        var responses = commandResponderDataArray[j].ResponsesToSend;
-                        var count = responses.Count;
-
-                        // Skip processing responses if that are none.
-                        if (count == 0)
-                        {
-                            continue;
-                        }
-
-                        for (var k = 0; k < count; k++)
-                        {
-                            var wrappedCommandResponse = responses[k];
-                            var requestId = new global::Improbable.Worker.Core.RequestId<IncomingCommandRequest>(wrappedCommandResponse.RequestId);
-
-                            if (wrappedCommandResponse.FailureMessage != null)
+                            if (responses.Count > 0)
                             {
-                                // Send a command failure if the string is non-null.
-                                connection.SendCommandFailure(requestId, wrappedCommandResponse.FailureMessage);
-                                continue;
+                                foreach (var response in responses)
+                                {
+                                    var requestId = new global::Improbable.Worker.Core.RequestId<IncomingCommandRequest>(response.RequestId);
+
+                                    if (response.FailureMessage != null)
+                                    {
+                                        // Send a command failure if the string is non-null.
+                                        connection.SendCommandFailure(requestId, response.FailureMessage);
+                                        continue;
+                                    }
+
+                                    var schemaCommandResponse = new global::Improbable.Worker.Core.SchemaCommandResponse(ComponentId, 1);
+                                    global::Generated.Improbable.Gdk.Tests.NonblittableTypes.FirstCommandResponse.Serialization.Serialize(response.Payload.Value, schemaCommandResponse.GetObject());
+
+                                    connection.SendCommandResponse(requestId, new global::Improbable.Worker.Core.CommandResponse(schemaCommandResponse));
+                                }
+
+                                responses.Clear();
+                            }
+                        }
+                    }
+
+                    chunks.Dispose();
+                }
+                {
+                    var senderType = sendSystem.GetArchetypeChunkComponentType<Generated.Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.CommandSenders.SecondCommand>(true);
+                    var responderType = sendSystem.GetArchetypeChunkComponentType<Generated.Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.CommandResponders.SecondCommand>(true);
+
+                    var chunks = EntityManager.CreateArchetypeChunkArray(CommandQueries[1], Allocator.TempJob);
+                    foreach (var chunk in chunks)
+                    {
+                        var entities = chunk.GetNativeArray(entityType);
+                        var senders = chunk.GetNativeArray(senderType);
+                        var responders = chunk.GetNativeArray(responderType);
+                        for (var i = 0; i < senders.Length; i++)
+                        {
+                            var requests = senders[i].RequestsToSend;
+                            var responses = responders[i].ResponsesToSend;
+                            if (requests.Count > 0)
+                            {
+                                foreach (var request in requests)
+                                {
+                                    var schemaCommandRequest = new global::Improbable.Worker.Core.SchemaCommandRequest(ComponentId, 2);
+                                    global::Generated.Improbable.Gdk.Tests.NonblittableTypes.SecondCommandRequest.Serialization.Serialize(request.Payload, schemaCommandRequest.GetObject());
+
+                                    var requestId = connection.SendCommandRequest(request.TargetEntityId,
+                                        new global::Improbable.Worker.Core.CommandRequest(schemaCommandRequest),
+                                        request.TimeoutMillis,
+                                        request.AllowShortCircuiting ? ShortCircuitParameters : null);
+
+                                    secondCommandStorage.CommandRequestsInFlight[requestId.Id] =
+                                        new CommandRequestStore<global::Generated.Improbable.Gdk.Tests.NonblittableTypes.SecondCommandRequest>(entities[i], request.Payload, request.Context, request.RequestId);
+                                }
+
+                                requests.Clear();
                             }
 
-                            var schemaCommandResponse = new global::Improbable.Worker.Core.SchemaCommandResponse(ComponentId, 2);
-                            global::Generated.Improbable.Gdk.Tests.NonblittableTypes.SecondCommandResponse.Serialization.Serialize(wrappedCommandResponse.Payload.Value, schemaCommandResponse.GetObject());
+                            if (responses.Count > 0)
+                            {
+                                foreach (var response in responses)
+                                {
+                                    var requestId = new global::Improbable.Worker.Core.RequestId<IncomingCommandRequest>(response.RequestId);
 
-                            connection.SendCommandResponse(requestId, new global::Improbable.Worker.Core.CommandResponse(schemaCommandResponse));
+                                    if (response.FailureMessage != null)
+                                    {
+                                        // Send a command failure if the string is non-null.
+                                        connection.SendCommandFailure(requestId, response.FailureMessage);
+                                        continue;
+                                    }
+
+                                    var schemaCommandResponse = new global::Improbable.Worker.Core.SchemaCommandResponse(ComponentId, 2);
+                                    global::Generated.Improbable.Gdk.Tests.NonblittableTypes.SecondCommandResponse.Serialization.Serialize(response.Payload.Value, schemaCommandResponse.GetObject());
+
+                                    connection.SendCommandResponse(requestId, new global::Improbable.Worker.Core.CommandResponse(schemaCommandResponse));
+                                }
+
+                                responses.Clear();
+                            }
                         }
-
-                        responses.Clear();
                     }
+
+                    chunks.Dispose();
                 }
             }
-
         }
 
         internal class ComponentCleanup : ComponentCleanupHandler

--- a/test-project/ProjectSettings/EditorSettings.asset
+++ b/test-project/ProjectSettings/EditorSettings.asset
@@ -14,8 +14,9 @@ EditorSettings:
   m_EtcTextureFastCompressor: 1
   m_EtcTextureNormalCompressor: 2
   m_EtcTextureBestCompressor: 4
-  m_ProjectGenerationIncludedExtensions: txt;xml;fnt;cd
+  m_ProjectGenerationIncludedExtensions: txt;xml;fnt;cd;asmdef
   m_ProjectGenerationRootNamespace: 
   m_UserGeneratedProjectSuffix: 
   m_CollabEditorSettings:
     inProgressEnabled: 1
+  m_EnableTextureStreamingInPlayMode: 1

--- a/workers/unity/Assets/Generated/Improbable.Gdk.Generated.asmdef
+++ b/workers/unity/Assets/Generated/Improbable.Gdk.Generated.asmdef
@@ -1,6 +1,6 @@
 {
     "name": "Improbable.Gdk.Generated",
-    "references": [ "Unity.Entities", "Unity.Mathematics", "Unity.Entities.Hybrid", "Improbable.Gdk.Core" ],
+    "references": [ "Unity.Collections", "Unity.Entities", "Unity.Mathematics", "Unity.Entities.Hybrid", "Improbable.Gdk.Core" ],
     "includePlatforms": [],
     "excludePlatforms": [],
     "allowUnsafeCode": false

--- a/workers/unity/Packages/com.improbable.gdk.core/CodegenAdapters/ComponentReplicationHandler.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/CodegenAdapters/ComponentReplicationHandler.cs
@@ -8,10 +8,9 @@ namespace Improbable.Gdk.Core.CodegenAdapters
     {
         public abstract uint ComponentId { get; }
         public abstract ComponentType[] ReplicationComponentTypes { get; }
-        public abstract ComponentType[] CommandTypes { get; }
 
         public abstract void ExecuteReplication(ComponentGroup replicationGroup, Connection connection);
-        public abstract void SendCommands(List<ComponentGroup> commandComponentGroups, Connection connection);
+        public abstract void SendCommands(SpatialOSSendSystem sendSystem, Connection connection);
 
         protected EntityManager EntityManager;
         protected readonly CommandParameters ShortCircuitParameters;

--- a/workers/unity/Packages/com.improbable.gdk.core/Systems/SpatialOSSendSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Systems/SpatialOSSendSystem.cs
@@ -8,6 +8,7 @@ using Unity.Entities;
 namespace Improbable.Gdk.Core
 {
     [DisableAutoCreation]
+    [AlwaysUpdateSystem]
     [UpdateInGroup(typeof(SpatialOSSendGroup.InternalSpatialOSSendGroup))]
     public class SpatialOSSendSystem : ComponentSystem
     {
@@ -44,8 +45,6 @@ namespace Improbable.Gdk.Core
                     Handler = componentReplicationHandler,
                     ReplicationComponentGroup =
                         GetComponentGroup(componentReplicationHandler.ReplicationComponentTypes),
-                    CommandReplicationGroups = componentReplicationHandler.CommandTypes
-                        .Select(componentType => GetComponentGroup(componentType)).ToList()
                 });
             }
         }
@@ -71,7 +70,7 @@ namespace Improbable.Gdk.Core
 
             foreach (var replicator in componentReplicators)
             {
-                replicator.Execute(connection);
+                replicator.Execute(this, connection);
             }
         }
 
@@ -82,10 +81,10 @@ namespace Improbable.Gdk.Core
             public ComponentGroup ReplicationComponentGroup;
             public List<ComponentGroup> CommandReplicationGroups;
 
-            public void Execute(Connection connection)
+            public void Execute(SpatialOSSendSystem sendSystem, Connection connection)
             {
                 Handler.ExecuteReplication(ReplicationComponentGroup, connection);
-                Handler.SendCommands(CommandReplicationGroups, connection);
+                Handler.SendCommands(sendSystem, connection);
             }
         }
     }

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityComponentConversionGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityComponentConversionGenerator.tt
@@ -525,8 +525,8 @@ namespace <#= qualifiedNamespace #>
                 {
                     All = new[]
                     {
-                        ComponentType.Create<CommandRequests.<#= commandDetails.CommandName #>>(),
-                        ComponentType.Create<CommandResponses.<#= commandDetails.CommandName #>>(),
+                        ComponentType.Create<<#= qualifiedNamespace #>.<#= componentDetails.ComponentName #>.CommandSenders.<#= commandDetails.CommandName #>>(),
+                        ComponentType.Create<<#= qualifiedNamespace #>.<#= componentDetails.ComponentName #>.CommandResponders.<#= commandDetails.CommandName #>>(),
                     },
                     Any = Array.Empty<ComponentType>(),
                     None = Array.Empty<ComponentType>(),

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityComponentConversionGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityComponentConversionGenerator.tt
@@ -518,6 +518,22 @@ namespace <#= qualifiedNamespace #>
             private CommandStorages.<#= commandDetails.CommandName#> <#= commandDetails.CamelCaseCommandName #>Storage;
 <# } #>
 
+            private EntityArchetypeQuery[] CommandQueries =
+            {
+<# foreach (var commandDetails in commandDetailsList) { #>
+                new EntityArchetypeQuery()
+                {
+                    All = new[]
+                    {
+                        ComponentType.Create<CommandRequests.<#= commandDetails.CommandName #>>(),
+                        ComponentType.Create<CommandResponses.<#= commandDetails.CommandName #>>(),
+                    },
+                    Any = Array.Empty<ComponentType>(),
+                    None = Array.Empty<ComponentType>(),
+                },
+<# } #>
+            };
+
             public ComponentReplicator(EntityManager entityManager, Unity.Entities.World world) : base(entityManager)
             {
                 var bookkeepingSystem = world.GetOrCreateManager<CommandRequestTrackerSystem>();
@@ -586,14 +602,8 @@ for (var i = 0; i < commandDetailsList.Count; i++) {
                 {
                     var senderType = sendSystem.GetArchetypeChunkComponentType<<#= commandSenderType #>>(true);
                     var responderType = sendSystem.GetArchetypeChunkComponentType<<#= commandResponderType #>>(true);
-                    var query = new EntityArchetypeQuery()
-                    {
-                        All = new[] { ComponentType.Create<<#= commandSenderType #>>(), ComponentType.Create<<#= commandResponderType #>>() },
-                        Any = Array.Empty<ComponentType>(),
-                        None = Array.Empty<ComponentType>(),
-                    };
 
-                    var chunks = EntityManager.CreateArchetypeChunkArray(query, Allocator.TempJob);
+                    var chunks = EntityManager.CreateArchetypeChunkArray(CommandQueries[<#= i #>], Allocator.TempJob);
                     foreach (var chunk in chunks)
                     {
                         var entities = chunk.GetNativeArray(entityType);

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityComponentConversionGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityComponentConversionGenerator.tt
@@ -16,6 +16,7 @@ using System.Linq;
 using UnityEngine;
 using Unity.Mathematics;
 using Unity.Entities;
+using Unity.Collections;
 using Improbable.Worker.Core;
 using Improbable.Gdk.Core;
 using Improbable.Gdk.Core.CodegenAdapters;
@@ -513,13 +514,6 @@ namespace <#= qualifiedNamespace #>
                 ComponentType.ReadOnly<SpatialEntityId>()
             };
 
-            public override ComponentType[] CommandTypes => new ComponentType[] {
-<# foreach (var commandDetails in commandDetailsList) { #>
-                ComponentType.ReadOnly<<#= qualifiedNamespace #>.<#= componentDetails.ComponentName #>.CommandSenders.<#= commandDetails.CommandName #>>(),
-                ComponentType.ReadOnly<<#= qualifiedNamespace #>.<#= componentDetails.ComponentName #>.CommandResponders.<#= commandDetails.CommandName #>>(),
-<# } #>
-            };
-
 <# foreach (var commandDetails in commandDetailsList) { #>
             private CommandStorages.<#= commandDetails.CommandName#> <#= commandDetails.CamelCaseCommandName #>Storage;
 <# } #>
@@ -580,90 +574,82 @@ namespace <#= qualifiedNamespace #>
                 }
             }
 
-            public override void SendCommands(List<ComponentGroup> commandComponentGroups, global::Improbable.Worker.Core.Connection connection)
+            public override void SendCommands(SpatialOSSendSystem sendSystem, global::Improbable.Worker.Core.Connection connection)
             {
+                var entityType = sendSystem.GetArchetypeChunkEntityType();
 <#
 for (var i = 0; i < commandDetailsList.Count; i++) {
     var commandDetails = commandDetailsList[i];
     var commandSenderType = $"{qualifiedNamespace}.{componentDetails.ComponentName}.CommandSenders.{commandDetails.CommandName}";
     var commandResponderType = $"{qualifiedNamespace}.{componentDetails.ComponentName}.CommandResponders.{commandDetails.CommandName}";
 #>
-                if (!commandComponentGroups[<#= 2*i #>].IsEmptyIgnoreFilter)
                 {
-                    var componentGroup = commandComponentGroups[<#= 2*i #>];
-                    var commandSenderDataArray = componentGroup.GetComponentDataArray<<#= commandSenderType #>>();
-                    var entityArray = componentGroup.GetEntityArray();
-
-                    for (var j = 0; j < commandSenderDataArray.Length; j++)
+                    var senderType = sendSystem.GetArchetypeChunkComponentType<<#= commandSenderType #>>(true);
+                    var responderType = sendSystem.GetArchetypeChunkComponentType<<#= commandResponderType #>>(true);
+                    var query = new EntityArchetypeQuery()
                     {
-                        var requests = commandSenderDataArray[j].RequestsToSend;
-                        var count = requests.Count;
+                        All = new[] { ComponentType.Create<<#= commandSenderType #>>(), ComponentType.Create<<#= commandResponderType #>>() },
+                        Any = Array.Empty<ComponentType>(),
+                        None = Array.Empty<ComponentType>(),
+                    };
 
-                        // Skip processing requests if that are none.
-                        if (count == 0)
-                        {
-                            continue;
-                        }
-
-                        for (var k = 0; k < count; k++)
-                        {
-                            var wrappedCommandRequest = requests[k];
-
-                            var schemaCommandRequest = new global::Improbable.Worker.Core.SchemaCommandRequest(ComponentId, <#= commandDetails.CommandIndex #>);
-                            <#= commandDetails.FqnRequestType #>.Serialization.Serialize(wrappedCommandRequest.Payload, schemaCommandRequest.GetObject());
-
-                            var requestId = connection.SendCommandRequest(wrappedCommandRequest.TargetEntityId,
-                                new global::Improbable.Worker.Core.CommandRequest(schemaCommandRequest),
-                                wrappedCommandRequest.TimeoutMillis,
-                                wrappedCommandRequest.AllowShortCircuiting ? ShortCircuitParameters : null);
-
-                            <#= commandDetails.CamelCaseCommandName #>Storage.CommandRequestsInFlight[requestId.Id] =
-                                new CommandRequestStore<<#= commandDetails.FqnRequestType #>>(entityArray[j], wrappedCommandRequest.Payload, wrappedCommandRequest.Context, wrappedCommandRequest.RequestId);
-                        }
-
-                        requests.Clear();
-                    }
-                }
-                if (!commandComponentGroups[<#= 2*i + 1 #>].IsEmptyIgnoreFilter)
-                {
-                    var componentGroup = commandComponentGroups[<#= 2*i + 1 #>];
-                    var commandResponderDataArray = componentGroup.GetComponentDataArray<<#= commandResponderType #>>();
-
-                    for (var j = 0; j < commandResponderDataArray.Length; j++)
+                    var chunks = EntityManager.CreateArchetypeChunkArray(query, Allocator.TempJob);
+                    foreach (var chunk in chunks)
                     {
-                        var responses = commandResponderDataArray[j].ResponsesToSend;
-                        var count = responses.Count;
-
-                        // Skip processing responses if that are none.
-                        if (count == 0)
+                        var entities = chunk.GetNativeArray(entityType);
+                        var senders = chunk.GetNativeArray(senderType);
+                        var responders = chunk.GetNativeArray(responderType);
+                        for (var i = 0; i < senders.Length; i++)
                         {
-                            continue;
-                        }
-
-                        for (var k = 0; k < count; k++)
-                        {
-                            var wrappedCommandResponse = responses[k];
-                            var requestId = new global::Improbable.Worker.Core.RequestId<IncomingCommandRequest>(wrappedCommandResponse.RequestId);
-
-                            if (wrappedCommandResponse.FailureMessage != null)
+                            var requests = senders[i].RequestsToSend;
+                            var responses = responders[i].ResponsesToSend;
+                            if (requests.Count > 0)
                             {
-                                // Send a command failure if the string is non-null.
-                                connection.SendCommandFailure(requestId, wrappedCommandResponse.FailureMessage);
-                                continue;
+                                foreach (var request in requests)
+                                {
+                                    var schemaCommandRequest = new global::Improbable.Worker.Core.SchemaCommandRequest(ComponentId, <#= commandDetails.CommandIndex #>);
+                                    <#= commandDetails.FqnRequestType #>.Serialization.Serialize(request.Payload, schemaCommandRequest.GetObject());
+
+                                    var requestId = connection.SendCommandRequest(request.TargetEntityId,
+                                        new global::Improbable.Worker.Core.CommandRequest(schemaCommandRequest),
+                                        request.TimeoutMillis,
+                                        request.AllowShortCircuiting ? ShortCircuitParameters : null);
+
+                                    <#= commandDetails.CamelCaseCommandName #>Storage.CommandRequestsInFlight[requestId.Id] =
+                                        new CommandRequestStore<<#= commandDetails.FqnRequestType #>>(entities[i], request.Payload, request.Context, request.RequestId);
+                                }
+
+                                requests.Clear();
                             }
 
-                            var schemaCommandResponse = new global::Improbable.Worker.Core.SchemaCommandResponse(ComponentId, <#= commandDetails.CommandIndex #>);
-                            <#= commandDetails.FqnResponseType #>.Serialization.Serialize(wrappedCommandResponse.Payload.Value, schemaCommandResponse.GetObject());
+                            if (responses.Count > 0)
+                            {
+                                foreach (var response in responses)
+                                {
+                                    var requestId = new global::Improbable.Worker.Core.RequestId<IncomingCommandRequest>(response.RequestId);
 
-                            connection.SendCommandResponse(requestId, new global::Improbable.Worker.Core.CommandResponse(schemaCommandResponse));
+                                    if (response.FailureMessage != null)
+                                    {
+                                        // Send a command failure if the string is non-null.
+                                        connection.SendCommandFailure(requestId, response.FailureMessage);
+                                        continue;
+                                    }
+
+                                    var schemaCommandResponse = new global::Improbable.Worker.Core.SchemaCommandResponse(ComponentId, <#= commandDetails.CommandIndex #>);
+                                    <#= commandDetails.FqnResponseType #>.Serialization.Serialize(response.Payload.Value, schemaCommandResponse.GetObject());
+
+                                    connection.SendCommandResponse(requestId, new global::Improbable.Worker.Core.CommandResponse(schemaCommandResponse));
+                                }
+
+                                responses.Clear();
+                            }
                         }
-
-                        responses.Clear();
                     }
+
+                    chunks.Dispose();
                 }
 <# } #>
             }
-
         }
 
         internal class ComponentCleanup : ComponentCleanupHandler


### PR DESCRIPTION
#### Description
This is both an optimisation and redesign.

With this redesign, the command sending will do less iterations, and uses faster component iterators to improve overall performance of the SpatialOSSendSystem.
It is also a good example of how Archetype Chunks can be used in our core, and how they work with code generation.