### PR TITLE
Update Generated Code Logs and Exceptions

### DIFF
--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveBlittableSingularTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveBlittableSingularTranslation.cs
@@ -41,10 +41,7 @@ namespace Improbable.Gdk.Tests
 
             public override void OnAddComponent(AddComponentOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "AddComponentOp", out var entity))
-                {
-                    return;
-                }
+                var entity = TryGetEntityFromEntityId(op.EntityId);
 
                 var data = Improbable.Gdk.Tests.ExhaustiveBlittableSingular.Serialization.Deserialize(op.Data.SchemaData.Value.GetFields(), World);
                 data.DirtyBit = false;
@@ -103,10 +100,7 @@ namespace Improbable.Gdk.Tests
 
             public override void OnRemoveComponent(RemoveComponentOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "RemoveComponentOp", out var entity))
-                {
-                    return;
-                }
+                var entity = TryGetEntityFromEntityId(op.EntityId);
 
                 entityManager.RemoveComponent<Improbable.Gdk.Tests.ExhaustiveBlittableSingular.Component>(entity);
 
@@ -130,10 +124,7 @@ namespace Improbable.Gdk.Tests
 
             public override void OnComponentUpdate(ComponentUpdateOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "OnComponentUpdate", out var entity))
-                {
-                    return;
-                }
+                var entity = TryGetEntityFromEntityId(op.EntityId);
 
                 if (entityManager.HasComponent<NotAuthoritative<Improbable.Gdk.Tests.ExhaustiveBlittableSingular.Component>>(entity))
                 {
@@ -168,21 +159,12 @@ namespace Improbable.Gdk.Tests
 
             public override void OnAuthorityChange(AuthorityChangeOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "AuthorityChangeOp", out var entity))
-                {
-                    return;
-                }
-
+                var entity = TryGetEntityFromEntityId(op.EntityId);
                 ApplyAuthorityChange(entity, op.Authority, op.EntityId);
             }
 
             public override void OnCommandRequest(CommandRequestOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "CommandRequestOp", out var entity))
-                {
-                    return;
-                }
-
                 var commandIndex = op.Request.SchemaData.Value.GetCommandIndex();
                 switch (commandIndex)
                 {
@@ -279,22 +261,6 @@ namespace Improbable.Gdk.Tests
                 }
 
                 authorityChanges.Add(authority);
-            }
-
-            private bool IsValidEntityId(global::Improbable.Worker.EntityId entityId, string opType, out Unity.Entities.Entity entity)
-            {
-                if (!Worker.TryGetEntity(entityId, out entity))
-                {
-                    LogDispatcher.HandleLog(LogType.Error, new LogEvent(EntityNotFound)
-                        .WithField(LoggingUtils.LoggerName, LoggerName)
-                        .WithField(LoggingUtils.EntityId, entityId.Id)
-                        .WithField("Op", opType)
-                        .WithField("Component", "Improbable.Gdk.Tests.ExhaustiveBlittableSingular")
-                    );
-                    return false;
-                }
-
-                return true;
             }
 
             private void LogInvalidAuthorityTransition(Authority newAuthority, Authority expectedOldAuthority, global::Improbable.Worker.EntityId entityId)

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveBlittableSingularTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveBlittableSingularTranslation.cs
@@ -169,13 +169,7 @@ namespace Improbable.Gdk.Tests
                 switch (commandIndex)
                 {
                     default:
-                        LogDispatcher.HandleLog(LogType.Error, new LogEvent(CommandIndexNotFound)
-                            .WithField(LoggingUtils.LoggerName, LoggerName)
-                            .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                            .WithField("CommandIndex", commandIndex)
-                            .WithField("Component", "Improbable.Gdk.Tests.ExhaustiveBlittableSingular")
-                        );
-                        break;
+                        throw new UnknownCommandIndexException(commandIndex, "ExhaustiveBlittableSingular");
                 }
             }
 
@@ -185,13 +179,7 @@ namespace Improbable.Gdk.Tests
                 switch (commandIndex)
                 {
                     default:
-                        LogDispatcher.HandleLog(LogType.Error, new LogEvent(CommandIndexNotFound)
-                            .WithField(LoggingUtils.LoggerName, LoggerName)
-                            .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                            .WithField("CommandIndex", commandIndex)
-                            .WithField("Component", "Improbable.Gdk.Tests.ExhaustiveBlittableSingular")
-                        );
-                        break;
+                        throw new UnknownCommandIndexException(commandIndex, "ExhaustiveBlittableSingular");
                 }
             }
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKeyTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKeyTranslation.cs
@@ -58,10 +58,7 @@ namespace Improbable.Gdk.Tests
 
             public override void OnAddComponent(AddComponentOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "AddComponentOp", out var entity))
-                {
-                    return;
-                }
+                var entity = TryGetEntityFromEntityId(op.EntityId);
 
                 var data = Improbable.Gdk.Tests.ExhaustiveMapKey.Serialization.Deserialize(op.Data.SchemaData.Value.GetFields(), World);
                 data.DirtyBit = false;
@@ -122,10 +119,7 @@ namespace Improbable.Gdk.Tests
 
             public override void OnRemoveComponent(RemoveComponentOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "RemoveComponentOp", out var entity))
-                {
-                    return;
-                }
+                var entity = TryGetEntityFromEntityId(op.EntityId);
 
                 var data = entityManager.GetComponentData<Improbable.Gdk.Tests.ExhaustiveMapKey.Component>(entity);
                 ExhaustiveMapKey.ReferenceTypeProviders.Field1Provider.Free(data.field1Handle);
@@ -168,10 +162,7 @@ namespace Improbable.Gdk.Tests
 
             public override void OnComponentUpdate(ComponentUpdateOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "OnComponentUpdate", out var entity))
-                {
-                    return;
-                }
+                var entity = TryGetEntityFromEntityId(op.EntityId);
 
                 if (entityManager.HasComponent<NotAuthoritative<Improbable.Gdk.Tests.ExhaustiveMapKey.Component>>(entity))
                 {
@@ -206,21 +197,12 @@ namespace Improbable.Gdk.Tests
 
             public override void OnAuthorityChange(AuthorityChangeOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "AuthorityChangeOp", out var entity))
-                {
-                    return;
-                }
-
+                var entity = TryGetEntityFromEntityId(op.EntityId);
                 ApplyAuthorityChange(entity, op.Authority, op.EntityId);
             }
 
             public override void OnCommandRequest(CommandRequestOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "CommandRequestOp", out var entity))
-                {
-                    return;
-                }
-
                 var commandIndex = op.Request.SchemaData.Value.GetCommandIndex();
                 switch (commandIndex)
                 {
@@ -317,22 +299,6 @@ namespace Improbable.Gdk.Tests
                 }
 
                 authorityChanges.Add(authority);
-            }
-
-            private bool IsValidEntityId(global::Improbable.Worker.EntityId entityId, string opType, out Unity.Entities.Entity entity)
-            {
-                if (!Worker.TryGetEntity(entityId, out entity))
-                {
-                    LogDispatcher.HandleLog(LogType.Error, new LogEvent(EntityNotFound)
-                        .WithField(LoggingUtils.LoggerName, LoggerName)
-                        .WithField(LoggingUtils.EntityId, entityId.Id)
-                        .WithField("Op", opType)
-                        .WithField("Component", "Improbable.Gdk.Tests.ExhaustiveMapKey")
-                    );
-                    return false;
-                }
-
-                return true;
             }
 
             private void LogInvalidAuthorityTransition(Authority newAuthority, Authority expectedOldAuthority, global::Improbable.Worker.EntityId entityId)

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKeyTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapKeyTranslation.cs
@@ -207,13 +207,7 @@ namespace Improbable.Gdk.Tests
                 switch (commandIndex)
                 {
                     default:
-                        LogDispatcher.HandleLog(LogType.Error, new LogEvent(CommandIndexNotFound)
-                            .WithField(LoggingUtils.LoggerName, LoggerName)
-                            .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                            .WithField("CommandIndex", commandIndex)
-                            .WithField("Component", "Improbable.Gdk.Tests.ExhaustiveMapKey")
-                        );
-                        break;
+                        throw new UnknownCommandIndexException(commandIndex, "ExhaustiveMapKey");
                 }
             }
 
