### PR TITLE
UTY-1099: Add Unit Tests to SpatialOS Send System

### DIFF
--- a/workers/unity/Packages/com.improbable.gdk.core/Attributes/DisableAutoRegisterAttribute.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Attributes/DisableAutoRegisterAttribute.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Improbable.Gdk.Core
+{
+    /// <summary>
+    ///     This attribute denotes that a CodegenAdapter class should not be automatically registered with
+    ///     that which consumes them. The intended use for this attribute is testing.
+    /// </summary>
+    internal class DisableAutoRegisterAttribute : Attribute
+    {
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.core/Attributes/DisableAutoRegisterAttribute.cs.meta
+++ b/workers/unity/Packages/com.improbable.gdk.core/Attributes/DisableAutoRegisterAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1fcde1c715982a548a54b1d003cfd785
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/workers/unity/Packages/com.improbable.gdk.core/CodegenAdapters/ComponentDispatcherHandler.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/CodegenAdapters/ComponentDispatcherHandler.cs
@@ -40,13 +40,5 @@ namespace Improbable.Gdk.Core.CodegenAdapters
             World = world;
             Worker = worker;
         }
-
-        /// <summary>
-        ///     This attribute denotes that a ComponentDispatcherHandler should not be automatically registered with
-        ///     that which consumes them. The intended use for this attribute is testing.
-        /// </summary>
-        public class DisableAutoRegisterAttribute : Attribute
-        {
-        }
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.core/Systems/SpatialOSReceiveSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Systems/SpatialOSReceiveSystem.cs
@@ -374,7 +374,7 @@ namespace Improbable.Gdk.Core
             var componentDispatcherTypes = AppDomain.CurrentDomain.GetAssemblies()
                 .SelectMany(assembly => assembly.GetTypes())
                 .Where(type => typeof(ComponentDispatcherHandler).IsAssignableFrom(type) && !type.IsAbstract
-                    && type.GetCustomAttribute(typeof(ComponentDispatcherHandler.DisableAutoRegisterAttribute)) ==
+                    && type.GetCustomAttribute(typeof(DisableAutoRegisterAttribute)) ==
                     null);
 
             WorldCommands.AddWorldCommandRequesters(World, EntityManager, worker.WorkerEntity);

--- a/workers/unity/Packages/com.improbable.gdk.core/Systems/SpatialOSSendSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Systems/SpatialOSSendSystem.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using Improbable.Gdk.Core.CodegenAdapters;
 using Improbable.Worker.Core;
 using Unity.Entities;
@@ -24,29 +25,6 @@ namespace Improbable.Gdk.Core
             connection = World.GetExistingManager<WorkerSystem>().Connection;
 
             PopulateDefaultComponentReplicators();
-        }
-
-        private void PopulateDefaultComponentReplicators()
-        {
-            // Find all component specific replicators and create an instance.
-            var componentReplicationTypes = AppDomain.CurrentDomain.GetAssemblies()
-                .SelectMany(assembly => assembly.GetTypes())
-                .Where(type => typeof(ComponentReplicationHandler).IsAssignableFrom(type) && !type.IsAbstract);
-
-            foreach (var componentReplicationType in componentReplicationTypes)
-            {
-                var componentReplicationHandler =
-                    (ComponentReplicationHandler) Activator.CreateInstance(componentReplicationType,
-                        new object[] { EntityManager, World });
-
-                componentReplicators.Add(new ComponentReplicator
-                {
-                    ComponentId = componentReplicationHandler.ComponentId,
-                    Handler = componentReplicationHandler,
-                    ReplicationComponentGroup =
-                        GetComponentGroup(componentReplicationHandler.ReplicationComponentTypes),
-                });
-            }
         }
 
         public bool TryRegisterCustomReplicationSystem(uint componentId)
@@ -74,12 +52,40 @@ namespace Improbable.Gdk.Core
             }
         }
 
