### PR TITLE
Bug/uty 1259 fix scoring

### DIFF
--- a/workers/unity/Assets/Playground/Scripts/Player/PlayerCommandsSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/Player/PlayerCommandsSystem.cs
@@ -94,7 +94,8 @@ namespace Playground
                     EntityToLaunch = component.SpatialEntityId,
                     ImpactPoint = impactPoint,
                     LaunchDirection = launchDirection,
-                    LaunchEnergy = command == PlayerCommand.LaunchLarge ? LargeEnergy : SmallEnergy
+                    LaunchEnergy = command == PlayerCommand.LaunchLarge ? LargeEnergy : SmallEnergy,
+                    Player = playerId
                 }));
         }
     }

--- a/workers/unity/Assets/Playground/Scripts/Player/ProcessLaunchCommandSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/Player/ProcessLaunchCommandSystem.cs
@@ -62,7 +62,6 @@ namespace Playground
                 {
                     var info = requests[j].RawRequest;
                     var energy = math.min(info.LaunchEnergy, energyLeft);
-
                     sender.RequestsToSend.Add(new Launchable.LaunchMe.Request(info.EntityToLaunch, new Generated.Playground.LaunchMeCommandRequest
                     {
                         ImpactPoint = info.ImpactPoint,

--- a/workers/unity/Assets/Playground/Scripts/Player/ProcessLaunchCommandSystem.cs
+++ b/workers/unity/Assets/Playground/Scripts/Player/ProcessLaunchCommandSystem.cs
@@ -62,11 +62,13 @@ namespace Playground
                 {
                     var info = requests[j].RawRequest;
                     var energy = math.min(info.LaunchEnergy, energyLeft);
+
                     sender.RequestsToSend.Add(new Launchable.LaunchMe.Request(info.EntityToLaunch, new Generated.Playground.LaunchMeCommandRequest
                     {
                         ImpactPoint = info.ImpactPoint,
                         LaunchDirection = info.LaunchDirection,
-                        LaunchEnergy = energy
+                        LaunchEnergy = energy,
+                        Player = info.Player
                     }));
                     energyLeft -= energy;
                     j++;


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Scoring in Playground was broken because player ID was not being passed. This has been fixed by putting the player IDs into the relevant requests again.