@@ -223,13 +217,7 @@ namespace Improbable.Gdk.Tests
                 switch (commandIndex)
                 {
                     default:
-                        LogDispatcher.HandleLog(LogType.Error, new LogEvent(CommandIndexNotFound)
-                            .WithField(LoggingUtils.LoggerName, LoggerName)
-                            .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                            .WithField("CommandIndex", commandIndex)
-                            .WithField("Component", "Improbable.Gdk.Tests.ExhaustiveMapKey")
-                        );
-                        break;
+                        throw new UnknownCommandIndexException(commandIndex, "ExhaustiveMapKey");
                 }
             }
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValueTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValueTranslation.cs
@@ -58,10 +58,7 @@ namespace Improbable.Gdk.Tests
 
             public override void OnAddComponent(AddComponentOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "AddComponentOp", out var entity))
-                {
-                    return;
-                }
+                var entity = TryGetEntityFromEntityId(op.EntityId);
 
                 var data = Improbable.Gdk.Tests.ExhaustiveMapValue.Serialization.Deserialize(op.Data.SchemaData.Value.GetFields(), World);
                 data.DirtyBit = false;
@@ -122,10 +119,7 @@ namespace Improbable.Gdk.Tests
 
             public override void OnRemoveComponent(RemoveComponentOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "RemoveComponentOp", out var entity))
-                {
-                    return;
-                }
+                var entity = TryGetEntityFromEntityId(op.EntityId);
 
                 var data = entityManager.GetComponentData<Improbable.Gdk.Tests.ExhaustiveMapValue.Component>(entity);
                 ExhaustiveMapValue.ReferenceTypeProviders.Field1Provider.Free(data.field1Handle);
@@ -168,10 +162,7 @@ namespace Improbable.Gdk.Tests
 
             public override void OnComponentUpdate(ComponentUpdateOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "OnComponentUpdate", out var entity))
-                {
-                    return;
-                }
+                var entity = TryGetEntityFromEntityId(op.EntityId);
 
                 if (entityManager.HasComponent<NotAuthoritative<Improbable.Gdk.Tests.ExhaustiveMapValue.Component>>(entity))
                 {
@@ -206,21 +197,12 @@ namespace Improbable.Gdk.Tests
 
             public override void OnAuthorityChange(AuthorityChangeOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "AuthorityChangeOp", out var entity))
-                {
-                    return;
-                }
-
+                var entity = TryGetEntityFromEntityId(op.EntityId);
                 ApplyAuthorityChange(entity, op.Authority, op.EntityId);
             }
 
             public override void OnCommandRequest(CommandRequestOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "CommandRequestOp", out var entity))
-                {
-                    return;
-                }
-
                 var commandIndex = op.Request.SchemaData.Value.GetCommandIndex();
                 switch (commandIndex)
                 {
@@ -317,22 +299,6 @@ namespace Improbable.Gdk.Tests
                 }
 
                 authorityChanges.Add(authority);
-            }
-
-            private bool IsValidEntityId(global::Improbable.Worker.EntityId entityId, string opType, out Unity.Entities.Entity entity)
-            {
-                if (!Worker.TryGetEntity(entityId, out entity))
-                {
-                    LogDispatcher.HandleLog(LogType.Error, new LogEvent(EntityNotFound)
-                        .WithField(LoggingUtils.LoggerName, LoggerName)
-                        .WithField(LoggingUtils.EntityId, entityId.Id)
-                        .WithField("Op", opType)
-                        .WithField("Component", "Improbable.Gdk.Tests.ExhaustiveMapValue")
-                    );
-                    return false;
-                }
-
-                return true;
             }
 
             private void LogInvalidAuthorityTransition(Authority newAuthority, Authority expectedOldAuthority, global::Improbable.Worker.EntityId entityId)

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValueTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveMapValueTranslation.cs
@@ -207,13 +207,7 @@ namespace Improbable.Gdk.Tests
                 switch (commandIndex)
                 {
                     default:
-                        LogDispatcher.HandleLog(LogType.Error, new LogEvent(CommandIndexNotFound)
-                            .WithField(LoggingUtils.LoggerName, LoggerName)
-                            .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                            .WithField("CommandIndex", commandIndex)
-                            .WithField("Component", "Improbable.Gdk.Tests.ExhaustiveMapValue")
-                        );
-                        break;
+                        throw new UnknownCommandIndexException(commandIndex, "ExhaustiveMapValue");
                 }
             }
 
@@ -223,13 +217,7 @@ namespace Improbable.Gdk.Tests
                 switch (commandIndex)
                 {
                     default:
-                        LogDispatcher.HandleLog(LogType.Error, new LogEvent(CommandIndexNotFound)
-                            .WithField(LoggingUtils.LoggerName, LoggerName)
-                            .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                            .WithField("CommandIndex", commandIndex)
-                            .WithField("Component", "Improbable.Gdk.Tests.ExhaustiveMapValue")
-                        );
-                        break;
+                        throw new UnknownCommandIndexException(commandIndex, "ExhaustiveMapValue");
                 }
             }
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptionalTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptionalTranslation.cs
@@ -58,10 +58,7 @@ namespace Improbable.Gdk.Tests
 
             public override void OnAddComponent(AddComponentOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "AddComponentOp", out var entity))
-                {
-                    return;
-                }
+                var entity = TryGetEntityFromEntityId(op.EntityId);
 
                 var data = Improbable.Gdk.Tests.ExhaustiveOptional.Serialization.Deserialize(op.Data.SchemaData.Value.GetFields(), World);
                 data.DirtyBit = false;
@@ -122,10 +119,7 @@ namespace Improbable.Gdk.Tests
 
             public override void OnRemoveComponent(RemoveComponentOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "RemoveComponentOp", out var entity))
-                {
-                    return;
-                }
+                var entity = TryGetEntityFromEntityId(op.EntityId);
 
                 var data = entityManager.GetComponentData<Improbable.Gdk.Tests.ExhaustiveOptional.Component>(entity);
                 ExhaustiveOptional.ReferenceTypeProviders.Field1Provider.Free(data.field1Handle);
@@ -168,10 +162,7 @@ namespace Improbable.Gdk.Tests
 
             public override void OnComponentUpdate(ComponentUpdateOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "OnComponentUpdate", out var entity))
-                {
-                    return;
-                }
+                var entity = TryGetEntityFromEntityId(op.EntityId);
 
                 if (entityManager.HasComponent<NotAuthoritative<Improbable.Gdk.Tests.ExhaustiveOptional.Component>>(entity))
                 {
@@ -206,21 +197,12 @@ namespace Improbable.Gdk.Tests
 
             public override void OnAuthorityChange(AuthorityChangeOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "AuthorityChangeOp", out var entity))
-                {
-                    return;
-                }
-
+                var entity = TryGetEntityFromEntityId(op.EntityId);
                 ApplyAuthorityChange(entity, op.Authority, op.EntityId);
             }
 
             public override void OnCommandRequest(CommandRequestOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "CommandRequestOp", out var entity))
-                {
-                    return;
-                }
-
                 var commandIndex = op.Request.SchemaData.Value.GetCommandIndex();
                 switch (commandIndex)
                 {
@@ -317,22 +299,6 @@ namespace Improbable.Gdk.Tests
                 }
 
                 authorityChanges.Add(authority);
-            }
-
-            private bool IsValidEntityId(global::Improbable.Worker.EntityId entityId, string opType, out Unity.Entities.Entity entity)
-            {
-                if (!Worker.TryGetEntity(entityId, out entity))
-                {
-                    LogDispatcher.HandleLog(LogType.Error, new LogEvent(EntityNotFound)
-                        .WithField(LoggingUtils.LoggerName, LoggerName)
-                        .WithField(LoggingUtils.EntityId, entityId.Id)
-                        .WithField("Op", opType)
-                        .WithField("Component", "Improbable.Gdk.Tests.ExhaustiveOptional")
-                    );
-                    return false;
-                }
-
-                return true;
             }
 
             private void LogInvalidAuthorityTransition(Authority newAuthority, Authority expectedOldAuthority, global::Improbable.Worker.EntityId entityId)

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptionalTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveOptionalTranslation.cs
@@ -207,13 +207,7 @@ namespace Improbable.Gdk.Tests
                 switch (commandIndex)
                 {
                     default:
-                        LogDispatcher.HandleLog(LogType.Error, new LogEvent(CommandIndexNotFound)
-                            .WithField(LoggingUtils.LoggerName, LoggerName)
-                            .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                            .WithField("CommandIndex", commandIndex)
-                            .WithField("Component", "Improbable.Gdk.Tests.ExhaustiveOptional")
-                        );
-                        break;
+                        throw new UnknownCommandIndexException(commandIndex, "ExhaustiveOptional");
                 }
             }
 
