### PR TITLE
Changed tick system dependencies

### DIFF
--- a/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/TickSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.transformsynchronization/Systems/TickSystem.cs
@@ -17,8 +17,7 @@ using UnityEngine.Experimental.PlayerLoop;
 namespace Improbable.Gdk.TransformSynchronization
 {
     [DisableAutoCreation]
-    [UpdateBefore(typeof(DefaultUpdateLatestTransformSystem))]
-    [UpdateInGroup(typeof(FixedUpdate))]
+    [UpdateBefore(typeof(FixedUpdate))]
     public class TickSystem : ComponentSystem
     {
         private struct Data


### PR DESCRIPTION
Accidentally broke cubes by breaking dependencies.
