### PR TITLE
Document EntityId logging behaviour in the cloud.

### DIFF
--- a/docs/content/ecs/logging.md
+++ b/docs/content/ecs/logging.md
@@ -22,7 +22,7 @@ You can access the dispatcher through the [WorkerSystem](accessing-worker-info.m
 There are two log context variables:
 
 * `LoggingUtils.LoggerName`, which specifies where the log was sent from
-* `LoggingUtils.EntityId`, which links the log to a specific entity. When running the game in the cloud, this lets you filter for a particular entity's logs using the Inspector and Logger. 
+* `LoggingUtils.EntityId`, which links the log to a specific entity. When running the game in the cloud using the `ForwardingDispatcher`, this lets you filter for a particular entity's logs using the Inspector and Logger.
 
 These are automatically picked up by the `ForwardingDispatcher` if provided. Other context variables are formatted in a string and sent with the log message.
 

--- a/docs/content/ecs/logging.md
+++ b/docs/content/ecs/logging.md
@@ -22,7 +22,7 @@ You can access the dispatcher through the [WorkerSystem](accessing-worker-info.m
 There are two log context variables:
 
 * `LoggingUtils.LoggerName`, which specifies where the log was sent from
-* `LoggingUtils.EntityId`, which links the log to a specific entity
+* `LoggingUtils.EntityId`, which links the log to a specific entity. When running the game in the cloud, this lets you filter for a particular entity's logs using the Inspector and Logger. 
 
 These are automatically picked up by the `ForwardingDispatcher` if provided. Other context variables are formatted in a string and sent with the log message.
 


### PR DESCRIPTION
#### Description
Added a sentence to the `LoggingUtils.EntityId` variable documentation, to document why it might be useful to provide. This relates to the imminent release of entity id filtering in the Inspector and Logger. 

#### Tests
No tests.

#### Documentation
See above.

#### Primary reviewers
@jessicafalk 