@@ -223,13 +217,7 @@ namespace Improbable.Gdk.Tests
                 switch (commandIndex)
                 {
                     default:
-                        LogDispatcher.HandleLog(LogType.Error, new LogEvent(CommandIndexNotFound)
-                            .WithField(LoggingUtils.LoggerName, LoggerName)
-                            .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                            .WithField("CommandIndex", commandIndex)
-                            .WithField("Component", "Improbable.Gdk.Tests.ExhaustiveOptional")
-                        );
-                        break;
+                        throw new UnknownCommandIndexException(commandIndex, "ExhaustiveOptional");
                 }
             }
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeatedTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeatedTranslation.cs
@@ -58,10 +58,7 @@ namespace Improbable.Gdk.Tests
 
             public override void OnAddComponent(AddComponentOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "AddComponentOp", out var entity))
-                {
-                    return;
-                }
+                var entity = TryGetEntityFromEntityId(op.EntityId);
 
                 var data = Improbable.Gdk.Tests.ExhaustiveRepeated.Serialization.Deserialize(op.Data.SchemaData.Value.GetFields(), World);
                 data.DirtyBit = false;
@@ -122,10 +119,7 @@ namespace Improbable.Gdk.Tests
 
             public override void OnRemoveComponent(RemoveComponentOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "RemoveComponentOp", out var entity))
-                {
-                    return;
-                }
+                var entity = TryGetEntityFromEntityId(op.EntityId);
 
                 var data = entityManager.GetComponentData<Improbable.Gdk.Tests.ExhaustiveRepeated.Component>(entity);
                 ExhaustiveRepeated.ReferenceTypeProviders.Field1Provider.Free(data.field1Handle);
@@ -168,10 +162,7 @@ namespace Improbable.Gdk.Tests
 
             public override void OnComponentUpdate(ComponentUpdateOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "OnComponentUpdate", out var entity))
-                {
-                    return;
-                }
+                var entity = TryGetEntityFromEntityId(op.EntityId);
 
                 if (entityManager.HasComponent<NotAuthoritative<Improbable.Gdk.Tests.ExhaustiveRepeated.Component>>(entity))
                 {
@@ -206,21 +197,12 @@ namespace Improbable.Gdk.Tests
 
             public override void OnAuthorityChange(AuthorityChangeOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "AuthorityChangeOp", out var entity))
-                {
-                    return;
-                }
-
+                var entity = TryGetEntityFromEntityId(op.EntityId);
                 ApplyAuthorityChange(entity, op.Authority, op.EntityId);
             }
 
             public override void OnCommandRequest(CommandRequestOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "CommandRequestOp", out var entity))
-                {
-                    return;
-                }
-
                 var commandIndex = op.Request.SchemaData.Value.GetCommandIndex();
                 switch (commandIndex)
                 {
@@ -317,22 +299,6 @@ namespace Improbable.Gdk.Tests
                 }
 
                 authorityChanges.Add(authority);
-            }
-
-            private bool IsValidEntityId(global::Improbable.Worker.EntityId entityId, string opType, out Unity.Entities.Entity entity)
-            {
-                if (!Worker.TryGetEntity(entityId, out entity))
-                {
-                    LogDispatcher.HandleLog(LogType.Error, new LogEvent(EntityNotFound)
-                        .WithField(LoggingUtils.LoggerName, LoggerName)
-                        .WithField(LoggingUtils.EntityId, entityId.Id)
-                        .WithField("Op", opType)
-                        .WithField("Component", "Improbable.Gdk.Tests.ExhaustiveRepeated")
-                    );
-                    return false;
-                }
-
-                return true;
             }
 
             private void LogInvalidAuthorityTransition(Authority newAuthority, Authority expectedOldAuthority, global::Improbable.Worker.EntityId entityId)

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeatedTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveRepeatedTranslation.cs
@@ -207,13 +207,7 @@ namespace Improbable.Gdk.Tests
                 switch (commandIndex)
                 {
                     default:
-                        LogDispatcher.HandleLog(LogType.Error, new LogEvent(CommandIndexNotFound)
-                            .WithField(LoggingUtils.LoggerName, LoggerName)
-                            .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                            .WithField("CommandIndex", commandIndex)
-                            .WithField("Component", "Improbable.Gdk.Tests.ExhaustiveRepeated")
-                        );
-                        break;
+                        throw new UnknownCommandIndexException(commandIndex, "ExhaustiveRepeated");
                 }
             }
 
@@ -223,13 +217,7 @@ namespace Improbable.Gdk.Tests
                 switch (commandIndex)
                 {
                     default:
-                        LogDispatcher.HandleLog(LogType.Error, new LogEvent(CommandIndexNotFound)
-                            .WithField(LoggingUtils.LoggerName, LoggerName)
-                            .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                            .WithField("CommandIndex", commandIndex)
-                            .WithField("Component", "Improbable.Gdk.Tests.ExhaustiveRepeated")
-                        );
-                        break;
+                        throw new UnknownCommandIndexException(commandIndex, "ExhaustiveRepeated");
                 }
             }
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingularTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingularTranslation.cs
@@ -177,13 +177,7 @@ namespace Improbable.Gdk.Tests
                 switch (commandIndex)
                 {
                     default:
-                        LogDispatcher.HandleLog(LogType.Error, new LogEvent(CommandIndexNotFound)
-                            .WithField(LoggingUtils.LoggerName, LoggerName)
-                            .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                            .WithField("CommandIndex", commandIndex)
-                            .WithField("Component", "Improbable.Gdk.Tests.ExhaustiveSingular")
-                        );
-                        break;
+                        throw new UnknownCommandIndexException(commandIndex, "ExhaustiveSingular");
                 }
             }
 
@@ -193,13 +187,7 @@ namespace Improbable.Gdk.Tests
                 switch (commandIndex)
                 {
                     default:
-                        LogDispatcher.HandleLog(LogType.Error, new LogEvent(CommandIndexNotFound)
-                            .WithField(LoggingUtils.LoggerName, LoggerName)
-                            .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                            .WithField("CommandIndex", commandIndex)
-                            .WithField("Component", "Improbable.Gdk.Tests.ExhaustiveSingular")
-                        );
-                        break;
+                        throw new UnknownCommandIndexException(commandIndex, "ExhaustiveSingular");
                 }
             }
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingularTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/ExhaustiveSingularTranslation.cs
@@ -43,10 +43,7 @@ namespace Improbable.Gdk.Tests
 
             public override void OnAddComponent(AddComponentOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "AddComponentOp", out var entity))
-                {
-                    return;
-                }
+                var entity = TryGetEntityFromEntityId(op.EntityId);
 
                 var data = Improbable.Gdk.Tests.ExhaustiveSingular.Serialization.Deserialize(op.Data.SchemaData.Value.GetFields(), World);
                 data.DirtyBit = false;
@@ -107,10 +104,7 @@ namespace Improbable.Gdk.Tests
 
             public override void OnRemoveComponent(RemoveComponentOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "RemoveComponentOp", out var entity))
-                {
-                    return;
-                }
+                var entity = TryGetEntityFromEntityId(op.EntityId);
 
                 var data = entityManager.GetComponentData<Improbable.Gdk.Tests.ExhaustiveSingular.Component>(entity);
                 ExhaustiveSingular.ReferenceTypeProviders.Field3Provider.Free(data.field3Handle);
@@ -138,10 +132,7 @@ namespace Improbable.Gdk.Tests
 
             public override void OnComponentUpdate(ComponentUpdateOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "OnComponentUpdate", out var entity))
-                {
-                    return;
-                }
+                var entity = TryGetEntityFromEntityId(op.EntityId);
 
                 if (entityManager.HasComponent<NotAuthoritative<Improbable.Gdk.Tests.ExhaustiveSingular.Component>>(entity))
                 {
@@ -176,21 +167,12 @@ namespace Improbable.Gdk.Tests
 
             public override void OnAuthorityChange(AuthorityChangeOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "AuthorityChangeOp", out var entity))
-                {
-                    return;
-                }
-
+                var entity = TryGetEntityFromEntityId(op.EntityId);
                 ApplyAuthorityChange(entity, op.Authority, op.EntityId);
             }
 
             public override void OnCommandRequest(CommandRequestOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "CommandRequestOp", out var entity))
-                {
-                    return;
-                }
-
                 var commandIndex = op.Request.SchemaData.Value.GetCommandIndex();
                 switch (commandIndex)
                 {
@@ -287,22 +269,6 @@ namespace Improbable.Gdk.Tests
                 }
 
                 authorityChanges.Add(authority);