+        internal void AddComponentReplicator(ComponentReplicationHandler componentReplicationHandler)
+        {
+            componentReplicators.Add(new ComponentReplicator
+            {
+                ComponentId = componentReplicationHandler.ComponentId,
+                Handler = componentReplicationHandler,
+                ReplicationComponentGroup =
+                    GetComponentGroup(componentReplicationHandler.ReplicationComponentTypes),
+            });
+        }
+
+        private void PopulateDefaultComponentReplicators()
+        {
+            // Find all component specific replicators and create an instance.
+            var componentReplicationTypes = AppDomain.CurrentDomain.GetAssemblies()
+                .SelectMany(assembly => assembly.GetTypes())
+                .Where(type => typeof(ComponentReplicationHandler).IsAssignableFrom(type) && !type.IsAbstract
+                    && type.GetCustomAttribute(typeof(DisableAutoRegisterAttribute)) == null);
+
+            foreach (var componentReplicationType in componentReplicationTypes)
+            {
+                var componentReplicationHandler =
+                    (ComponentReplicationHandler) Activator.CreateInstance(componentReplicationType,
+                        new object[] { EntityManager, World });
+
+                AddComponentReplicator(componentReplicationHandler);
+            }
+        }
+
         private struct ComponentReplicator
         {
             public uint ComponentId;
             public ComponentReplicationHandler Handler;
             public ComponentGroup ReplicationComponentGroup;
-            public List<ComponentGroup> CommandReplicationGroups;
 
             public void Execute(SpatialOSSendSystem sendSystem, Connection connection)
             {

--- a/workers/unity/Packages/com.improbable.gdk.core/Systems/SpatialOSSendSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Systems/SpatialOSSendSystem.cs
@@ -75,7 +75,7 @@ namespace Improbable.Gdk.Core
             {
                 var componentReplicationHandler =
                     (ComponentReplicationHandler) Activator.CreateInstance(componentReplicationType,
-                        new object[] { EntityManager, World });
+                        EntityManager, World);
 
                 AddComponentReplicator(componentReplicationHandler);
             }

--- a/workers/unity/Packages/com.improbable.gdk.core/Tests/Editmode/Systems/SpatialOSSendSystemTests.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Tests/Editmode/Systems/SpatialOSSendSystemTests.cs
@@ -1,0 +1,77 @@
+﻿using Improbable.Gdk.Core.CodegenAdapters;
+using Improbable.Gdk.TestUtils;
+using Improbable.Worker.Core;
+using NUnit.Framework;
+using Unity.Entities;
+using UnityEngine;
+
+namespace Improbable.Gdk.Core.EditmodeTests
+{
+    [TestFixture]
+    public class SpatialOSSendSystemTests
+    {
+        internal const uint TestComponentId = 1;
+
+        private const string TestWorkerType = "TestWorker";
+        private const uint UnknownComponentId = 0;
+
+        private World world;
+        private SpatialOSSendSystem sendSystem;
+
+        private ILogDispatcher logDispatcher;
+
+        [OneTimeSetUp]
+        public void OneTimeSetup()
+        {
+            world = new World("test-world");
+            logDispatcher = new TestLogDispatcher();
+            world.CreateManager<WorkerSystem>(null, logDispatcher, TestWorkerType, Vector3.zero);
+
+            sendSystem = world.GetOrCreateManager<SpatialOSSendSystem>();
+
+            var testHandler = new TestComponentReplicationHandler(world.GetOrCreateManager<EntityManager>());
+            sendSystem.AddComponentReplicator(testHandler);
+        }
+
+        [OneTimeTearDown]
+        public void OneTimeTearDown()
+        {
+            logDispatcher.Dispose();
+            world.Dispose();
+        }
+
+        [Test]
+        public void TryRegisterCustomReplicationSystem_should_return_false_if_there_isnt_an_enabled_default_replicator()
+        {
+            Assert.IsFalse(sendSystem.TryRegisterCustomReplicationSystem(UnknownComponentId));
+        }
+
+        [Test]
+        public void TryRegisterCustomReplicationSystem_should_return_true_the_first_time_for_a_component_id()
+        {
+            Assert.IsTrue(sendSystem.TryRegisterCustomReplicationSystem(TestComponentId));
+            Assert.IsFalse(sendSystem.TryRegisterCustomReplicationSystem(TestComponentId));
+        }
+    }
+
+    [DisableAutoRegister]
+    public class TestComponentReplicationHandler : ComponentReplicationHandler
+    {
+        public override uint ComponentId => SpatialOSSendSystemTests.TestComponentId;
+        public override ComponentType[] ReplicationComponentTypes => new ComponentType[0];
+
+        public TestComponentReplicationHandler(EntityManager entityManager) : base(entityManager)
+        {
+        }
+
+        public override void ExecuteReplication(ComponentGroup replicationGroup, Connection connection)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public override void SendCommands(SpatialOSSendSystem sendSystem, Connection connection)
+        {
+            throw new System.NotImplementedException();
+        }
+    }
+}

--- a/workers/unity/Packages/com.improbable.gdk.core/Tests/Editmode/Systems/SpatialOSSendSystemTests.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Tests/Editmode/Systems/SpatialOSSendSystemTests.cs
@@ -5,7 +5,7 @@ using NUnit.Framework;
 using Unity.Entities;
 using UnityEngine;
 
-namespace Improbable.Gdk.Core.EditmodeTests
+namespace Improbable.Gdk.Core.EditmodeTests.Systems
 {
     [TestFixture]
     public class SpatialOSSendSystemTests

--- a/workers/unity/Packages/com.improbable.gdk.core/Tests/Editmode/Systems/SpatialOSSendSystemTests.cs.meta
+++ b/workers/unity/Packages/com.improbable.gdk.core/Tests/Editmode/Systems/SpatialOSSendSystemTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 06e77c605ba1309459e298831ac23e93
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
#### Description
A few unit tests for the `SpatialOSSendSystem` - mostly focused around registering custom replicators.
#### Tests
These are tests
#### Documentation
N/A
#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
@zeroZshadow 