### PR TITLE
Unify Test Namespaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,5 +61,6 @@ test-project/Assets/Plugins/Improbable.meta
 test-project/ProjectSettings/UnityConnectSettings.asset
 test-project/Assets/Generated/Source.meta
 test-project/Assets/Generated/Source/**/*.*
+test-project/Assets/.Schema/from_gdk_packages
 !test-project/Assets/Generated/Source/improbable/gdk/tests/**/*.cs
 

--- a/test-project/Assets/EditmodeTests/Components/BlittableComponentTests.cs
+++ b/test-project/Assets/EditmodeTests/Components/BlittableComponentTests.cs
@@ -2,7 +2,7 @@ using Improbable.Gdk.Core;
 using Improbable.Gdk.Tests.BlittableTypes;
 using NUnit.Framework;
 
-namespace Improbable.Gdk.CodeGenerator.End2EndTests
+namespace Improbable.Gdk.EditmodeTests.Ecs
 {
     [TestFixture]
     public class BlittableComponentTests

--- a/test-project/Assets/EditmodeTests/GameObjectRepresentation/CommandSenders/CommandRequestHandlerTests.cs
+++ b/test-project/Assets/EditmodeTests/GameObjectRepresentation/CommandSenders/CommandRequestHandlerTests.cs
@@ -3,7 +3,7 @@ using Improbable.Gdk.Tests.ComponentsWithNoFields;
 using NUnit.Framework;
 using Unity.Entities;
 
-namespace Improbable.Gdk.EditModeTests.MonoBehaviours.CommandSenders
+namespace Improbable.Gdk.EditmodeTests.GameObjectRepresentation.CommandSenders
 {
     [TestFixture]
     public class CommandRequestHandlerTests

--- a/test-project/Assets/EditmodeTests/GameObjectRepresentation/CommandSenders/CommandResponseHandlerTests.cs
+++ b/test-project/Assets/EditmodeTests/GameObjectRepresentation/CommandSenders/CommandResponseHandlerTests.cs
@@ -1,10 +1,11 @@
-﻿using Improbable.Gdk.Tests.ComponentsWithNoFields;
+﻿using Improbable.Gdk.Core;
+using Improbable.Gdk.Tests.ComponentsWithNoFields;
 using Improbable.Worker;
 using Improbable.Worker.Core;
 using NUnit.Framework;
 using Unity.Entities;
 
-namespace Improbable.Gdk.Core.EditmodeTests.MonoBehaviours.CommandSenders
+namespace Improbable.Gdk.EditmodeTests.GameObjectRepresentation.CommandSenders
 {
     [TestFixture]
     public class CommandResponseHandlerTests

--- a/test-project/Assets/EditmodeTests/GameObjectRepresentation/MonoBehaviourActivationManager/ActivationManagerTestBase.cs
+++ b/test-project/Assets/EditmodeTests/GameObjectRepresentation/MonoBehaviourActivationManager/ActivationManagerTestBase.cs
@@ -1,9 +1,10 @@
 using Improbable.Gdk.Core;
+using Improbable.Gdk.GameObjectRepresentation;
 using NUnit.Framework;
 using Unity.Entities;
 using UnityEngine;
 
-namespace Improbable.Gdk.GameObjectRepresentation.EditModeTests.MonoBehaviourActivationManagerTests
+namespace Improbable.Gdk.EditmodeTests.GameObjectRepresentation.MonoBehaviourActivationManagerTests
 {
     public abstract class ActivationManagerTestBase
     {

--- a/test-project/Assets/EditmodeTests/GameObjectRepresentation/MonoBehaviourActivationManager/AuthorityRequiredBehaviourActivationTestsBase.cs
+++ b/test-project/Assets/EditmodeTests/GameObjectRepresentation/MonoBehaviourActivationManager/AuthorityRequiredBehaviourActivationTestsBase.cs
@@ -2,7 +2,7 @@ using Improbable.Worker.Core;
 using NUnit.Framework;
 using UnityEngine;
 
-namespace Improbable.Gdk.GameObjectRepresentation.EditModeTests.MonoBehaviourActivationManagerTests
+namespace Improbable.Gdk.EditmodeTests.GameObjectRepresentation.MonoBehaviourActivationManagerTests
 {
     public abstract class AuthorityRequiredBehaviourActivationTestsBase<TBehaviour> : ActivationManagerTestBase
         where TBehaviour : MonoBehaviour

--- a/test-project/Assets/EditmodeTests/GameObjectRepresentation/MonoBehaviourActivationManager/CommandHandlerBehaviourActivationTests.cs
+++ b/test-project/Assets/EditmodeTests/GameObjectRepresentation/MonoBehaviourActivationManager/CommandHandlerBehaviourActivationTests.cs
@@ -1,8 +1,9 @@
+using Improbable.Gdk.GameObjectRepresentation;
 using Improbable.Gdk.Tests.ComponentsWithNoFields;
 using NUnit.Framework;
 using UnityEngine;
 
-namespace Improbable.Gdk.GameObjectRepresentation.EditModeTests.MonoBehaviourActivationManagerTests
+namespace Improbable.Gdk.EditmodeTests.GameObjectRepresentation.MonoBehaviourActivationManagerTests
 {
     [TestFixture]
     public class CommandHandlerBehaviourActivationTests :

--- a/test-project/Assets/EditmodeTests/GameObjectRepresentation/MonoBehaviourActivationManager/MultipleBehaviourActivationTests.cs
+++ b/test-project/Assets/EditmodeTests/GameObjectRepresentation/MonoBehaviourActivationManager/MultipleBehaviourActivationTests.cs
@@ -2,7 +2,7 @@ using Improbable.Worker.Core;
 using NUnit.Framework;
 
 
-namespace Improbable.Gdk.GameObjectRepresentation.EditModeTests.MonoBehaviourActivationManagerTests
+namespace Improbable.Gdk.EditmodeTests.GameObjectRepresentation.MonoBehaviourActivationManagerTests
 {
     using ReaderBehaviour = ReaderBehaviourActivationTests.TestBehaviourWithReader;
     using WriterBehaviour = WriterBehaviourActivationTests.TestBehaviourWithWriter;

--- a/test-project/Assets/EditmodeTests/GameObjectRepresentation/MonoBehaviourActivationManager/ReaderBehaviourActivationTests.cs
+++ b/test-project/Assets/EditmodeTests/GameObjectRepresentation/MonoBehaviourActivationManager/ReaderBehaviourActivationTests.cs
@@ -1,8 +1,9 @@
+using Improbable.Gdk.GameObjectRepresentation;
 using Improbable.Worker.Core;
 using NUnit.Framework;
 using UnityEngine;
 
-namespace Improbable.Gdk.GameObjectRepresentation.EditModeTests.MonoBehaviourActivationManagerTests
+namespace Improbable.Gdk.EditmodeTests.GameObjectRepresentation.MonoBehaviourActivationManagerTests
 {
     [TestFixture]
     public class ReaderBehaviourActivationTests : ActivationManagerTestBase

--- a/test-project/Assets/EditmodeTests/GameObjectRepresentation/MonoBehaviourActivationManager/ReadersAndWriterBehaviourActivationTests.cs
+++ b/test-project/Assets/EditmodeTests/GameObjectRepresentation/MonoBehaviourActivationManager/ReadersAndWriterBehaviourActivationTests.cs
@@ -1,7 +1,8 @@
+using Improbable.Gdk.GameObjectRepresentation;
 using NUnit.Framework;
 using UnityEngine;
 
-namespace Improbable.Gdk.GameObjectRepresentation.EditModeTests.MonoBehaviourActivationManagerTests
+namespace Improbable.Gdk.EditmodeTests.GameObjectRepresentation.MonoBehaviourActivationManagerTests
 {
     [TestFixture]
     public class ReadersAndWriterBehaviourActivationTests :

--- a/test-project/Assets/EditmodeTests/GameObjectRepresentation/MonoBehaviourActivationManager/RequestSenderBehaviourActivationTests.cs
+++ b/test-project/Assets/EditmodeTests/GameObjectRepresentation/MonoBehaviourActivationManager/RequestSenderBehaviourActivationTests.cs
@@ -1,10 +1,11 @@
 using Improbable.Gdk.Core.Commands;
+using Improbable.Gdk.GameObjectRepresentation;
 using Improbable.Gdk.Tests.ComponentsWithNoFields;
 using Improbable.Worker.Core;
 using NUnit.Framework;
 using UnityEngine;
 
-namespace Improbable.Gdk.GameObjectRepresentation.EditModeTests.MonoBehaviourActivationManagerTests
+namespace Improbable.Gdk.EditmodeTests.GameObjectRepresentation.MonoBehaviourActivationManagerTests
 {
     [TestFixture]
     public class RequestSenderBehaviourActivationTests : ActivationManagerTestBase

--- a/test-project/Assets/EditmodeTests/GameObjectRepresentation/MonoBehaviourActivationManager/WorkerTypeActivationTests.cs
+++ b/test-project/Assets/EditmodeTests/GameObjectRepresentation/MonoBehaviourActivationManager/WorkerTypeActivationTests.cs
@@ -1,7 +1,8 @@
+using Improbable.Gdk.GameObjectRepresentation;
 using NUnit.Framework;
 using UnityEngine;
 
-namespace Improbable.Gdk.GameObjectRepresentation.EditModeTests.MonoBehaviourActivationManagerTests
+namespace Improbable.Gdk.EditmodeTests.GameObjectRepresentation.MonoBehaviourActivationManagerTests
 {
     [TestFixture]
     public class WorkerTypeActivationTests : ActivationManagerTestBase

--- a/test-project/Assets/EditmodeTests/GameObjectRepresentation/MonoBehaviourActivationManager/WriterBehaviourActivationTests.cs
+++ b/test-project/Assets/EditmodeTests/GameObjectRepresentation/MonoBehaviourActivationManager/WriterBehaviourActivationTests.cs
@@ -1,7 +1,8 @@
+using Improbable.Gdk.GameObjectRepresentation;
 using NUnit.Framework;
 using UnityEngine;
 
-namespace Improbable.Gdk.GameObjectRepresentation.EditModeTests.MonoBehaviourActivationManagerTests
+namespace Improbable.Gdk.EditmodeTests.GameObjectRepresentation.MonoBehaviourActivationManagerTests
 {
     [TestFixture]
     public class WriterBehaviourActivationTests :

--- a/test-project/Assets/EditmodeTests/GameObjectRepresentation/Readers/EventTests.cs
+++ b/test-project/Assets/EditmodeTests/GameObjectRepresentation/Readers/EventTests.cs
@@ -9,7 +9,7 @@ using UnityEngine;
 using UnityEngine.TestTools;
 using ComponentWithEvents = Improbable.Gdk.Tests.ComponentsWithNoFields.ComponentWithNoFieldsWithEvents;
 
-namespace Improbable.Gdk.EditModeTests.MonoBehaviours.Readers
+namespace Improbable.Gdk.EditmodeTests.GameObjectRepresentation.Readers
 {
     [TestFixture]
     internal class EventTests

--- a/test-project/Assets/EditmodeTests/GameObjectRepresentation/Readers/NonBlittableReaderTests.cs
+++ b/test-project/Assets/EditmodeTests/GameObjectRepresentation/Readers/NonBlittableReaderTests.cs
@@ -4,7 +4,7 @@ using Improbable.Gdk.Tests.NonblittableTypes;
 using NUnit.Framework;
 using Unity.Entities;
 
-namespace Improbable.Gdk.EditModeTests.MonoBehaviours.Readers
+namespace Improbable.Gdk.EditmodeTests.GameObjectRepresentation.Readers
 {
     [TestFixture]
     public class NonBlittableReaderTests

--- a/test-project/Assets/EditmodeTests/GameObjectRepresentation/Readers/NonBlittableWriterTests.cs
+++ b/test-project/Assets/EditmodeTests/GameObjectRepresentation/Readers/NonBlittableWriterTests.cs
@@ -4,7 +4,7 @@ using Improbable.Gdk.Tests.NonblittableTypes;
 using NUnit.Framework;
 using Unity.Entities;
 
-namespace Improbable.Gdk.EditModeTests.MonoBehaviours.Readers
+namespace Improbable.Gdk.EditmodeTests.GameObjectRepresentation.Readers
 {
     [TestFixture]
     public class NonBlittableWriterTests

--- a/test-project/Assets/EditmodeTests/GameObjectRepresentation/Readers/ReaderAuthorityTests.cs
+++ b/test-project/Assets/EditmodeTests/GameObjectRepresentation/Readers/ReaderAuthorityTests.cs
@@ -7,7 +7,7 @@ using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
 
-namespace Improbable.Gdk.EditModeTests.MonoBehaviours.Readers
+namespace Improbable.Gdk.EditmodeTests.GameObjectRepresentation.Readers
 {
     [TestFixture]
     internal class ReaderAuthorityTests : ReaderWriterTestsBase

--- a/test-project/Assets/EditmodeTests/GameObjectRepresentation/Readers/ReaderDataTests.cs
+++ b/test-project/Assets/EditmodeTests/GameObjectRepresentation/Readers/ReaderDataTests.cs
@@ -1,7 +1,7 @@
 ﻿using Improbable.Gdk.Tests.BlittableTypes;
 using NUnit.Framework;
 
-namespace Improbable.Gdk.EditModeTests.MonoBehaviours.Readers
+namespace Improbable.Gdk.EditmodeTests.GameObjectRepresentation.Readers
 {
     [TestFixture]
     internal class ReaderDataTests : ReaderWriterTestsBase

--- a/test-project/Assets/EditmodeTests/GameObjectRepresentation/Readers/ReaderWriterTestsBase.cs
+++ b/test-project/Assets/EditmodeTests/GameObjectRepresentation/Readers/ReaderWriterTestsBase.cs
@@ -3,7 +3,7 @@ using Improbable.Gdk.Tests.BlittableTypes;
 using NUnit.Framework;
 using Unity.Entities;
 
-namespace Improbable.Gdk.EditModeTests.MonoBehaviours.Readers
+namespace Improbable.Gdk.EditmodeTests.GameObjectRepresentation.Readers
 {
     internal abstract class ReaderWriterTestsBase
     {

--- a/test-project/Assets/EditmodeTests/GameObjectRepresentation/Readers/ReaderWriterUpdateTests.cs
+++ b/test-project/Assets/EditmodeTests/GameObjectRepresentation/Readers/ReaderWriterUpdateTests.cs
@@ -5,7 +5,7 @@ using NUnit.Framework;
 using UnityEngine;
 using UnityEngine.TestTools;
 
-namespace Improbable.Gdk.EditModeTests.MonoBehaviours.Readers
+namespace Improbable.Gdk.EditmodeTests.GameObjectRepresentation.Readers
 {
     [TestFixture]
     internal class ReaderWriterUpdateTests : ReaderWriterTestsBase

--- a/test-project/Assets/EditmodeTests/GameObjectRepresentation/Readers/WriterSendUpdateTests.cs
+++ b/test-project/Assets/EditmodeTests/GameObjectRepresentation/Readers/WriterSendUpdateTests.cs
@@ -2,7 +2,7 @@
 using Improbable.Gdk.Tests.BlittableTypes;
 using NUnit.Framework;
 
-namespace Improbable.Gdk.EditModeTests.MonoBehaviours.Readers
+namespace Improbable.Gdk.EditmodeTests.GameObjectRepresentation.Readers
 {
     [TestFixture]
     internal class WriterSendUpdateTests : ReaderWriterTestsBase

--- a/test-project/Assets/EditmodeTests/GameObjectRepresentation/RequiredFieldInjectorTests.cs
+++ b/test-project/Assets/EditmodeTests/GameObjectRepresentation/RequiredFieldInjectorTests.cs
@@ -8,7 +8,7 @@ using NUnit.Framework;
 using Unity.Entities;
 using UnityEngine;
 
-namespace Improbable.Gdk.EditModeTests
+namespace Improbable.Gdk.EditmodeTests.GameObjectRepresentation
 {
     [TestFixture]
     public class RequiredFieldInjectorTests


### PR DESCRIPTION
#### Description
Small cosmetic changes - make all the namespaces in the `test-project` unified for easier viewing in the TestRunner. Driveby on the gitignore
#### Tests
Yes
#### Documentation
N/A
#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.