-            }
-
-            private bool IsValidEntityId(global::Improbable.Worker.EntityId entityId, string opType, out Unity.Entities.Entity entity)
-            {
-                if (!Worker.TryGetEntity(entityId, out entity))
-                {
-                    LogDispatcher.HandleLog(LogType.Error, new LogEvent(EntityNotFound)
-                        .WithField(LoggingUtils.LoggerName, LoggerName)
-                        .WithField(LoggingUtils.EntityId, entityId.Id)
-                        .WithField("Op", opType)
-                        .WithField("Component", "Improbable.Gdk.Tests.ExhaustiveSingular")
-                    );
-                    return false;
-                }
-
-                return true;
             }
 
             private void LogInvalidAuthorityTransition(Authority newAuthority, Authority expectedOldAuthority, global::Improbable.Worker.EntityId entityId)

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/NestedComponentTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/NestedComponentTranslation.cs
@@ -41,10 +41,7 @@ namespace Improbable.Gdk.Tests
 
             public override void OnAddComponent(AddComponentOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "AddComponentOp", out var entity))
-                {
-                    return;
-                }
+                var entity = TryGetEntityFromEntityId(op.EntityId);
 
                 var data = Improbable.Gdk.Tests.NestedComponent.Serialization.Deserialize(op.Data.SchemaData.Value.GetFields(), World);
                 data.DirtyBit = false;
@@ -89,10 +86,7 @@ namespace Improbable.Gdk.Tests
 
             public override void OnRemoveComponent(RemoveComponentOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "RemoveComponentOp", out var entity))
-                {
-                    return;
-                }
+                var entity = TryGetEntityFromEntityId(op.EntityId);
 
                 entityManager.RemoveComponent<Improbable.Gdk.Tests.NestedComponent.Component>(entity);
 
@@ -116,10 +110,7 @@ namespace Improbable.Gdk.Tests
 
             public override void OnComponentUpdate(ComponentUpdateOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "OnComponentUpdate", out var entity))
-                {
-                    return;
-                }
+                var entity = TryGetEntityFromEntityId(op.EntityId);
 
                 if (entityManager.HasComponent<NotAuthoritative<Improbable.Gdk.Tests.NestedComponent.Component>>(entity))
                 {
@@ -154,21 +145,12 @@ namespace Improbable.Gdk.Tests
 
             public override void OnAuthorityChange(AuthorityChangeOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "AuthorityChangeOp", out var entity))
-                {
-                    return;
-                }
-
+                var entity = TryGetEntityFromEntityId(op.EntityId);
                 ApplyAuthorityChange(entity, op.Authority, op.EntityId);
             }
 
             public override void OnCommandRequest(CommandRequestOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "CommandRequestOp", out var entity))
-                {
-                    return;
-                }
-
                 var commandIndex = op.Request.SchemaData.Value.GetCommandIndex();
                 switch (commandIndex)
                 {
@@ -265,22 +247,6 @@ namespace Improbable.Gdk.Tests
                 }
 
                 authorityChanges.Add(authority);
-            }
-
-            private bool IsValidEntityId(global::Improbable.Worker.EntityId entityId, string opType, out Unity.Entities.Entity entity)
-            {
-                if (!Worker.TryGetEntity(entityId, out entity))
-                {
-                    LogDispatcher.HandleLog(LogType.Error, new LogEvent(EntityNotFound)
-                        .WithField(LoggingUtils.LoggerName, LoggerName)
-                        .WithField(LoggingUtils.EntityId, entityId.Id)
-                        .WithField("Op", opType)
-                        .WithField("Component", "Improbable.Gdk.Tests.NestedComponent")
-                    );
-                    return false;
-                }
-
-                return true;
             }
 
             private void LogInvalidAuthorityTransition(Authority newAuthority, Authority expectedOldAuthority, global::Improbable.Worker.EntityId entityId)

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/NestedComponentTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/NestedComponentTranslation.cs
@@ -155,13 +155,7 @@ namespace Improbable.Gdk.Tests
                 switch (commandIndex)
                 {
                     default:
-                        LogDispatcher.HandleLog(LogType.Error, new LogEvent(CommandIndexNotFound)
-                            .WithField(LoggingUtils.LoggerName, LoggerName)
-                            .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                            .WithField("CommandIndex", commandIndex)
-                            .WithField("Component", "Improbable.Gdk.Tests.NestedComponent")
-                        );
-                        break;
+                        throw new UnknownCommandIndexException(commandIndex, "NestedComponent");
                 }
             }
 
@@ -171,13 +165,7 @@ namespace Improbable.Gdk.Tests
                 switch (commandIndex)
                 {
                     default:
-                        LogDispatcher.HandleLog(LogType.Error, new LogEvent(CommandIndexNotFound)
-                            .WithField(LoggingUtils.LoggerName, LoggerName)
-                            .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                            .WithField("CommandIndex", commandIndex)
-                            .WithField("Component", "Improbable.Gdk.Tests.NestedComponent")
-                        );
-                        break;
+                        throw new UnknownCommandIndexException(commandIndex, "NestedComponent");
                 }
             }
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/ConnectionTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/ConnectionTranslation.cs
@@ -187,13 +187,7 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
                 switch (commandIndex)
                 {
                     default:
-                        LogDispatcher.HandleLog(LogType.Error, new LogEvent(CommandIndexNotFound)
-                            .WithField(LoggingUtils.LoggerName, LoggerName)
-                            .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                            .WithField("CommandIndex", commandIndex)
-                            .WithField("Component", "Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection")
-                        );
-                        break;
+                        throw new UnknownCommandIndexException(commandIndex, "Connection");
                 }
             }
 
@@ -203,13 +197,7 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
                 switch (commandIndex)
                 {
                     default:
-                        LogDispatcher.HandleLog(LogType.Error, new LogEvent(CommandIndexNotFound)
-                            .WithField(LoggingUtils.LoggerName, LoggerName)
-                            .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                            .WithField("CommandIndex", commandIndex)
-                            .WithField("Component", "Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection")
-                        );
-                        break;
+                        throw new UnknownCommandIndexException(commandIndex, "Connection");
                 }
             }
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/ConnectionTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/alternateschemasyntax/ConnectionTranslation.cs
@@ -42,10 +42,7 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
 
             public override void OnAddComponent(AddComponentOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "AddComponentOp", out var entity))
-                {
-                    return;
-                }
+                var entity = TryGetEntityFromEntityId(op.EntityId);
 
                 var data = Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Serialization.Deserialize(op.Data.SchemaData.Value.GetFields(), World);
                 data.DirtyBit = false;
@@ -89,10 +86,7 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
 
             public override void OnRemoveComponent(RemoveComponentOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "RemoveComponentOp", out var entity))
-                {
-                    return;
-                }
+                var entity = TryGetEntityFromEntityId(op.EntityId);
 
                 entityManager.RemoveComponent<Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>(entity);
 
@@ -116,10 +110,7 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
 
             public override void OnComponentUpdate(ComponentUpdateOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "OnComponentUpdate", out var entity))
-                {
-                    return;
-                }
+                var entity = TryGetEntityFromEntityId(op.EntityId);
 
                 if (entityManager.HasComponent<NotAuthoritative<Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection.Component>>(entity))
                 {
@@ -186,21 +177,12 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
 
             public override void OnAuthorityChange(AuthorityChangeOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "AuthorityChangeOp", out var entity))
-                {
-                    return;
-                }
-
+                var entity = TryGetEntityFromEntityId(op.EntityId);
                 ApplyAuthorityChange(entity, op.Authority, op.EntityId);
             }
 
             public override void OnCommandRequest(CommandRequestOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "CommandRequestOp", out var entity))
-                {
-                    return;
-                }
-
                 var commandIndex = op.Request.SchemaData.Value.GetCommandIndex();
                 switch (commandIndex)
                 {
@@ -310,22 +292,6 @@ namespace Improbable.Gdk.Tests.AlternateSchemaSyntax
                 }
 
                 authorityChanges.Add(authority);
-            }
-
-            private bool IsValidEntityId(global::Improbable.Worker.EntityId entityId, string opType, out Unity.Entities.Entity entity)
-            {
-                if (!Worker.TryGetEntity(entityId, out entity))
-                {
-                    LogDispatcher.HandleLog(LogType.Error, new LogEvent(EntityNotFound)
-                        .WithField(LoggingUtils.LoggerName, LoggerName)
-                        .WithField(LoggingUtils.EntityId, entityId.Id)
-                        .WithField("Op", opType)
-                        .WithField("Component", "Improbable.Gdk.Tests.AlternateSchemaSyntax.Connection")
-                    );
-                    return false;
-                }
-
-                return true;
             }
 
             private void LogInvalidAuthorityTransition(Authority newAuthority, Authority expectedOldAuthority, global::Improbable.Worker.EntityId entityId)

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentTranslation.cs
@@ -242,13 +242,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                         OnSecondCommandRequest(op);
                         break;
                     default:
