### PR TITLE
UTY-1188: Cleanup the Cleanup System

### DIFF
--- a/workers/unity/Packages/com.improbable.gdk.core/Tests/Editmode/Systems/SpatialOSReceiveSystemTests.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Tests/Editmode/Systems/SpatialOSReceiveSystemTests.cs
@@ -82,7 +82,7 @@ namespace Improbable.Gdk.Core.EditmodeTests.Systems
                 {
                     WorldCommands.DeallocateWorldCommandRequesters(entityManager, entity);
                 }
-                catch (Exception e)
+                catch (Exception)
                 {
                 }
             }


### PR DESCRIPTION
#### Description
`entities@0.0.12-preview12` added the `EntityCommandBuffer.RemoveComponent(Entity, ComponentType` API. Cleaned up the cleanup system by using this API.

Drive-by to remove warning 
#### Tests
Ran unit tests for the `CleanReactiveSystem` & ran playground.
#### Documentation
N/A
#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
@zeroZshadow 