### PR TITLE
UTY-1173: update the warning message on entity query request creation

### DIFF
--- a/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands.cs
@@ -702,7 +702,7 @@ namespace Improbable.Gdk.Core.Commands
             {
                 if (entityQuery.ResultType is SnapshotResultType)
                 {
-                    Debug.LogWarning("Cannot safely access component data from entity query - this is a known bug. To protect the integrity of this worker, this request will be dropped before sending.");
+                    Debug.LogWarning("Cannot safely access component data from entity query - this is a known issue. To protect its integrity, the worker will drop the request before sending.");
                 }
 
                 return new Request


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
update the warning message when creating an entity query request with `ResultType` as `SnapshotResultType` - based on Laura's feedback
#### Tests
none
What automated tests are included in this PR?
#### Documentation
none
#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.