-                        LogDispatcher.HandleLog(LogType.Error, new LogEvent(CommandIndexNotFound)
-                            .WithField(LoggingUtils.LoggerName, LoggerName)
-                            .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                            .WithField("CommandIndex", commandIndex)
-                            .WithField("Component", "Improbable.Gdk.Tests.BlittableTypes.BlittableComponent")
-                        );
-                        break;
+                        throw new UnknownCommandIndexException(commandIndex, "BlittableComponent");
                 }
             }
 
@@ -264,13 +258,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                         OnSecondCommandResponse(op);
                         break;
                     default:
-                        LogDispatcher.HandleLog(LogType.Error, new LogEvent(CommandIndexNotFound)
-                            .WithField(LoggingUtils.LoggerName, LoggerName)
-                            .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                            .WithField("CommandIndex", commandIndex)
-                            .WithField("Component", "Improbable.Gdk.Tests.BlittableTypes.BlittableComponent")
-                        );
-                        break;
+                        throw new UnknownCommandIndexException(commandIndex, "BlittableComponent");
                 }
             }
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentTranslation.cs
@@ -55,10 +55,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
 
             public override void OnAddComponent(AddComponentOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "AddComponentOp", out var entity))
-                {
-                    return;
-                }
+                var entity = TryGetEntityFromEntityId(op.EntityId);
 
                 var data = Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Serialization.Deserialize(op.Data.SchemaData.Value.GetFields(), World);
                 data.DirtyBit = false;
@@ -107,10 +104,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
 
             public override void OnRemoveComponent(RemoveComponentOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "RemoveComponentOp", out var entity))
-                {
-                    return;
-                }
+                var entity = TryGetEntityFromEntityId(op.EntityId);
 
                 entityManager.RemoveComponent<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>(entity);
 
@@ -134,10 +128,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
 
             public override void OnComponentUpdate(ComponentUpdateOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "OnComponentUpdate", out var entity))
-                {
-                    return;
-                }
+                var entity = TryGetEntityFromEntityId(op.EntityId);
 
                 if (entityManager.HasComponent<NotAuthoritative<Improbable.Gdk.Tests.BlittableTypes.BlittableComponent.Component>>(entity))
                 {
@@ -235,21 +226,12 @@ namespace Improbable.Gdk.Tests.BlittableTypes
 
             public override void OnAuthorityChange(AuthorityChangeOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "AuthorityChangeOp", out var entity))
-                {
-                    return;
-                }
-
+                var entity = TryGetEntityFromEntityId(op.EntityId);
                 ApplyAuthorityChange(entity, op.Authority, op.EntityId);
             }
 
             public override void OnCommandRequest(CommandRequestOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "CommandRequestOp", out var entity))
-                {
-                    return;
-                }
-
                 var commandIndex = op.Request.SchemaData.Value.GetCommandIndex();
                 switch (commandIndex)
                 {
@@ -412,22 +394,6 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                 authorityChanges.Add(authority);
             }
 
-            private bool IsValidEntityId(global::Improbable.Worker.EntityId entityId, string opType, out Unity.Entities.Entity entity)
-            {
-                if (!Worker.TryGetEntity(entityId, out entity))
-                {
-                    LogDispatcher.HandleLog(LogType.Error, new LogEvent(EntityNotFound)
-                        .WithField(LoggingUtils.LoggerName, LoggerName)
-                        .WithField(LoggingUtils.EntityId, entityId.Id)
-                        .WithField("Op", opType)
-                        .WithField("Component", "Improbable.Gdk.Tests.BlittableTypes.BlittableComponent")
-                    );
-                    return false;
-                }
-
-                return true;
-            }
-
             private void LogInvalidAuthorityTransition(Authority newAuthority, Authority expectedOldAuthority, global::Improbable.Worker.EntityId entityId)
             {
                 LogDispatcher.HandleLog(LogType.Error, new LogEvent(InvalidAuthorityChange)
@@ -441,10 +407,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
 
             private void OnFirstCommandRequest(CommandRequestOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "CommandRequestOp", out var entity))
-                {
-                    return;
-                }
+                var entity = TryGetEntityFromEntityId(op.EntityId);
 
                 var deserializedRequest = global::Improbable.Gdk.Tests.BlittableTypes.FirstCommandRequest.Serialization.Deserialize(op.Request.SchemaData.Value.GetObject());
 
@@ -480,7 +443,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                 firstCommandStorage.CommandRequestsInFlight.Remove(op.RequestId.Id);
                 if (!entityManager.Exists(entity))
                 {
-                    LogDispatcher.HandleLog(LogType.Error, new LogEvent(EntityNotFound)
+                    LogDispatcher.HandleLog(LogType.Log, new LogEvent(EntityNotFound)
                         .WithField(LoggingUtils.LoggerName, LoggerName)
                         .WithField("Op", "CommandResponseOp - FirstCommand")
                         .WithField("Component", "Improbable.Gdk.Tests.BlittableTypes.BlittableComponent")
@@ -519,10 +482,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
             }
             private void OnSecondCommandRequest(CommandRequestOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "CommandRequestOp", out var entity))
-                {
-                    return;
-                }
+                var entity = TryGetEntityFromEntityId(op.EntityId);
 
                 var deserializedRequest = global::Improbable.Gdk.Tests.BlittableTypes.SecondCommandRequest.Serialization.Deserialize(op.Request.SchemaData.Value.GetObject());
 
@@ -558,7 +518,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                 secondCommandStorage.CommandRequestsInFlight.Remove(op.RequestId.Id);
                 if (!entityManager.Exists(entity))
                 {
-                    LogDispatcher.HandleLog(LogType.Error, new LogEvent(EntityNotFound)
+                    LogDispatcher.HandleLog(LogType.Log, new LogEvent(EntityNotFound)
                         .WithField(LoggingUtils.LoggerName, LoggerName)
                         .WithField("Op", "CommandResponseOp - SecondCommand")
                         .WithField("Component", "Improbable.Gdk.Tests.BlittableTypes.BlittableComponent")

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsTranslation.cs
@@ -41,10 +41,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
 
             public override void OnAddComponent(AddComponentOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "AddComponentOp", out var entity))
-                {
-                    return;
-                }
+                var entity = TryGetEntityFromEntityId(op.EntityId);
 
                 var data = Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Serialization.Deserialize(op.Data.SchemaData.Value.GetFields(), World);
                 data.DirtyBit = false;
@@ -88,10 +85,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
 
             public override void OnRemoveComponent(RemoveComponentOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "RemoveComponentOp", out var entity))
-                {
-                    return;
-                }
+                var entity = TryGetEntityFromEntityId(op.EntityId);
 
                 entityManager.RemoveComponent<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>(entity);
 
@@ -115,10 +109,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
 
             public override void OnComponentUpdate(ComponentUpdateOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "OnComponentUpdate", out var entity))
-                {
-                    return;
-                }
+                var entity = TryGetEntityFromEntityId(op.EntityId);
 
                 if (entityManager.HasComponent<NotAuthoritative<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields.Component>>(entity))
                 {
@@ -153,21 +144,12 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
 
             public override void OnAuthorityChange(AuthorityChangeOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "AuthorityChangeOp", out var entity))
-                {
-                    return;
-                }
-
+                var entity = TryGetEntityFromEntityId(op.EntityId);
                 ApplyAuthorityChange(entity, op.Authority, op.EntityId);
             }
 
             public override void OnCommandRequest(CommandRequestOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "CommandRequestOp", out var entity))
-                {
-                    return;
-                }
-
                 var commandIndex = op.Request.SchemaData.Value.GetCommandIndex();
                 switch (commandIndex)
                 {
@@ -264,22 +246,6 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                 }
 
                 authorityChanges.Add(authority);
-            }
-
-            private bool IsValidEntityId(global::Improbable.Worker.EntityId entityId, string opType, out Unity.Entities.Entity entity)
-            {
-                if (!Worker.TryGetEntity(entityId, out entity))
-                {
-                    LogDispatcher.HandleLog(LogType.Error, new LogEvent(EntityNotFound)
-                        .WithField(LoggingUtils.LoggerName, LoggerName)
-                        .WithField(LoggingUtils.EntityId, entityId.Id)
-                        .WithField("Op", opType)
-                        .WithField("Component", "Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields")
-                    );
-                    return false;
-                }
-
-                return true;
             }
 
             private void LogInvalidAuthorityTransition(Authority newAuthority, Authority expectedOldAuthority, global::Improbable.Worker.EntityId entityId)

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsTranslation.cs
@@ -154,13 +154,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                 switch (commandIndex)
                 {
                     default:
-                        LogDispatcher.HandleLog(LogType.Error, new LogEvent(CommandIndexNotFound)
-                            .WithField(LoggingUtils.LoggerName, LoggerName)
-                            .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                            .WithField("CommandIndex", commandIndex)
-                            .WithField("Component", "Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields")
-                        );
-                        break;
+                        throw new UnknownCommandIndexException(commandIndex, "ComponentWithNoFields");
                 }
             }
 
