### PR TITLE
UTY-1234: helper methods to determine if entity is on worker

### DIFF
--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/SpatialOSComponent.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/SpatialOSComponent.cs
@@ -11,5 +11,10 @@ namespace Improbable.Gdk.GameObjectRepresentation
         public Entity Entity;
         public World World;
         public WorkerSystem Worker;
+
+        public bool IsEntityOnThisWorker(EntityId entityId)
+        {
+            return Worker.EntityIdToEntity.ContainsKey(entityId);
+        }
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/SpatialOSComponent.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/SpatialOSComponent.cs
@@ -16,10 +16,5 @@ namespace Improbable.Gdk.GameObjectRepresentation
         {
             return Worker.EntityIdToEntity.ContainsKey(entityId);
         }
-
-        public bool IsEntityOnThisWorker(Entity entity)
-        {
-            return Worker.EntityIdToEntity.ContainsValue(entity);
-        }
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/SpatialOSComponent.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/SpatialOSComponent.cs
@@ -16,5 +16,10 @@ namespace Improbable.Gdk.GameObjectRepresentation
         {
             return Worker.EntityIdToEntity.ContainsKey(entityId);
         }
+
+        public bool IsEntityOnThisWorker(Entity entity)
+        {
+            return Worker.EntityIdToEntity.ContainsValue(entity);
+        }
     }
 }


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Add IsEntityOnThisWorker helper method to SpatialOsComponent, decided not to include a version that takes an Entity, to avoid iterating through a whole Dictionary
#### Tests
none
#### Documentation
none
#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