@@ -170,13 +164,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                 switch (commandIndex)
                 {
                     default:
-                        LogDispatcher.HandleLog(LogType.Error, new LogEvent(CommandIndexNotFound)
-                            .WithField(LoggingUtils.LoggerName, LoggerName)
-                            .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                            .WithField("CommandIndex", commandIndex)
-                            .WithField("Component", "Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFields")
-                        );
-                        break;
+                        throw new UnknownCommandIndexException(commandIndex, "ComponentWithNoFields");
                 }
             }
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsTranslation.cs
@@ -47,10 +47,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
 
             public override void OnAddComponent(AddComponentOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "AddComponentOp", out var entity))
-                {
-                    return;
-                }
+                var entity = TryGetEntityFromEntityId(op.EntityId);
 
                 var data = Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Serialization.Deserialize(op.Data.SchemaData.Value.GetFields(), World);
                 data.DirtyBit = false;
@@ -94,10 +91,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
 
             public override void OnRemoveComponent(RemoveComponentOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "RemoveComponentOp", out var entity))
-                {
-                    return;
-                }
+                var entity = TryGetEntityFromEntityId(op.EntityId);
 
                 entityManager.RemoveComponent<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>(entity);
 
@@ -121,10 +115,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
 
             public override void OnComponentUpdate(ComponentUpdateOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "OnComponentUpdate", out var entity))
-                {
-                    return;
-                }
+                var entity = TryGetEntityFromEntityId(op.EntityId);
 
                 if (entityManager.HasComponent<NotAuthoritative<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands.Component>>(entity))
                 {
@@ -159,21 +150,12 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
 
             public override void OnAuthorityChange(AuthorityChangeOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "AuthorityChangeOp", out var entity))
-                {
-                    return;
-                }
-
+                var entity = TryGetEntityFromEntityId(op.EntityId);
                 ApplyAuthorityChange(entity, op.Authority, op.EntityId);
             }
 
             public override void OnCommandRequest(CommandRequestOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "CommandRequestOp", out var entity))
-                {
-                    return;
-                }
-
                 var commandIndex = op.Request.SchemaData.Value.GetCommandIndex();
                 switch (commandIndex)
                 {
@@ -291,22 +273,6 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                 authorityChanges.Add(authority);
             }
 
-            private bool IsValidEntityId(global::Improbable.Worker.EntityId entityId, string opType, out Unity.Entities.Entity entity)
-            {
-                if (!Worker.TryGetEntity(entityId, out entity))
-                {
-                    LogDispatcher.HandleLog(LogType.Error, new LogEvent(EntityNotFound)
-                        .WithField(LoggingUtils.LoggerName, LoggerName)
-                        .WithField(LoggingUtils.EntityId, entityId.Id)
-                        .WithField("Op", opType)
-                        .WithField("Component", "Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands")
-                    );
-                    return false;
-                }
-
-                return true;
-            }
-
             private void LogInvalidAuthorityTransition(Authority newAuthority, Authority expectedOldAuthority, global::Improbable.Worker.EntityId entityId)
             {
                 LogDispatcher.HandleLog(LogType.Error, new LogEvent(InvalidAuthorityChange)
@@ -320,10 +286,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
 
             private void OnCmdRequest(CommandRequestOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "CommandRequestOp", out var entity))
-                {
-                    return;
-                }
+                var entity = TryGetEntityFromEntityId(op.EntityId);
 
                 var deserializedRequest = global::Improbable.Gdk.Tests.ComponentsWithNoFields.Empty.Serialization.Deserialize(op.Request.SchemaData.Value.GetObject());
 
@@ -359,7 +322,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                 cmdStorage.CommandRequestsInFlight.Remove(op.RequestId.Id);
                 if (!entityManager.Exists(entity))
                 {
-                    LogDispatcher.HandleLog(LogType.Error, new LogEvent(EntityNotFound)
+                    LogDispatcher.HandleLog(LogType.Log, new LogEvent(EntityNotFound)
                         .WithField(LoggingUtils.LoggerName, LoggerName)
                         .WithField("Op", "CommandResponseOp - Cmd")
                         .WithField("Component", "Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands")

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsTranslation.cs
@@ -163,13 +163,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                         OnCmdRequest(op);
                         break;
                     default:
-                        LogDispatcher.HandleLog(LogType.Error, new LogEvent(CommandIndexNotFound)
-                            .WithField(LoggingUtils.LoggerName, LoggerName)
-                            .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                            .WithField("CommandIndex", commandIndex)
-                            .WithField("Component", "Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands")
-                        );
-                        break;
+                        throw new UnknownCommandIndexException(commandIndex, "ComponentWithNoFieldsWithCommands");
                 }
             }
 
@@ -182,13 +176,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                         OnCmdResponse(op);
                         break;
                     default:
-                        LogDispatcher.HandleLog(LogType.Error, new LogEvent(CommandIndexNotFound)
-                            .WithField(LoggingUtils.LoggerName, LoggerName)
-                            .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                            .WithField("CommandIndex", commandIndex)
-                            .WithField("Component", "Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithCommands")
-                        );
-                        break;
+                        throw new UnknownCommandIndexException(commandIndex, "ComponentWithNoFieldsWithCommands");
                 }
             }
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEventsTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEventsTranslation.cs
@@ -187,13 +187,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                 switch (commandIndex)
                 {
                     default:
-                        LogDispatcher.HandleLog(LogType.Error, new LogEvent(CommandIndexNotFound)
-                            .WithField(LoggingUtils.LoggerName, LoggerName)
-                            .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                            .WithField("CommandIndex", commandIndex)
-                            .WithField("Component", "Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents")
-                        );
-                        break;
+                        throw new UnknownCommandIndexException(commandIndex, "ComponentWithNoFieldsWithEvents");
                 }
             }
 
@@ -203,13 +197,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                 switch (commandIndex)
                 {
                     default:
-                        LogDispatcher.HandleLog(LogType.Error, new LogEvent(CommandIndexNotFound)
-                            .WithField(LoggingUtils.LoggerName, LoggerName)
-                            .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                            .WithField("CommandIndex", commandIndex)
-                            .WithField("Component", "Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents")
-                        );
-                        break;
+                        throw new UnknownCommandIndexException(commandIndex, "ComponentWithNoFieldsWithEvents");
                 }
             }
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEventsTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithEventsTranslation.cs
@@ -42,10 +42,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
 
             public override void OnAddComponent(AddComponentOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "AddComponentOp", out var entity))
-                {
-                    return;
-                }
+                var entity = TryGetEntityFromEntityId(op.EntityId);
 
                 var data = Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Serialization.Deserialize(op.Data.SchemaData.Value.GetFields(), World);
                 data.DirtyBit = false;
@@ -89,10 +86,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
 
             public override void OnRemoveComponent(RemoveComponentOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "RemoveComponentOp", out var entity))
-                {
-                    return;
-                }
+                var entity = TryGetEntityFromEntityId(op.EntityId);
 
                 entityManager.RemoveComponent<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>(entity);
 
@@ -116,10 +110,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
 
             public override void OnComponentUpdate(ComponentUpdateOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "OnComponentUpdate", out var entity))
-                {
-                    return;
-                }
+                var entity = TryGetEntityFromEntityId(op.EntityId);
 
                 if (entityManager.HasComponent<NotAuthoritative<Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents.Component>>(entity))
                 {
@@ -186,21 +177,12 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
 
             public override void OnAuthorityChange(AuthorityChangeOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "AuthorityChangeOp", out var entity))
-                {
-                    return;
-                }
-
+                var entity = TryGetEntityFromEntityId(op.EntityId);
                 ApplyAuthorityChange(entity, op.Authority, op.EntityId);
             }
 
             public override void OnCommandRequest(CommandRequestOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "CommandRequestOp", out var entity))
-                {
-                    return;
-                }
-
                 var commandIndex = op.Request.SchemaData.Value.GetCommandIndex();
                 switch (commandIndex)
                 {
@@ -310,22 +292,6 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                 }
 
                 authorityChanges.Add(authority);
-            }
-
-            private bool IsValidEntityId(global::Improbable.Worker.EntityId entityId, string opType, out Unity.Entities.Entity entity)
-            {
-                if (!Worker.TryGetEntity(entityId, out entity))
-                {
-                    LogDispatcher.HandleLog(LogType.Error, new LogEvent(EntityNotFound)
-                        .WithField(LoggingUtils.LoggerName, LoggerName)
-                        .WithField(LoggingUtils.EntityId, entityId.Id)
-                        .WithField("Op", opType)
-                        .WithField("Component", "Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents")
-                    );
-                    return false;
-                }
-
-                return true;
             }
 
             private void LogInvalidAuthorityTransition(Authority newAuthority, Authority expectedOldAuthority, global::Improbable.Worker.EntityId entityId)

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentTranslation.cs
@@ -59,10 +59,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
 
             public override void OnAddComponent(AddComponentOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "AddComponentOp", out var entity))
-                {
-                    return;
-                }
+                var entity = TryGetEntityFromEntityId(op.EntityId);
 
                 var data = Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Serialization.Deserialize(op.Data.SchemaData.Value.GetFields(), World);
                 data.DirtyBit = false;
@@ -115,10 +112,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
 
             public override void OnRemoveComponent(RemoveComponentOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "RemoveComponentOp", out var entity))
-                {
-                    return;
-                }
+                var entity = TryGetEntityFromEntityId(op.EntityId);
 
                 var data = entityManager.GetComponentData<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>(entity);
                 NonBlittableComponent.ReferenceTypeProviders.StringFieldProvider.Free(data.stringFieldHandle);
@@ -148,10 +142,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
 
             public override void OnComponentUpdate(ComponentUpdateOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "OnComponentUpdate", out var entity))
-                {
-                    return;
-                }
+                var entity = TryGetEntityFromEntityId(op.EntityId);
 
                 if (entityManager.HasComponent<NotAuthoritative<Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent.Component>>(entity))
                 {
@@ -249,21 +240,12 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
 
             public override void OnAuthorityChange(AuthorityChangeOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "AuthorityChangeOp", out var entity))
-                {
-                    return;
-                }
-
+                var entity = TryGetEntityFromEntityId(op.EntityId);
                 ApplyAuthorityChange(entity, op.Authority, op.EntityId);
             }
 
             public override void OnCommandRequest(CommandRequestOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "CommandRequestOp", out var entity))
-                {
-                    return;
-                }
-
                 var commandIndex = op.Request.SchemaData.Value.GetCommandIndex();
                 switch (commandIndex)
                 {
@@ -426,22 +408,6 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                 authorityChanges.Add(authority);
             }
 
-            private bool IsValidEntityId(global::Improbable.Worker.EntityId entityId, string opType, out Unity.Entities.Entity entity)
-            {
-                if (!Worker.TryGetEntity(entityId, out entity))
-                {
-                    LogDispatcher.HandleLog(LogType.Error, new LogEvent(EntityNotFound)
-                        .WithField(LoggingUtils.LoggerName, LoggerName)
-                        .WithField(LoggingUtils.EntityId, entityId.Id)
-                        .WithField("Op", opType)
-                        .WithField("Component", "Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent")
-                    );
-                    return false;
-                }
-
-                return true;
-            }
-
             private void LogInvalidAuthorityTransition(Authority newAuthority, Authority expectedOldAuthority, global::Improbable.Worker.EntityId entityId)
             {
                 LogDispatcher.HandleLog(LogType.Error, new LogEvent(InvalidAuthorityChange)
@@ -455,10 +421,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
 
             private void OnFirstCommandRequest(CommandRequestOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "CommandRequestOp", out var entity))
-                {
-                    return;
-                }
+                var entity = TryGetEntityFromEntityId(op.EntityId);
 
                 var deserializedRequest = global::Improbable.Gdk.Tests.NonblittableTypes.FirstCommandRequest.Serialization.Deserialize(op.Request.SchemaData.Value.GetObject());
 
@@ -494,7 +457,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                 firstCommandStorage.CommandRequestsInFlight.Remove(op.RequestId.Id);
                 if (!entityManager.Exists(entity))
                 {
-                    LogDispatcher.HandleLog(LogType.Error, new LogEvent(EntityNotFound)
+                    LogDispatcher.HandleLog(LogType.Log, new LogEvent(EntityNotFound)
                         .WithField(LoggingUtils.LoggerName, LoggerName)
                         .WithField("Op", "CommandResponseOp - FirstCommand")
                         .WithField("Component", "Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent")
@@ -533,10 +496,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
             }
             private void OnSecondCommandRequest(CommandRequestOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "CommandRequestOp", out var entity))
-                {
-                    return;
-                }
+                var entity = TryGetEntityFromEntityId(op.EntityId);
 
                 var deserializedRequest = global::Improbable.Gdk.Tests.NonblittableTypes.SecondCommandRequest.Serialization.Deserialize(op.Request.SchemaData.Value.GetObject());
 
@@ -572,7 +532,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                 secondCommandStorage.CommandRequestsInFlight.Remove(op.RequestId.Id);
                 if (!entityManager.Exists(entity))
                 {
-                    LogDispatcher.HandleLog(LogType.Error, new LogEvent(EntityNotFound)
+                    LogDispatcher.HandleLog(LogType.Log, new LogEvent(EntityNotFound)
                         .WithField(LoggingUtils.LoggerName, LoggerName)
                         .WithField("Op", "CommandResponseOp - SecondCommand")
                         .WithField("Component", "Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent")

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentTranslation.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentTranslation.cs
@@ -256,13 +256,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                         OnSecondCommandRequest(op);
                         break;
                     default:
-                        LogDispatcher.HandleLog(LogType.Error, new LogEvent(CommandIndexNotFound)
-                            .WithField(LoggingUtils.LoggerName, LoggerName)
-                            .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                            .WithField("CommandIndex", commandIndex)
-                            .WithField("Component", "Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent")
-                        );
-                        break;
+                        throw new UnknownCommandIndexException(commandIndex, "NonBlittableComponent");
                 }
             }
 
@@ -278,13 +272,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                         OnSecondCommandResponse(op);
                         break;
                     default:
-                        LogDispatcher.HandleLog(LogType.Error, new LogEvent(CommandIndexNotFound)
-                            .WithField(LoggingUtils.LoggerName, LoggerName)
-                            .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                            .WithField("CommandIndex", commandIndex)
-                            .WithField("Component", "Improbable.Gdk.Tests.NonblittableTypes.NonBlittableComponent")
-                        );
-                        break;
+                        throw new UnknownCommandIndexException(commandIndex, "NonBlittableComponent");
                 }
             }
 

--- a/workers/unity/Packages/com.improbable.gdk.core/CodegenAdapters/ComponentDispatcherHandler.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/CodegenAdapters/ComponentDispatcherHandler.cs
@@ -43,7 +43,7 @@ namespace Improbable.Gdk.Core.CodegenAdapters
 
         /// <summary>
         ///     A helper method that wraps TryGetEntity on the Worker. This throws if the entity does not exist.
-        ///     The reason is throws is that this method is called on receiving ops and not having that Entity Id is
+        ///     The reason this throws is that this method is called on receiving ops and not having that Entity Id is
         ///     strictly incorrect.
         /// </summary>
         /// <param name="entityId">The Spatial EntityId to try and get.</param>

--- a/workers/unity/Packages/com.improbable.gdk.core/CodegenAdapters/ComponentDispatcherHandler.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/CodegenAdapters/ComponentDispatcherHandler.cs
@@ -32,7 +32,6 @@ namespace Improbable.Gdk.Core.CodegenAdapters
             "Received ComponentRemoved, but already received one for this entity.";
 
         protected const string EntityNotFound = "No entity found for entity specified in op.";
-        protected const string CommandIndexNotFound = "Command index not found.";
         protected const string InvalidAuthorityChange = "Invalid authority state change received.";
 
         protected ComponentDispatcherHandler(WorkerSystem worker, World world)
@@ -59,6 +58,20 @@ namespace Improbable.Gdk.Core.CodegenAdapters
             }
 
             return entity;
+        }
+
+        /// <summary>
+        ///     An exception for when the ComponentDispatcherHandler receive a CommandRequest or CommandResponse
+        ///     with an index that it does not know.
+        /// </summary>
+        protected class UnknownCommandIndexException : Exception
+        {
+            /// <param name="commandIndex">The unknown command index.</param>
+            /// <param name="componentName">The name of the component that the command was received on.</param>
+            public UnknownCommandIndexException(uint commandIndex, string componentName)
+                : base($"Unknown command index: {commandIndex} received for {componentName}")
+            {
+            }
         }
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.core/CodegenAdapters/ComponentDispatcherHandler.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/CodegenAdapters/ComponentDispatcherHandler.cs
@@ -69,7 +69,8 @@ namespace Improbable.Gdk.Core.CodegenAdapters
             /// <param name="commandIndex">The unknown command index.</param>
             /// <param name="componentName">The name of the component that the command was received on.</param>
             public UnknownCommandIndexException(uint commandIndex, string componentName)
-                : base($"Unknown command index: {commandIndex} received for {componentName}")
+                : base($"Unknown command index: {commandIndex} received for {componentName}. " +
+                    "This can be caused by adding commands to a component and not rebuilding workers.")
             {
             }
         }

--- a/workers/unity/Packages/com.improbable.gdk.core/CodegenAdapters/ComponentDispatcherHandler.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/CodegenAdapters/ComponentDispatcherHandler.cs
@@ -1,4 +1,5 @@
 using System;
+using Improbable.Worker;
 using Improbable.Worker.Core;
 using Unity.Entities;
 using Entity = Unity.Entities.Entity;
@@ -39,6 +40,25 @@ namespace Improbable.Gdk.Core.CodegenAdapters
             LogDispatcher = worker.LogDispatcher;
             World = world;
             Worker = worker;
+        }
+
+        /// <summary>
+        ///     A helper method that wraps TryGetEntity on the Worker. This throws if the entity does not exist.
+        ///     The reason is throws is that this method is called on receiving ops and not having that Entity Id is
+        ///     strictly incorrect.
+        /// </summary>
+        /// <param name="entityId">The Spatial EntityId to try and get.</param>
+        /// <returns>The Unity ECS entity that corresponds to the Spatial Entity ID.</returns>
+        /// <exception cref="InvalidSpatialEntityStateException"></exception>
+        protected Entity TryGetEntityFromEntityId(EntityId entityId)
+        {
+            if (!Worker.TryGetEntity(entityId, out var entity))
+            {
+                throw new InvalidSpatialEntityStateException(
+                    $"Could not find Unity Entity for Spatial Entity ID {entityId.Id}.");
+            }
+
+            return entity;
         }
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.core/CodegenAdapters/ComponentDispatcherHandler.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/CodegenAdapters/ComponentDispatcherHandler.cs
@@ -43,7 +43,7 @@ namespace Improbable.Gdk.Core.CodegenAdapters
 
         /// <summary>
         ///     A helper method that wraps TryGetEntity on the Worker. This throws if the entity does not exist.
-        ///     The reason this throws is that this method is called on receiving ops and not having that Entity Id is
+        ///     Calling this method on receiving an op and not having the Entity Id specified in the op is
         ///     strictly incorrect.
         /// </summary>
         /// <param name="entityId">The Spatial EntityId to try and get.</param>

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityComponentConversionGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityComponentConversionGenerator.tt
@@ -235,13 +235,7 @@ namespace <#= qualifiedNamespace #>
                         break;
 <# } #>
                     default:
-                        LogDispatcher.HandleLog(LogType.Error, new LogEvent(CommandIndexNotFound)
-                            .WithField(LoggingUtils.LoggerName, LoggerName)
-                            .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                            .WithField("CommandIndex", commandIndex)
-                            .WithField("Component", "<#= componentNamespace #>")
-                        );
-                        break;
+                        throw new UnknownCommandIndexException(commandIndex, "<#= componentDetails.ComponentName #>");
                 }
             }
 
@@ -256,13 +250,7 @@ namespace <#= qualifiedNamespace #>
                         break;
 <# } #>
                     default:
-                        LogDispatcher.HandleLog(LogType.Error, new LogEvent(CommandIndexNotFound)
-                            .WithField(LoggingUtils.LoggerName, LoggerName)
-                            .WithField(LoggingUtils.EntityId, op.EntityId.Id)
-                            .WithField("CommandIndex", commandIndex)
-                            .WithField("Component", "<#= componentNamespace #>")
-                        );
-                        break;
+                        throw new UnknownCommandIndexException(commandIndex, "<#= componentDetails.ComponentName #>");
                 }
             }
 

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityComponentConversionGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityComponentConversionGenerator.tt
@@ -69,10 +69,7 @@ namespace <#= qualifiedNamespace #>
 
             public override void OnAddComponent(AddComponentOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "AddComponentOp", out var entity))
-                {
-                    return;
-                }
+                var entity = TryGetEntityFromEntityId(op.EntityId);
 
                 var data = <#= componentNamespace #>.Serialization.Deserialize(op.Data.SchemaData.Value.GetFields(), World);
                 data.DirtyBit = false;
@@ -119,10 +116,7 @@ namespace <#= qualifiedNamespace #>
 
             public override void OnRemoveComponent(RemoveComponentOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "RemoveComponentOp", out var entity))
-                {
-                    return;
-                }
+                var entity = TryGetEntityFromEntityId(op.EntityId);
 <# if (!componentDetails.IsBlittable) { #>
 
                 var data = entityManager.GetComponentData<<#= componentNamespace #>.Component>(entity);
@@ -155,10 +149,7 @@ namespace <#= qualifiedNamespace #>
 
             public override void OnComponentUpdate(ComponentUpdateOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "OnComponentUpdate", out var entity))
-                {
-                    return;
-                }
+                var entity = TryGetEntityFromEntityId(op.EntityId);
 
                 if (entityManager.HasComponent<NotAuthoritative<<#= componentNamespace #>.Component>>(entity))
                 {
@@ -229,21 +220,12 @@ namespace <#= qualifiedNamespace #>
 
             public override void OnAuthorityChange(AuthorityChangeOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "AuthorityChangeOp", out var entity))
-                {
-                    return;
-                }
-
+                var entity = TryGetEntityFromEntityId(op.EntityId);
                 ApplyAuthorityChange(entity, op.Authority, op.EntityId);
             }
 
             public override void OnCommandRequest(CommandRequestOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "CommandRequestOp", out var entity))
-                {
-                    return;
-                }
-
                 var commandIndex = op.Request.SchemaData.Value.GetCommandIndex();
                 switch (commandIndex)
                 {
@@ -384,22 +366,6 @@ namespace <#= qualifiedNamespace #>
                 authorityChanges.Add(authority);
             }
 
-            private bool IsValidEntityId(global::Improbable.Worker.EntityId entityId, string opType, out Unity.Entities.Entity entity)
-            {
-                if (!Worker.TryGetEntity(entityId, out entity))
-                {
-                    LogDispatcher.HandleLog(LogType.Error, new LogEvent(EntityNotFound)
-                        .WithField(LoggingUtils.LoggerName, LoggerName)
-                        .WithField(LoggingUtils.EntityId, entityId.Id)
-                        .WithField("Op", opType)
-                        .WithField("Component", "<#= componentNamespace #>")
-                    );
-                    return false;
-                }
-
-                return true;
-            }
-
             private void LogInvalidAuthorityTransition(Authority newAuthority, Authority expectedOldAuthority, global::Improbable.Worker.EntityId entityId)
             {
                 LogDispatcher.HandleLog(LogType.Error, new LogEvent(InvalidAuthorityChange)
@@ -422,10 +388,7 @@ namespace <#= qualifiedNamespace #>
 #>
             private void On<#= commandDetails.CommandName #>Request(CommandRequestOp op)
             {
-                if (!IsValidEntityId(op.EntityId, "CommandRequestOp", out var entity))
-                {
-                    return;
-                }
+                var entity = TryGetEntityFromEntityId(op.EntityId);
 
                 var deserializedRequest = <#= commandDetails.FqnRequestType #>.Serialization.Deserialize(op.Request.SchemaData.Value.GetObject());
 
@@ -461,7 +424,7 @@ namespace <#= qualifiedNamespace #>
                 <#= commandStorage #>.CommandRequestsInFlight.Remove(op.RequestId.Id);
                 if (!entityManager.Exists(entity))
                 {
-                    LogDispatcher.HandleLog(LogType.Error, new LogEvent(EntityNotFound)
+                    LogDispatcher.HandleLog(LogType.Log, new LogEvent(EntityNotFound)
                         .WithField(LoggingUtils.LoggerName, LoggerName)
                         .WithField("Op", "CommandResponseOp - <#= commandDetails.CommandName #>")
                         .WithField("Component", "<#= componentNamespace #>")


### PR DESCRIPTION
#### Description
A couple changes:
* To maintain consistency with the changes in the `SpatialOSReceiveSystem` made in #330 - receiving an OP and not having the EntityId in the Worker throws instead of logs.
* A command response that is received after the entity has migrated/was deleted now just logs instead of errors (as this is a very much expected state).
* Driveby - make attribute for testing internal instead of public.

**Last commit is generated code**
#### Tests
Ran all tests + ran playground.
#### Documentation
N/A
#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
@jessicafalk 