### PR TITLE
Feature/nicer command related names

### DIFF
--- a/docs/content/ecs/commands.md
+++ b/docs/content/ecs/commands.md
@@ -155,7 +155,7 @@ The ECS entity that sent the request receives the response.
 Here's an example of receiving a command response, using the same schema as above:
 
 ```csharp
-public class BuildWallResponseHandler : ComponentSystem
+public class BuildWallResponseReceiver : ComponentSystem
 {
     public struct Data
     {

--- a/test-project/Assets/EditmodeTests/GameObjectRepresentation/CommandSenders/CommandRequestHandlerTests.cs
+++ b/test-project/Assets/EditmodeTests/GameObjectRepresentation/CommandSenders/CommandRequestHandlerTests.cs
@@ -6,7 +6,7 @@ using Unity.Entities;
 namespace Improbable.Gdk.EditmodeTests.GameObjectRepresentation.CommandSenders
 {
     [TestFixture]
-    public class CommandRequestHandlerTests
+    public class CommandRequestReceiverTests
     {
         [Test]
         public void SendResponse_queues_responses()

--- a/test-project/Assets/EditmodeTests/GameObjectRepresentation/CommandSenders/CommandRequestHandlerTests.cs
+++ b/test-project/Assets/EditmodeTests/GameObjectRepresentation/CommandSenders/CommandRequestHandlerTests.cs
@@ -26,10 +26,10 @@ namespace Improbable.Gdk.EditmodeTests.GameObjectRepresentation.CommandSenders
 
                 var receivedRequest = new ComponentWithNoFieldsWithCommands.Cmd.ReceivedRequest();
 
-                var cmdRequestResponder =
-                    new ComponentWithNoFieldsWithCommands.Cmd.RequestResponder(entityManager, entity, receivedRequest);
+                var cmdResponseSender =
+                    new ComponentWithNoFieldsWithCommands.Cmd.ResponseSender(entityManager, entity, receivedRequest);
 
-                cmdRequestResponder.SendResponse(new Empty());
+                cmdResponseSender.SendResponse(new Empty());
 
                 var componentData =
                     entityManager.GetComponentData<ComponentWithNoFieldsWithCommands.CommandResponders.Cmd>(entity);

--- a/test-project/Assets/EditmodeTests/GameObjectRepresentation/CommandSenders/CommandResponseHandlerTests.cs
+++ b/test-project/Assets/EditmodeTests/GameObjectRepresentation/CommandSenders/CommandResponseHandlerTests.cs
@@ -8,7 +8,7 @@ using Unity.Entities;
 namespace Improbable.Gdk.EditmodeTests.GameObjectRepresentation.CommandSenders
 {
     [TestFixture]
-    public class CommandResponseHandlerTests
+    public class CommandResponseReceiverTests
     {
         [Test]
         public void OnCmdResponseInternal_calls_OnCmdResponse_delegates()
@@ -18,15 +18,15 @@ namespace Improbable.Gdk.EditmodeTests.GameObjectRepresentation.CommandSenders
                 var entityManager = world.GetOrCreateManager<EntityManager>();
                 var entity = entityManager.CreateEntity();
 
-                var commandResponseHandler =
-                    new ComponentWithNoFieldsWithCommands.Requirable.CommandResponseHandler(entity, entityManager,
+                var commandResponseReceiver =
+                    new ComponentWithNoFieldsWithCommands.Requirable.CommandResponseReceiver(entity, entityManager,
                         new LoggingDispatcher());
 
                 var responseCallbackCalled = false;
 
-                commandResponseHandler.OnCmdResponse += response => { responseCallbackCalled = true; };
+                commandResponseReceiver.OnCmdResponse += response => { responseCallbackCalled = true; };
 
-                commandResponseHandler.OnCmdResponseInternal(
+                commandResponseReceiver.OnCmdResponseInternal(
                     new ComponentWithNoFieldsWithCommands.Cmd.ReceivedResponse(
                         new EntityId(0),
                         string.Empty,

--- a/test-project/Assets/EditmodeTests/GameObjectRepresentation/MonoBehaviourActivationManager/CommandHandlerBehaviourActivationTests.cs
+++ b/test-project/Assets/EditmodeTests/GameObjectRepresentation/MonoBehaviourActivationManager/CommandHandlerBehaviourActivationTests.cs
@@ -14,12 +14,12 @@ namespace Improbable.Gdk.EditmodeTests.GameObjectRepresentation.MonoBehaviourAct
 
         public class TestBehaviourWithCommandHandlers : MonoBehaviour
         {
-            [Require] public ComponentWithNoFieldsWithCommands.Requirable.CommandRequestHandler CommandRequestHandler;
+            [Require] public ComponentWithNoFieldsWithCommands.Requirable.CommandRequestReceiver CommandRequestReceiver;
         }
 
         protected override void ValidateRequirablesNotNull()
         {
-            Assert.IsNotNull(TestGameObject.GetComponent<TestBehaviourWithCommandHandlers>().CommandRequestHandler);
+            Assert.IsNotNull(TestGameObject.GetComponent<TestBehaviourWithCommandHandlers>().CommandRequestReceiver);
         }
     }
 }

--- a/test-project/Assets/EditmodeTests/GameObjectRepresentation/MonoBehaviourActivationManager/RequestSenderBehaviourActivationTests.cs
+++ b/test-project/Assets/EditmodeTests/GameObjectRepresentation/MonoBehaviourActivationManager/RequestSenderBehaviourActivationTests.cs
@@ -16,10 +16,10 @@ namespace Improbable.Gdk.EditmodeTests.GameObjectRepresentation.MonoBehaviourAct
         {
             [Require] public ComponentWithNoFieldsWithCommands.Requirable.CommandRequestSender CommandRequestSender;
 
-            [Require] public ComponentWithNoFieldsWithCommands.Requirable.CommandResponseHandler CommandResponseHandler;
+            [Require] public ComponentWithNoFieldsWithCommands.Requirable.CommandResponseReceiver CommandResponseReceiver;
 
             [Require] public WorldCommands.Requirable.WorldCommandRequestSender WorldCommandRequestSender;
-            [Require] public WorldCommands.Requirable.WorldCommandResponseHandler WorldCommandResponseHandler;
+            [Require] public WorldCommands.Requirable.WorldCommandResponseReceiver WorldCommandResponseReceiver;
         }
 
         protected override void PopulateBehaviours()
@@ -31,9 +31,9 @@ namespace Improbable.Gdk.EditmodeTests.GameObjectRepresentation.MonoBehaviourAct
         {
             var testBehaviour = TestGameObject.GetComponent<TestBehaviourWithCommandSender>();
             Assert.IsNotNull(testBehaviour.CommandRequestSender);
-            Assert.IsNotNull(testBehaviour.CommandResponseHandler);
+            Assert.IsNotNull(testBehaviour.CommandResponseReceiver);
             Assert.IsNotNull(testBehaviour.WorldCommandRequestSender);
-            Assert.IsNotNull(testBehaviour.WorldCommandResponseHandler);
+            Assert.IsNotNull(testBehaviour.WorldCommandResponseReceiver);
         }
 
         [Test]

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentGameObjectComponentDispatcher.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentGameObjectComponentDispatcher.cs
@@ -70,7 +70,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
             private const uint componentId = 1001;
             private static readonly InjectableId readerWriterInjectableId = new InjectableId(InjectableType.ReaderWriter, componentId);
             private static readonly InjectableId commandRequestReceiverInjectableId = new InjectableId(InjectableType.CommandRequestReceiver, componentId);
-            private static readonly InjectableId commandResponseHandlerInjectableId = new InjectableId(InjectableType.CommandResponseHandler, componentId);
+            private static readonly InjectableId commandResponseReceiverInjectableId = new InjectableId(InjectableType.CommandResponseReceiver, componentId);
 
             public override void MarkComponentsAddedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityToManagers)
             {
@@ -300,17 +300,17 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                     for (var i = 0; i < entities.Length; i++)
                     {
                         var injectableStore = entityToInjectableStore[entities[i]];
-                        if (!injectableStore.TryGetInjectablesForComponent(commandResponseHandlerInjectableId, out var commandResponseHandlers))
+                        if (!injectableStore.TryGetInjectablesForComponent(commandResponseReceiverInjectableId, out var commandResponseReceivers))
                         {
                             continue;
                         }
 
                         var commandResponseList = commandResponseLists[i];
-                        foreach (Requirable.CommandResponseHandler commandResponseHandler in commandResponseHandlers)
+                        foreach (Requirable.CommandResponseReceiver commandResponseReceiver in commandResponseReceivers)
                         {
                             foreach (var commandResponse in commandResponseList.Responses)
                             {
-                                commandResponseHandler.OnFirstCommandResponseInternal(commandResponse);
+                                commandResponseReceiver.OnFirstCommandResponseInternal(commandResponse);
                             }
                         }
                     }
@@ -323,17 +323,17 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                     for (var i = 0; i < entities.Length; i++)
                     {
                         var injectableStore = entityToInjectableStore[entities[i]];
-                        if (!injectableStore.TryGetInjectablesForComponent(commandResponseHandlerInjectableId, out var commandResponseHandlers))
+                        if (!injectableStore.TryGetInjectablesForComponent(commandResponseReceiverInjectableId, out var commandResponseReceivers))
                         {
                             continue;
                         }
 
                         var commandResponseList = commandResponseLists[i];
-                        foreach (Requirable.CommandResponseHandler commandResponseHandler in commandResponseHandlers)
+                        foreach (Requirable.CommandResponseReceiver commandResponseReceiver in commandResponseReceivers)
                         {
                             foreach (var commandResponse in commandResponseList.Responses)
                             {
-                                commandResponseHandler.OnSecondCommandResponseInternal(commandResponse);
+                                commandResponseReceiver.OnSecondCommandResponseInternal(commandResponse);
                             }
                         }
                     }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentGameObjectComponentDispatcher.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentGameObjectComponentDispatcher.cs
@@ -69,7 +69,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
 
             private const uint componentId = 1001;
             private static readonly InjectableId readerWriterInjectableId = new InjectableId(InjectableType.ReaderWriter, componentId);
-            private static readonly InjectableId commandRequestHandlerInjectableId = new InjectableId(InjectableType.CommandRequestHandler, componentId);
+            private static readonly InjectableId commandRequestReceiverInjectableId = new InjectableId(InjectableType.CommandRequestReceiver, componentId);
             private static readonly InjectableId commandResponseHandlerInjectableId = new InjectableId(InjectableType.CommandResponseHandler, componentId);
 
             public override void MarkComponentsAddedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityToManagers)
@@ -247,17 +247,17 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                     for (var i = 0; i < entities.Length; i++)
                     {
                         var injectableStore = entityToInjectableStore[entities[i]];
-                        if (!injectableStore.TryGetInjectablesForComponent(commandRequestHandlerInjectableId, out var commandRequestHandlers))
+                        if (!injectableStore.TryGetInjectablesForComponent(commandRequestReceiverInjectableId, out var commandRequestReceivers))
                         {
                             continue;
                         }
 
                         var commandRequestList = commandRequestLists[i];
-                        foreach (Requirable.CommandRequestHandler commandRequestHandler in commandRequestHandlers)
+                        foreach (Requirable.CommandRequestReceiver commandRequestReceiver in commandRequestReceivers)
                         {
                             foreach (var commandRequest in commandRequestList.Requests)
                             {
-                                commandRequestHandler.OnFirstCommandRequestInternal(commandRequest);
+                                commandRequestReceiver.OnFirstCommandRequestInternal(commandRequest);
                             }
                         }
                     }
@@ -270,17 +270,17 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                     for (var i = 0; i < entities.Length; i++)
                     {
                         var injectableStore = entityToInjectableStore[entities[i]];
-                        if (!injectableStore.TryGetInjectablesForComponent(commandRequestHandlerInjectableId, out var commandRequestHandlers))
+                        if (!injectableStore.TryGetInjectablesForComponent(commandRequestReceiverInjectableId, out var commandRequestReceivers))
                         {
                             continue;
                         }
 
                         var commandRequestList = commandRequestLists[i];
-                        foreach (Requirable.CommandRequestHandler commandRequestHandler in commandRequestHandlers)
+                        foreach (Requirable.CommandRequestReceiver commandRequestReceiver in commandRequestReceivers)
                         {
                             foreach (var commandRequest in commandRequestList.Requests)
                             {
-                                commandRequestHandler.OnSecondCommandRequestInternal(commandRequest);
+                                commandRequestReceiver.OnSecondCommandRequestInternal(commandRequest);
                             }
                         }
                     }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentMonoBehaviourCommandHandlers.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentMonoBehaviourCommandHandlers.cs
@@ -18,13 +18,13 @@ namespace Improbable.Gdk.Tests.BlittableTypes
     {
         public partial class FirstCommand
         {
-            public struct RequestResponder
+            public struct ResponseSender
             {
                 private readonly EntityManager entityManager;
                 private readonly Entity entity;
                 public FirstCommand.ReceivedRequest Request { get; }
 
-                internal RequestResponder(EntityManager entityManager, Entity entity, FirstCommand.ReceivedRequest request)
+                internal ResponseSender(EntityManager entityManager, Entity entity, FirstCommand.ReceivedRequest request)
                 {
                     this.entity = entity;
                     this.entityManager = entityManager;
@@ -47,13 +47,13 @@ namespace Improbable.Gdk.Tests.BlittableTypes
 
         public partial class SecondCommand
         {
-            public struct RequestResponder
+            public struct ResponseSender
             {
                 private readonly EntityManager entityManager;
                 private readonly Entity entity;
                 public SecondCommand.ReceivedRequest Request { get; }
 
-                internal RequestResponder(EntityManager entityManager, Entity entity, SecondCommand.ReceivedRequest request)
+                internal ResponseSender(EntityManager entityManager, Entity entity, SecondCommand.ReceivedRequest request)
                 {
                     this.entity = entity;
                     this.entityManager = entityManager;
@@ -153,8 +153,8 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                     this.entityManager = entityManager;
                     this.logger = logger;
                 }
-                private readonly List<Action<FirstCommand.RequestResponder>> firstCommandDelegates = new List<Action<FirstCommand.RequestResponder>>();
-                public event Action<FirstCommand.RequestResponder> OnFirstCommandRequest
+                private readonly List<Action<FirstCommand.ResponseSender>> firstCommandDelegates = new List<Action<FirstCommand.ResponseSender>>();
+                public event Action<FirstCommand.ResponseSender> OnFirstCommandRequest
                 {
                     add
                     {
@@ -178,10 +178,10 @@ namespace Improbable.Gdk.Tests.BlittableTypes
 
                 internal void OnFirstCommandRequestInternal(FirstCommand.ReceivedRequest request)
                 {
-                    GameObjectDelegates.DispatchWithErrorHandling(new FirstCommand.RequestResponder(entityManager, entity, request), firstCommandDelegates, logger);
+                    GameObjectDelegates.DispatchWithErrorHandling(new FirstCommand.ResponseSender(entityManager, entity, request), firstCommandDelegates, logger);
                 }
-                private readonly List<Action<SecondCommand.RequestResponder>> secondCommandDelegates = new List<Action<SecondCommand.RequestResponder>>();
-                public event Action<SecondCommand.RequestResponder> OnSecondCommandRequest
+                private readonly List<Action<SecondCommand.ResponseSender>> secondCommandDelegates = new List<Action<SecondCommand.ResponseSender>>();
+                public event Action<SecondCommand.ResponseSender> OnSecondCommandRequest
                 {
                     add
                     {
@@ -205,7 +205,7 @@ namespace Improbable.Gdk.Tests.BlittableTypes
 
                 internal void OnSecondCommandRequestInternal(SecondCommand.ReceivedRequest request)
                 {
-                    GameObjectDelegates.DispatchWithErrorHandling(new SecondCommand.RequestResponder(entityManager, entity, request), secondCommandDelegates, logger);
+                    GameObjectDelegates.DispatchWithErrorHandling(new SecondCommand.ResponseSender(entityManager, entity, request), secondCommandDelegates, logger);
                 }
             }
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentMonoBehaviourCommandHandlers.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentMonoBehaviourCommandHandlers.cs
@@ -209,24 +209,24 @@ namespace Improbable.Gdk.Tests.BlittableTypes
                 }
             }
 
-            [InjectableId(InjectableType.CommandResponseHandler, 1001)]
-            internal class CommandResponseHandlerCreator : IInjectableCreator
+            [InjectableId(InjectableType.CommandResponseReceiver, 1001)]
+            internal class CommandResponseReceiverCreator : IInjectableCreator
             {
                 public IInjectable CreateInjectable(Entity entity, EntityManager entityManager, ILogDispatcher logDispatcher)
                 {
-                    return new CommandResponseHandler(entity, entityManager, logDispatcher);
+                    return new CommandResponseReceiver(entity, entityManager, logDispatcher);
                 }
             }
 
-            [InjectableId(InjectableType.CommandResponseHandler, 1001)]
+            [InjectableId(InjectableType.CommandResponseReceiver, 1001)]
             [InjectionCondition(InjectionCondition.RequireNothing)]
-            public class CommandResponseHandler : RequirableBase
+            public class CommandResponseReceiver : RequirableBase
             {
                 private Entity entity;
                 private readonly EntityManager entityManager;
                 private readonly ILogDispatcher logger;
 
-                public CommandResponseHandler(Entity entity, EntityManager entityManager, ILogDispatcher logger) : base(logger)
+                public CommandResponseReceiver(Entity entity, EntityManager entityManager, ILogDispatcher logger) : base(logger)
                 {
                     this.entity = entity;
                     this.entityManager = entityManager;

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentMonoBehaviourCommandHandlers.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/blittabletypes/BlittableComponentMonoBehaviourCommandHandlers.cs
@@ -130,24 +130,24 @@ namespace Improbable.Gdk.Tests.BlittableTypes
 
             }
 
-            [InjectableId(InjectableType.CommandRequestHandler, 1001)]
-            internal class CommandRequestHandlerCreator : IInjectableCreator
+            [InjectableId(InjectableType.CommandRequestReceiver, 1001)]
+            internal class CommandRequestReceiverCreator : IInjectableCreator
             {
                 public IInjectable CreateInjectable(Entity entity, EntityManager entityManager, ILogDispatcher logDispatcher)
                 {
-                    return new CommandRequestHandler(entity, entityManager, logDispatcher);
+                    return new CommandRequestReceiver(entity, entityManager, logDispatcher);
                 }
             }
 
-            [InjectableId(InjectableType.CommandRequestHandler, 1001)]
+            [InjectableId(InjectableType.CommandRequestReceiver, 1001)]
             [InjectionCondition(InjectionCondition.RequireComponentWithAuthority)]
-            public class CommandRequestHandler : RequirableBase
+            public class CommandRequestReceiver : RequirableBase
             {
                 private Entity entity;
                 private readonly EntityManager entityManager;
                 private readonly ILogDispatcher logger;
 
-                public CommandRequestHandler(Entity entity, EntityManager entityManager, ILogDispatcher logger) : base(logger)
+                public CommandRequestReceiver(Entity entity, EntityManager entityManager, ILogDispatcher logger) : base(logger)
                 {
                     this.entity = entity;
                     this.entityManager = entityManager;

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsGameObjectComponentDispatcher.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsGameObjectComponentDispatcher.cs
@@ -65,7 +65,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
             private const uint componentId = 1005;
             private static readonly InjectableId readerWriterInjectableId = new InjectableId(InjectableType.ReaderWriter, componentId);
             private static readonly InjectableId commandRequestReceiverInjectableId = new InjectableId(InjectableType.CommandRequestReceiver, componentId);
-            private static readonly InjectableId commandResponseHandlerInjectableId = new InjectableId(InjectableType.CommandResponseHandler, componentId);
+            private static readonly InjectableId commandResponseReceiverInjectableId = new InjectableId(InjectableType.CommandResponseReceiver, componentId);
 
             public override void MarkComponentsAddedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityToManagers)
             {
@@ -197,17 +197,17 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                     for (var i = 0; i < entities.Length; i++)
                     {
                         var injectableStore = entityToInjectableStore[entities[i]];
-                        if (!injectableStore.TryGetInjectablesForComponent(commandResponseHandlerInjectableId, out var commandResponseHandlers))
+                        if (!injectableStore.TryGetInjectablesForComponent(commandResponseReceiverInjectableId, out var commandResponseReceivers))
                         {
                             continue;
                         }
 
                         var commandResponseList = commandResponseLists[i];
-                        foreach (Requirable.CommandResponseHandler commandResponseHandler in commandResponseHandlers)
+                        foreach (Requirable.CommandResponseReceiver commandResponseReceiver in commandResponseReceivers)
                         {
                             foreach (var commandResponse in commandResponseList.Responses)
                             {
-                                commandResponseHandler.OnCmdResponseInternal(commandResponse);
+                                commandResponseReceiver.OnCmdResponseInternal(commandResponse);
                             }
                         }
                     }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsGameObjectComponentDispatcher.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsGameObjectComponentDispatcher.cs
@@ -64,7 +64,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
 
             private const uint componentId = 1005;
             private static readonly InjectableId readerWriterInjectableId = new InjectableId(InjectableType.ReaderWriter, componentId);
-            private static readonly InjectableId commandRequestHandlerInjectableId = new InjectableId(InjectableType.CommandRequestHandler, componentId);
+            private static readonly InjectableId commandRequestReceiverInjectableId = new InjectableId(InjectableType.CommandRequestReceiver, componentId);
             private static readonly InjectableId commandResponseHandlerInjectableId = new InjectableId(InjectableType.CommandResponseHandler, componentId);
 
             public override void MarkComponentsAddedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityToManagers)
@@ -167,17 +167,17 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                     for (var i = 0; i < entities.Length; i++)
                     {
                         var injectableStore = entityToInjectableStore[entities[i]];
-                        if (!injectableStore.TryGetInjectablesForComponent(commandRequestHandlerInjectableId, out var commandRequestHandlers))
+                        if (!injectableStore.TryGetInjectablesForComponent(commandRequestReceiverInjectableId, out var commandRequestReceivers))
                         {
                             continue;
                         }
 
                         var commandRequestList = commandRequestLists[i];
-                        foreach (Requirable.CommandRequestHandler commandRequestHandler in commandRequestHandlers)
+                        foreach (Requirable.CommandRequestReceiver commandRequestReceiver in commandRequestReceivers)
                         {
                             foreach (var commandRequest in commandRequestList.Requests)
                             {
-                                commandRequestHandler.OnCmdRequestInternal(commandRequest);
+                                commandRequestReceiver.OnCmdRequestInternal(commandRequest);
                             }
                         }
                     }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsMonoBehaviourCommandHandlers.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsMonoBehaviourCommandHandlers.cs
@@ -139,24 +139,24 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                 }
             }
 
-            [InjectableId(InjectableType.CommandResponseHandler, 1005)]
-            internal class CommandResponseHandlerCreator : IInjectableCreator
+            [InjectableId(InjectableType.CommandResponseReceiver, 1005)]
+            internal class CommandResponseReceiverCreator : IInjectableCreator
             {
                 public IInjectable CreateInjectable(Entity entity, EntityManager entityManager, ILogDispatcher logDispatcher)
                 {
-                    return new CommandResponseHandler(entity, entityManager, logDispatcher);
+                    return new CommandResponseReceiver(entity, entityManager, logDispatcher);
                 }
             }
 
-            [InjectableId(InjectableType.CommandResponseHandler, 1005)]
+            [InjectableId(InjectableType.CommandResponseReceiver, 1005)]
             [InjectionCondition(InjectionCondition.RequireNothing)]
-            public class CommandResponseHandler : RequirableBase
+            public class CommandResponseReceiver : RequirableBase
             {
                 private Entity entity;
                 private readonly EntityManager entityManager;
                 private readonly ILogDispatcher logger;
 
-                public CommandResponseHandler(Entity entity, EntityManager entityManager, ILogDispatcher logger) : base(logger)
+                public CommandResponseReceiver(Entity entity, EntityManager entityManager, ILogDispatcher logger) : base(logger)
                 {
                     this.entity = entity;
                     this.entityManager = entityManager;

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsMonoBehaviourCommandHandlers.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsMonoBehaviourCommandHandlers.cs
@@ -87,24 +87,24 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
 
             }
 
-            [InjectableId(InjectableType.CommandRequestHandler, 1005)]
-            internal class CommandRequestHandlerCreator : IInjectableCreator
+            [InjectableId(InjectableType.CommandRequestReceiver, 1005)]
+            internal class CommandRequestReceiverCreator : IInjectableCreator
             {
                 public IInjectable CreateInjectable(Entity entity, EntityManager entityManager, ILogDispatcher logDispatcher)
                 {
-                    return new CommandRequestHandler(entity, entityManager, logDispatcher);
+                    return new CommandRequestReceiver(entity, entityManager, logDispatcher);
                 }
             }
 
-            [InjectableId(InjectableType.CommandRequestHandler, 1005)]
+            [InjectableId(InjectableType.CommandRequestReceiver, 1005)]
             [InjectionCondition(InjectionCondition.RequireComponentWithAuthority)]
-            public class CommandRequestHandler : RequirableBase
+            public class CommandRequestReceiver : RequirableBase
             {
                 private Entity entity;
                 private readonly EntityManager entityManager;
                 private readonly ILogDispatcher logger;
 
-                public CommandRequestHandler(Entity entity, EntityManager entityManager, ILogDispatcher logger) : base(logger)
+                public CommandRequestReceiver(Entity entity, EntityManager entityManager, ILogDispatcher logger) : base(logger)
                 {
                     this.entity = entity;
                     this.entityManager = entityManager;

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsMonoBehaviourCommandHandlers.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/componentswithnofields/ComponentWithNoFieldsWithCommandsMonoBehaviourCommandHandlers.cs
@@ -18,13 +18,13 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
     {
         public partial class Cmd
         {
-            public struct RequestResponder
+            public struct ResponseSender
             {
                 private readonly EntityManager entityManager;
                 private readonly Entity entity;
                 public Cmd.ReceivedRequest Request { get; }
 
-                internal RequestResponder(EntityManager entityManager, Entity entity, Cmd.ReceivedRequest request)
+                internal ResponseSender(EntityManager entityManager, Entity entity, Cmd.ReceivedRequest request)
                 {
                     this.entity = entity;
                     this.entityManager = entityManager;
@@ -110,8 +110,8 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
                     this.entityManager = entityManager;
                     this.logger = logger;
                 }
-                private readonly List<Action<Cmd.RequestResponder>> cmdDelegates = new List<Action<Cmd.RequestResponder>>();
-                public event Action<Cmd.RequestResponder> OnCmdRequest
+                private readonly List<Action<Cmd.ResponseSender>> cmdDelegates = new List<Action<Cmd.ResponseSender>>();
+                public event Action<Cmd.ResponseSender> OnCmdRequest
                 {
                     add
                     {
@@ -135,7 +135,7 @@ namespace Improbable.Gdk.Tests.ComponentsWithNoFields
 
                 internal void OnCmdRequestInternal(Cmd.ReceivedRequest request)
                 {
-                    GameObjectDelegates.DispatchWithErrorHandling(new Cmd.RequestResponder(entityManager, entity, request), cmdDelegates, logger);
+                    GameObjectDelegates.DispatchWithErrorHandling(new Cmd.ResponseSender(entityManager, entity, request), cmdDelegates, logger);
                 }
             }
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentGameObjectComponentDispatcher.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentGameObjectComponentDispatcher.cs
@@ -70,7 +70,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
             private const uint componentId = 1002;
             private static readonly InjectableId readerWriterInjectableId = new InjectableId(InjectableType.ReaderWriter, componentId);
             private static readonly InjectableId commandRequestReceiverInjectableId = new InjectableId(InjectableType.CommandRequestReceiver, componentId);
-            private static readonly InjectableId commandResponseHandlerInjectableId = new InjectableId(InjectableType.CommandResponseHandler, componentId);
+            private static readonly InjectableId commandResponseReceiverInjectableId = new InjectableId(InjectableType.CommandResponseReceiver, componentId);
 
             public override void MarkComponentsAddedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityToManagers)
             {
@@ -300,17 +300,17 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                     for (var i = 0; i < entities.Length; i++)
                     {
                         var injectableStore = entityToInjectableStore[entities[i]];
-                        if (!injectableStore.TryGetInjectablesForComponent(commandResponseHandlerInjectableId, out var commandResponseHandlers))
+                        if (!injectableStore.TryGetInjectablesForComponent(commandResponseReceiverInjectableId, out var commandResponseReceivers))
                         {
                             continue;
                         }
 
                         var commandResponseList = commandResponseLists[i];
-                        foreach (Requirable.CommandResponseHandler commandResponseHandler in commandResponseHandlers)
+                        foreach (Requirable.CommandResponseReceiver commandResponseReceiver in commandResponseReceivers)
                         {
                             foreach (var commandResponse in commandResponseList.Responses)
                             {
-                                commandResponseHandler.OnFirstCommandResponseInternal(commandResponse);
+                                commandResponseReceiver.OnFirstCommandResponseInternal(commandResponse);
                             }
                         }
                     }
@@ -323,17 +323,17 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                     for (var i = 0; i < entities.Length; i++)
                     {
                         var injectableStore = entityToInjectableStore[entities[i]];
-                        if (!injectableStore.TryGetInjectablesForComponent(commandResponseHandlerInjectableId, out var commandResponseHandlers))
+                        if (!injectableStore.TryGetInjectablesForComponent(commandResponseReceiverInjectableId, out var commandResponseReceivers))
                         {
                             continue;
                         }
 
                         var commandResponseList = commandResponseLists[i];
-                        foreach (Requirable.CommandResponseHandler commandResponseHandler in commandResponseHandlers)
+                        foreach (Requirable.CommandResponseReceiver commandResponseReceiver in commandResponseReceivers)
                         {
                             foreach (var commandResponse in commandResponseList.Responses)
                             {
-                                commandResponseHandler.OnSecondCommandResponseInternal(commandResponse);
+                                commandResponseReceiver.OnSecondCommandResponseInternal(commandResponse);
                             }
                         }
                     }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentGameObjectComponentDispatcher.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentGameObjectComponentDispatcher.cs
@@ -69,7 +69,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
 
             private const uint componentId = 1002;
             private static readonly InjectableId readerWriterInjectableId = new InjectableId(InjectableType.ReaderWriter, componentId);
-            private static readonly InjectableId commandRequestHandlerInjectableId = new InjectableId(InjectableType.CommandRequestHandler, componentId);
+            private static readonly InjectableId commandRequestReceiverInjectableId = new InjectableId(InjectableType.CommandRequestReceiver, componentId);
             private static readonly InjectableId commandResponseHandlerInjectableId = new InjectableId(InjectableType.CommandResponseHandler, componentId);
 
             public override void MarkComponentsAddedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityToManagers)
@@ -247,17 +247,17 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                     for (var i = 0; i < entities.Length; i++)
                     {
                         var injectableStore = entityToInjectableStore[entities[i]];
-                        if (!injectableStore.TryGetInjectablesForComponent(commandRequestHandlerInjectableId, out var commandRequestHandlers))
+                        if (!injectableStore.TryGetInjectablesForComponent(commandRequestReceiverInjectableId, out var commandRequestReceivers))
                         {
                             continue;
                         }
 
                         var commandRequestList = commandRequestLists[i];
-                        foreach (Requirable.CommandRequestHandler commandRequestHandler in commandRequestHandlers)
+                        foreach (Requirable.CommandRequestReceiver commandRequestReceiver in commandRequestReceivers)
                         {
                             foreach (var commandRequest in commandRequestList.Requests)
                             {
-                                commandRequestHandler.OnFirstCommandRequestInternal(commandRequest);
+                                commandRequestReceiver.OnFirstCommandRequestInternal(commandRequest);
                             }
                         }
                     }
@@ -270,17 +270,17 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                     for (var i = 0; i < entities.Length; i++)
                     {
                         var injectableStore = entityToInjectableStore[entities[i]];
-                        if (!injectableStore.TryGetInjectablesForComponent(commandRequestHandlerInjectableId, out var commandRequestHandlers))
+                        if (!injectableStore.TryGetInjectablesForComponent(commandRequestReceiverInjectableId, out var commandRequestReceivers))
                         {
                             continue;
                         }
 
                         var commandRequestList = commandRequestLists[i];
-                        foreach (Requirable.CommandRequestHandler commandRequestHandler in commandRequestHandlers)
+                        foreach (Requirable.CommandRequestReceiver commandRequestReceiver in commandRequestReceivers)
                         {
                             foreach (var commandRequest in commandRequestList.Requests)
                             {
-                                commandRequestHandler.OnSecondCommandRequestInternal(commandRequest);
+                                commandRequestReceiver.OnSecondCommandRequestInternal(commandRequest);
                             }
                         }
                     }

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentMonoBehaviourCommandHandlers.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentMonoBehaviourCommandHandlers.cs
@@ -130,24 +130,24 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
 
             }
 
-            [InjectableId(InjectableType.CommandRequestHandler, 1002)]
-            internal class CommandRequestHandlerCreator : IInjectableCreator
+            [InjectableId(InjectableType.CommandRequestReceiver, 1002)]
+            internal class CommandRequestReceiverCreator : IInjectableCreator
             {
                 public IInjectable CreateInjectable(Entity entity, EntityManager entityManager, ILogDispatcher logDispatcher)
                 {
-                    return new CommandRequestHandler(entity, entityManager, logDispatcher);
+                    return new CommandRequestReceiver(entity, entityManager, logDispatcher);
                 }
             }
 
-            [InjectableId(InjectableType.CommandRequestHandler, 1002)]
+            [InjectableId(InjectableType.CommandRequestReceiver, 1002)]
             [InjectionCondition(InjectionCondition.RequireComponentWithAuthority)]
-            public class CommandRequestHandler : RequirableBase
+            public class CommandRequestReceiver : RequirableBase
             {
                 private Entity entity;
                 private readonly EntityManager entityManager;
                 private readonly ILogDispatcher logger;
 
-                public CommandRequestHandler(Entity entity, EntityManager entityManager, ILogDispatcher logger) : base(logger)
+                public CommandRequestReceiver(Entity entity, EntityManager entityManager, ILogDispatcher logger) : base(logger)
                 {
                     this.entity = entity;
                     this.entityManager = entityManager;

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentMonoBehaviourCommandHandlers.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentMonoBehaviourCommandHandlers.cs
@@ -18,13 +18,13 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
     {
         public partial class FirstCommand
         {
-            public struct RequestResponder
+            public struct ResponseSender
             {
                 private readonly EntityManager entityManager;
                 private readonly Entity entity;
                 public FirstCommand.ReceivedRequest Request { get; }
 
-                internal RequestResponder(EntityManager entityManager, Entity entity, FirstCommand.ReceivedRequest request)
+                internal ResponseSender(EntityManager entityManager, Entity entity, FirstCommand.ReceivedRequest request)
                 {
                     this.entity = entity;
                     this.entityManager = entityManager;
@@ -47,13 +47,13 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
 
         public partial class SecondCommand
         {
-            public struct RequestResponder
+            public struct ResponseSender
             {
                 private readonly EntityManager entityManager;
                 private readonly Entity entity;
                 public SecondCommand.ReceivedRequest Request { get; }
 
-                internal RequestResponder(EntityManager entityManager, Entity entity, SecondCommand.ReceivedRequest request)
+                internal ResponseSender(EntityManager entityManager, Entity entity, SecondCommand.ReceivedRequest request)
                 {
                     this.entity = entity;
                     this.entityManager = entityManager;
@@ -153,8 +153,8 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                     this.entityManager = entityManager;
                     this.logger = logger;
                 }
-                private readonly List<Action<FirstCommand.RequestResponder>> firstCommandDelegates = new List<Action<FirstCommand.RequestResponder>>();
-                public event Action<FirstCommand.RequestResponder> OnFirstCommandRequest
+                private readonly List<Action<FirstCommand.ResponseSender>> firstCommandDelegates = new List<Action<FirstCommand.ResponseSender>>();
+                public event Action<FirstCommand.ResponseSender> OnFirstCommandRequest
                 {
                     add
                     {
@@ -178,10 +178,10 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
 
                 internal void OnFirstCommandRequestInternal(FirstCommand.ReceivedRequest request)
                 {
-                    GameObjectDelegates.DispatchWithErrorHandling(new FirstCommand.RequestResponder(entityManager, entity, request), firstCommandDelegates, logger);
+                    GameObjectDelegates.DispatchWithErrorHandling(new FirstCommand.ResponseSender(entityManager, entity, request), firstCommandDelegates, logger);
                 }
-                private readonly List<Action<SecondCommand.RequestResponder>> secondCommandDelegates = new List<Action<SecondCommand.RequestResponder>>();
-                public event Action<SecondCommand.RequestResponder> OnSecondCommandRequest
+                private readonly List<Action<SecondCommand.ResponseSender>> secondCommandDelegates = new List<Action<SecondCommand.ResponseSender>>();
+                public event Action<SecondCommand.ResponseSender> OnSecondCommandRequest
                 {
                     add
                     {
@@ -205,7 +205,7 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
 
                 internal void OnSecondCommandRequestInternal(SecondCommand.ReceivedRequest request)
                 {
-                    GameObjectDelegates.DispatchWithErrorHandling(new SecondCommand.RequestResponder(entityManager, entity, request), secondCommandDelegates, logger);
+                    GameObjectDelegates.DispatchWithErrorHandling(new SecondCommand.ResponseSender(entityManager, entity, request), secondCommandDelegates, logger);
                 }
             }
 

--- a/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentMonoBehaviourCommandHandlers.cs
+++ b/test-project/Assets/Generated/Source/improbable/gdk/tests/nonblittabletypes/NonBlittableComponentMonoBehaviourCommandHandlers.cs
@@ -209,24 +209,24 @@ namespace Improbable.Gdk.Tests.NonblittableTypes
                 }
             }
 
-            [InjectableId(InjectableType.CommandResponseHandler, 1002)]
-            internal class CommandResponseHandlerCreator : IInjectableCreator
+            [InjectableId(InjectableType.CommandResponseReceiver, 1002)]
+            internal class CommandResponseReceiverCreator : IInjectableCreator
             {
                 public IInjectable CreateInjectable(Entity entity, EntityManager entityManager, ILogDispatcher logDispatcher)
                 {
-                    return new CommandResponseHandler(entity, entityManager, logDispatcher);
+                    return new CommandResponseReceiver(entity, entityManager, logDispatcher);
                 }
             }
 
-            [InjectableId(InjectableType.CommandResponseHandler, 1002)]
+            [InjectableId(InjectableType.CommandResponseReceiver, 1002)]
             [InjectionCondition(InjectionCondition.RequireNothing)]
-            public class CommandResponseHandler : RequirableBase
+            public class CommandResponseReceiver : RequirableBase
             {
                 private Entity entity;
                 private readonly EntityManager entityManager;
                 private readonly ILogDispatcher logger;
 
-                public CommandResponseHandler(Entity entity, EntityManager entityManager, ILogDispatcher logger) : base(logger)
+                public CommandResponseReceiver(Entity entity, EntityManager entityManager, ILogDispatcher logger) : base(logger)
                 {
                     this.entity = entity;
                     this.entityManager = entityManager;

--- a/workers/unity/Assets/Playground/Scripts/MonoBehaviours/CubeSpawnerInputBehaviour.cs
+++ b/workers/unity/Assets/Playground/Scripts/MonoBehaviours/CubeSpawnerInputBehaviour.cs
@@ -19,7 +19,7 @@ namespace Playground.MonoBehaviours
         [Require] private PlayerInput.Requirable.Writer playerInputWriter;
         [Require] private CubeSpawner.Requirable.Reader cubeSpawnerReader;
         [Require] private CubeSpawner.Requirable.CommandRequestSender cubeSpawnerCommandSender;
-        [Require] private CubeSpawner.Requirable.CommandResponseHandler cubeSpawnerCommandResponseHandler;
+        [Require] private CubeSpawner.Requirable.CommandResponseReceiver cubeSpawnerCommandResponseReceiver;
 
         private ILogDispatcher logDispatcher;
         private EntityId ownEntityId;
@@ -30,8 +30,8 @@ namespace Playground.MonoBehaviours
             logDispatcher = spatialOSComponent.Worker.LogDispatcher;
             ownEntityId = spatialOSComponent.SpatialEntityId;
 
-            cubeSpawnerCommandResponseHandler.OnSpawnCubeResponse += OnSpawnCubeResponse;
-            cubeSpawnerCommandResponseHandler.OnDeleteSpawnedCubeResponse += OnDeleteSpawnedCubeResponse;
+            cubeSpawnerCommandResponseReceiver.OnSpawnCubeResponse += OnSpawnCubeResponse;
+            cubeSpawnerCommandResponseReceiver.OnDeleteSpawnedCubeResponse += OnDeleteSpawnedCubeResponse;
         }
 
         private void OnSpawnCubeResponse(CubeSpawner.SpawnCube.ReceivedResponse response)

--- a/workers/unity/Assets/Playground/Scripts/MonoBehaviours/DeleteCubeCommandReceiver.cs
+++ b/workers/unity/Assets/Playground/Scripts/MonoBehaviours/DeleteCubeCommandReceiver.cs
@@ -32,18 +32,18 @@ namespace Playground.MonoBehaviours
             worldCommandResponseHandler.OnDeleteEntityResponse += OnDeleteEntityResponse;
         }
 
-        private void OnDeleteSpawnedCubeRequest(CubeSpawner.DeleteSpawnedCube.RequestResponder requestResponder)
+        private void OnDeleteSpawnedCubeRequest(CubeSpawner.DeleteSpawnedCube.ResponseSender responseSender)
         {
-            var entityId = requestResponder.Request.Payload.CubeEntityId;
+            var entityId = responseSender.Request.Payload.CubeEntityId;
             var spawnedCubes = cubeSpawnerWriter.Data.SpawnedCubes;
 
             if (!spawnedCubes.Contains(entityId))
             {
-                requestResponder.SendResponseFailure($"Requested entity id {entityId} not found in list.");
+                responseSender.SendResponseFailure($"Requested entity id {entityId} not found in list.");
             }
             else
             {
-                requestResponder.SendResponse(new Empty());
+                responseSender.SendResponse(new Empty());
             }
 
             worldCommandRequestSender.DeleteEntity(entityId, context: this);

--- a/workers/unity/Assets/Playground/Scripts/MonoBehaviours/DeleteCubeCommandReceiver.cs
+++ b/workers/unity/Assets/Playground/Scripts/MonoBehaviours/DeleteCubeCommandReceiver.cs
@@ -21,7 +21,7 @@ namespace Playground.MonoBehaviours
         [Require] private CubeSpawner.Requirable.Writer cubeSpawnerWriter;
         [Require] private CubeSpawner.Requirable.CommandRequestReceiver cubeSpawnerCommandRequestReceiver;
         [Require] private WorldCommands.Requirable.WorldCommandRequestSender worldCommandRequestSender;
-        [Require] private WorldCommands.Requirable.WorldCommandResponseHandler worldCommandResponseHandler;
+        [Require] private WorldCommands.Requirable.WorldCommandResponseReceiver worldCommandResponseReceiver;
 
         private ILogDispatcher logDispatcher;
 
@@ -29,7 +29,7 @@ namespace Playground.MonoBehaviours
         {
             logDispatcher = GetComponent<SpatialOSComponent>().Worker.LogDispatcher;
             cubeSpawnerCommandRequestReceiver.OnDeleteSpawnedCubeRequest += OnDeleteSpawnedCubeRequest;
-            worldCommandResponseHandler.OnDeleteEntityResponse += OnDeleteEntityResponse;
+            worldCommandResponseReceiver.OnDeleteEntityResponse += OnDeleteEntityResponse;
         }
 
         private void OnDeleteSpawnedCubeRequest(CubeSpawner.DeleteSpawnedCube.ResponseSender responseSender)

--- a/workers/unity/Assets/Playground/Scripts/MonoBehaviours/DeleteCubeCommandReceiver.cs
+++ b/workers/unity/Assets/Playground/Scripts/MonoBehaviours/DeleteCubeCommandReceiver.cs
@@ -19,7 +19,7 @@ namespace Playground.MonoBehaviours
     public class DeleteCubeCommandReceiver : MonoBehaviour
     {
         [Require] private CubeSpawner.Requirable.Writer cubeSpawnerWriter;
-        [Require] private CubeSpawner.Requirable.CommandRequestHandler cubeSpawnerCommandRequestHandler;
+        [Require] private CubeSpawner.Requirable.CommandRequestReceiver cubeSpawnerCommandRequestReceiver;
         [Require] private WorldCommands.Requirable.WorldCommandRequestSender worldCommandRequestSender;
         [Require] private WorldCommands.Requirable.WorldCommandResponseHandler worldCommandResponseHandler;
 
@@ -28,7 +28,7 @@ namespace Playground.MonoBehaviours
         public void OnEnable()
         {
             logDispatcher = GetComponent<SpatialOSComponent>().Worker.LogDispatcher;
-            cubeSpawnerCommandRequestHandler.OnDeleteSpawnedCubeRequest += OnDeleteSpawnedCubeRequest;
+            cubeSpawnerCommandRequestReceiver.OnDeleteSpawnedCubeRequest += OnDeleteSpawnedCubeRequest;
             worldCommandResponseHandler.OnDeleteEntityResponse += OnDeleteEntityResponse;
         }
 

--- a/workers/unity/Assets/Playground/Scripts/MonoBehaviours/SpawnCubeCommandReceiver.cs
+++ b/workers/unity/Assets/Playground/Scripts/MonoBehaviours/SpawnCubeCommandReceiver.cs
@@ -23,7 +23,7 @@ namespace Playground.MonoBehaviours
     public class SpawnCubeCommandReceiver : MonoBehaviour
     {
         [Require] private TransformInternal.Requirable.Reader transformReader;
-        [Require] private CubeSpawner.Requirable.CommandRequestHandler cubeSpawnerCommandRequestHandler;
+        [Require] private CubeSpawner.Requirable.CommandRequestReceiver cubeSpawnerCommandRequestReceiver;
         [Require] private CubeSpawner.Requirable.Writer cubeSpawnerWriter;
         [Require] private WorldCommands.Requirable.WorldCommandRequestSender worldCommandRequestSender;
         [Require] private WorldCommands.Requirable.WorldCommandResponseHandler worldCommandResponseHandler;
@@ -33,7 +33,7 @@ namespace Playground.MonoBehaviours
         public void OnEnable()
         {
             logDispatcher = GetComponent<SpatialOSComponent>().Worker.LogDispatcher;
-            cubeSpawnerCommandRequestHandler.OnSpawnCubeRequest += OnSpawnCubeRequest;
+            cubeSpawnerCommandRequestReceiver.OnSpawnCubeRequest += OnSpawnCubeRequest;
             worldCommandResponseHandler.OnReserveEntityIdsResponse += OnEntityIdsReserved;
             worldCommandResponseHandler.OnCreateEntityResponse += OnEntityCreated;
         }

--- a/workers/unity/Assets/Playground/Scripts/MonoBehaviours/SpawnCubeCommandReceiver.cs
+++ b/workers/unity/Assets/Playground/Scripts/MonoBehaviours/SpawnCubeCommandReceiver.cs
@@ -26,7 +26,7 @@ namespace Playground.MonoBehaviours
         [Require] private CubeSpawner.Requirable.CommandRequestReceiver cubeSpawnerCommandRequestReceiver;
         [Require] private CubeSpawner.Requirable.Writer cubeSpawnerWriter;
         [Require] private WorldCommands.Requirable.WorldCommandRequestSender worldCommandRequestSender;
-        [Require] private WorldCommands.Requirable.WorldCommandResponseHandler worldCommandResponseHandler;
+        [Require] private WorldCommands.Requirable.WorldCommandResponseReceiver worldCommandResponseReceiver;
 
         private ILogDispatcher logDispatcher;
 
@@ -34,8 +34,8 @@ namespace Playground.MonoBehaviours
         {
             logDispatcher = GetComponent<SpatialOSComponent>().Worker.LogDispatcher;
             cubeSpawnerCommandRequestReceiver.OnSpawnCubeRequest += OnSpawnCubeRequest;
-            worldCommandResponseHandler.OnReserveEntityIdsResponse += OnEntityIdsReserved;
-            worldCommandResponseHandler.OnCreateEntityResponse += OnEntityCreated;
+            worldCommandResponseReceiver.OnReserveEntityIdsResponse += OnEntityIdsReserved;
+            worldCommandResponseReceiver.OnCreateEntityResponse += OnEntityCreated;
         }
 
         private void OnSpawnCubeRequest(CubeSpawner.SpawnCube.ResponseSender responseSender)

--- a/workers/unity/Assets/Playground/Scripts/MonoBehaviours/SpawnCubeCommandReceiver.cs
+++ b/workers/unity/Assets/Playground/Scripts/MonoBehaviours/SpawnCubeCommandReceiver.cs
@@ -38,9 +38,9 @@ namespace Playground.MonoBehaviours
             worldCommandResponseHandler.OnCreateEntityResponse += OnEntityCreated;
         }
 
-        private void OnSpawnCubeRequest(CubeSpawner.SpawnCube.RequestResponder requestResponder)
+        private void OnSpawnCubeRequest(CubeSpawner.SpawnCube.ResponseSender responseSender)
         {
-            requestResponder.SendResponse(new Empty());
+            responseSender.SendResponse(new Empty());
 
             worldCommandRequestSender.ReserveEntityIds(1, context: this);
         }

--- a/workers/unity/Assets/Playground/Scripts/MonoBehaviours/ToggleRotationCommandReceiver.cs
+++ b/workers/unity/Assets/Playground/Scripts/MonoBehaviours/ToggleRotationCommandReceiver.cs
@@ -15,7 +15,7 @@ namespace Playground.MonoBehaviours
     {
         public float TimeBetweenSpinChanges = 1.0f;
 
-        [Require] private SpinnerRotation.Requirable.CommandRequestHandler requestHandler;
+        [Require] private SpinnerRotation.Requirable.CommandRequestReceiver requestReceiver;
 
         private RotationBehaviour rotationBehaviour;
 
@@ -24,7 +24,7 @@ namespace Playground.MonoBehaviours
         private void OnEnable()
         {
             rotationBehaviour = GetComponent<RotationBehaviour>();
-            requestHandler.OnSpinnerToggleRotationRequest += OnSpinnerToggleRotationRequest;
+            requestReceiver.OnSpinnerToggleRotationRequest += OnSpinnerToggleRotationRequest;
         }
 
         private void OnDisable()

--- a/workers/unity/Assets/Playground/Scripts/MonoBehaviours/ToggleRotationCommandReceiver.cs
+++ b/workers/unity/Assets/Playground/Scripts/MonoBehaviours/ToggleRotationCommandReceiver.cs
@@ -32,7 +32,7 @@ namespace Playground.MonoBehaviours
             nextAvailableSpinChangeTime = Time.time;
         }
 
-        private void OnSpinnerToggleRotationRequest(SpinnerRotation.SpinnerToggleRotation.RequestResponder spinnerToggleRotationRequest)
+        private void OnSpinnerToggleRotationRequest(SpinnerRotation.SpinnerToggleRotation.ResponseSender spinnerToggleRotationRequest)
         {
             if (Time.time < nextAvailableSpinChangeTime)
             {

--- a/workers/unity/Assets/Playground/Scripts/MonoBehaviours/ToggleRotationCommandSender.cs
+++ b/workers/unity/Assets/Playground/Scripts/MonoBehaviours/ToggleRotationCommandSender.cs
@@ -18,16 +18,16 @@ namespace Playground.MonoBehaviours
     {
         [Require] private SpinnerRotation.Requirable.Reader reader;
         [Require] private SpinnerRotation.Requirable.CommandRequestSender requestSender;
-        [Require] private SpinnerRotation.Requirable.CommandResponseHandler responseHandler;
+        [Require] private SpinnerRotation.Requirable.CommandResponseReceiver responseReceiver;
         private EntityId ownEntityId;
 
         private void OnEnable()
         {
             ownEntityId = GetComponent<SpatialOSComponent>().SpatialEntityId;
-            responseHandler.OnSpinnerToggleRotationResponse += ResponseHandlerOnOnSpinnerToggleRotationResponse;
+            responseReceiver.OnSpinnerToggleRotationResponse += ResponseReceiverOnOnSpinnerToggleRotationResponse;
         }
 
-        private void ResponseHandlerOnOnSpinnerToggleRotationResponse(
+        private void ResponseReceiverOnOnSpinnerToggleRotationResponse(
             SpinnerRotation.SpinnerToggleRotation.ReceivedResponse obj)
         {
             if (obj.StatusCode != StatusCode.Success)

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/GameObjectWorldCommandSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/GameObjectWorldCommandSystem.cs
@@ -57,24 +57,24 @@ namespace Improbable.Gdk.GameObjectRepresentation
         [Inject] private DeleteEntityResponseData deleteEntityResponseData;
         [Inject] private EntityQueryResponseData entityQueryResponseData;
 
-        private static readonly InjectableId WorldCommandResponseHandlerInjectableId =
-            new InjectableId(InjectableType.WorldCommandResponseHandler, InjectableId.NullComponentId);
+        private static readonly InjectableId WorldCommandResponseReceiverInjectableId =
+            new InjectableId(InjectableType.WorldCommandResponseReceiver, InjectableId.NullComponentId);
 
         protected override void OnUpdate()
         {
             for (var i = 0; i < reserveEntityIdsResponseData.Length; ++i)
             {
                 var entity = reserveEntityIdsResponseData.Entities[i];
-                var worldCommandResponseHandlers = GetWorldCommandResponseHandlersForEntity(entity);
+                var worldCommandResponseReceivers = GetWorldCommandResponseReceiversForEntity(entity);
 
-                if (worldCommandResponseHandlers == null)
+                if (worldCommandResponseReceivers == null)
                 {
                     continue;
                 }
 
                 foreach (var receivedResponse in reserveEntityIdsResponseData.CommandResponses[i].Responses)
                 {
-                    foreach (var worldCommandHandler in worldCommandResponseHandlers)
+                    foreach (var worldCommandHandler in worldCommandResponseReceivers)
                     {
                         worldCommandHandler.OnReserveEntityIdsResponseInternal(receivedResponse);
                     }
@@ -84,16 +84,16 @@ namespace Improbable.Gdk.GameObjectRepresentation
             for (var i = 0; i < createEntityResponseData.Length; ++i)
             {
                 var entity = createEntityResponseData.Entities[i];
-                var worldCommandResponseHandlers = GetWorldCommandResponseHandlersForEntity(entity);
+                var worldCommandResponseReceivers = GetWorldCommandResponseReceiversForEntity(entity);
 
-                if (worldCommandResponseHandlers == null)
+                if (worldCommandResponseReceivers == null)
                 {
                     continue;
                 }
 
                 foreach (var receivedResponse in createEntityResponseData.CommandResponses[i].Responses)
                 {
-                    foreach (var worldCommandHandler in worldCommandResponseHandlers)
+                    foreach (var worldCommandHandler in worldCommandResponseReceivers)
                     {
                         worldCommandHandler.OnCreateEntityResponseInternal(receivedResponse);
                     }
@@ -103,16 +103,16 @@ namespace Improbable.Gdk.GameObjectRepresentation
             for (var i = 0; i < deleteEntityResponseData.Length; ++i)
             {
                 var entity = deleteEntityResponseData.Entities[i];
-                var worldCommandResponseHandlers = GetWorldCommandResponseHandlersForEntity(entity);
+                var worldCommandResponseReceivers = GetWorldCommandResponseReceiversForEntity(entity);
 
-                if (worldCommandResponseHandlers == null)
+                if (worldCommandResponseReceivers == null)
                 {
                     continue;
                 }
 
                 foreach (var receivedResponse in deleteEntityResponseData.CommandResponses[i].Responses)
                 {
-                    foreach (var worldCommandHandler in worldCommandResponseHandlers)
+                    foreach (var worldCommandHandler in worldCommandResponseReceivers)
                     {
                         worldCommandHandler.OnDeleteEntityResponseInternal(receivedResponse);
                     }
@@ -122,16 +122,16 @@ namespace Improbable.Gdk.GameObjectRepresentation
             for (var i = 0; i < entityQueryResponseData.Length; ++i)
             {
                 var entity = entityQueryResponseData.Entities[i];
-                var worldCommandResponseHandlers = GetWorldCommandResponseHandlersForEntity(entity);
+                var worldCommandResponseReceivers = GetWorldCommandResponseReceiversForEntity(entity);
 
-                if (worldCommandResponseHandlers == null)
+                if (worldCommandResponseReceivers == null)
                 {
                     continue;
                 }
 
                 foreach (var receivedResponse in entityQueryResponseData.CommandResponses[i].Responses)
                 {
-                    foreach (var worldCommandHandler in worldCommandResponseHandlers)
+                    foreach (var worldCommandHandler in worldCommandResponseReceivers)
                     {
                         worldCommandHandler.OnEntityQueryResponseInternal(receivedResponse);
                     }
@@ -139,7 +139,7 @@ namespace Improbable.Gdk.GameObjectRepresentation
             }
         }
 
-        private WorldCommands.Requirable.WorldCommandResponseHandler[] GetWorldCommandResponseHandlersForEntity(
+        private WorldCommands.Requirable.WorldCommandResponseReceiver[] GetWorldCommandResponseReceiversForEntity(
             Entity entity)
         {
             var entityToReaderWriterStore = gameObjectDispatcherSystem.EntityToReaderWriterStore;
@@ -149,7 +149,7 @@ namespace Improbable.Gdk.GameObjectRepresentation
                 return null;
             }
 
-            if (!injectableStore.TryGetInjectablesForComponent(WorldCommandResponseHandlerInjectableId,
+            if (!injectableStore.TryGetInjectablesForComponent(WorldCommandResponseReceiverInjectableId,
                 out var injectables))
             {
                 return null;
@@ -161,7 +161,7 @@ namespace Improbable.Gdk.GameObjectRepresentation
             }
 
             return Array.ConvertAll(injectables.ToArray(),
-                injectable => (WorldCommands.Requirable.WorldCommandResponseHandler) injectable);
+                injectable => (WorldCommands.Requirable.WorldCommandResponseReceiver) injectable);
         }
     }
 }

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/Injection/InjectableId.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/Injection/InjectableId.cs
@@ -10,9 +10,9 @@ namespace Improbable.Gdk.GameObjectRepresentation
         ReaderWriter,
         CommandRequestSender,
         CommandRequestReceiver,
-        CommandResponseHandler,
+        CommandResponseReceiver,
         WorldCommandRequestSender,
-        WorldCommandResponseHandler,
+        WorldCommandResponseReceiver,
     }
 
     /// <summary>

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/Injection/InjectableId.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/Injection/InjectableId.cs
@@ -9,7 +9,7 @@ namespace Improbable.Gdk.GameObjectRepresentation
     {
         ReaderWriter,
         CommandRequestSender,
-        CommandRequestHandler,
+        CommandRequestReceiver,
         CommandResponseHandler,
         WorldCommandRequestSender,
         WorldCommandResponseHandler,

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/Injection/WorldCommandResponseHandler.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/Injection/WorldCommandResponseHandler.cs
@@ -17,9 +17,9 @@ namespace Improbable.Gdk.Core.Commands
     {
         public static partial class Requirable
         {
-            [InjectableId(InjectableType.WorldCommandResponseHandler, InjectableId.NullComponentId)]
+            [InjectableId(InjectableType.WorldCommandResponseReceiver, InjectableId.NullComponentId)]
             [InjectionCondition(InjectionCondition.RequireNothing)]
-            public class WorldCommandResponseHandler : RequirableBase
+            public class WorldCommandResponseReceiver : RequirableBase
             {
                 private readonly ILogDispatcher logDispatcher;
 
@@ -30,7 +30,7 @@ namespace Improbable.Gdk.Core.Commands
                 private readonly List<Action<DeleteEntity.ReceivedResponse>> deleteEntityDelegates;
                 private readonly List<Action<EntityQuery.ReceivedResponse>> entityQueryDelegates;
 
-                private WorldCommandResponseHandler(ILogDispatcher logDispatcher) : base(logDispatcher)
+                private WorldCommandResponseReceiver(ILogDispatcher logDispatcher) : base(logDispatcher)
                 {
                     this.logDispatcher = logDispatcher;
                     reserveEntityIdsDelegates = new List<Action<ReserveEntityIds.ReceivedResponse>>();
@@ -151,13 +151,13 @@ namespace Improbable.Gdk.Core.Commands
                         logDispatcher);
                 }
 
-                [InjectableId(InjectableType.WorldCommandResponseHandler, InjectableId.NullComponentId)]
-                private class WorldCommandResponseHandlerCreator : IInjectableCreator
+                [InjectableId(InjectableType.WorldCommandResponseReceiver, InjectableId.NullComponentId)]
+                private class WorldCommandResponseReceiverCreator : IInjectableCreator
                 {
                     public IInjectable CreateInjectable(Entity entity, EntityManager entityManager,
                         ILogDispatcher logDispatcher)
                     {
-                        return new WorldCommandResponseHandler(logDispatcher);
+                        return new WorldCommandResponseReceiver(logDispatcher);
                     }
                 }
             }

--- a/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/ReadersWriters/RequirableBase.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/GameObjectRepresentation/ReadersWriters/RequirableBase.cs
@@ -7,7 +7,7 @@ namespace Improbable.Gdk.GameObjectRepresentation
     public class RequirableBase : IInjectable, IDisposable
     {
         private const string AccessedDisposedRequirable =
-            "Tried to access a disposed [Require] SpatialOS MonoBehaviour API object (e.g. Reader, Writer, CommandRequestSender, CommandRequestHandler etc.). " +
+            "Tried to access a disposed [Require] SpatialOS MonoBehaviour API object (e.g. Reader, Writer, CommandRequestSender, CommandRequestReceiver etc.). " +
             "Note that [Require] objects are already disposed at the time OnDisable() is called. " +
             "Also note that user callbacks are deregistered automatically so there is no need to manually deregister them in OnDisable().";
 

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityGameObjectCommandHandlersGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityGameObjectCommandHandlersGenerator.tt
@@ -100,24 +100,24 @@ namespace <#= qualifiedNamespace #>
 <# } #>
             }
 
-            [InjectableId(InjectableType.CommandRequestHandler, <#= unityComponentDefinition.Id #>)]
-            internal class CommandRequestHandlerCreator : IInjectableCreator
+            [InjectableId(InjectableType.CommandRequestReceiver, <#= unityComponentDefinition.Id #>)]
+            internal class CommandRequestReceiverCreator : IInjectableCreator
             {
                 public IInjectable CreateInjectable(Entity entity, EntityManager entityManager, ILogDispatcher logDispatcher)
                 {
-                    return new CommandRequestHandler(entity, entityManager, logDispatcher);
+                    return new CommandRequestReceiver(entity, entityManager, logDispatcher);
                 }
             }
 
-            [InjectableId(InjectableType.CommandRequestHandler, <#= unityComponentDefinition.Id #>)]
+            [InjectableId(InjectableType.CommandRequestReceiver, <#= unityComponentDefinition.Id #>)]
             [InjectionCondition(InjectionCondition.RequireComponentWithAuthority)]
-            public class CommandRequestHandler : RequirableBase
+            public class CommandRequestReceiver : RequirableBase
             {
                 private Entity entity;
                 private readonly EntityManager entityManager;
                 private readonly ILogDispatcher logger;
 
-                public CommandRequestHandler(Entity entity, EntityManager entityManager, ILogDispatcher logger) : base(logger)
+                public CommandRequestReceiver(Entity entity, EntityManager entityManager, ILogDispatcher logger) : base(logger)
                 {
                     this.entity = entity;
                     this.entityManager = entityManager;

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityGameObjectCommandHandlersGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityGameObjectCommandHandlersGenerator.tt
@@ -28,13 +28,13 @@ namespace <#= qualifiedNamespace #>
 #>
         public partial class <#= commandDetails.CommandName #>
         {
-            public struct RequestResponder
+            public struct ResponseSender
             {
                 private readonly EntityManager entityManager;
                 private readonly Entity entity;
                 public <#= rawRequestType #> Request { get; }
 
-                internal RequestResponder(EntityManager entityManager, Entity entity, <#= rawRequestType #> request)
+                internal ResponseSender(EntityManager entityManager, Entity entity, <#= rawRequestType #> request)
                 {
                     this.entity = entity;
                     this.entityManager = entityManager;
@@ -127,11 +127,11 @@ namespace <#= qualifiedNamespace #>
            var delegateList = commandDetails.CamelCaseCommandName + "Delegates";
            var rawRequestType = commandDetails.CommandName + ".ReceivedRequest";
            var rawResponseType = commandDetails.CommandName + ".Response";
-           var wrappedRequestType = commandDetails.CommandName + ".RequestResponder";
+           var responseSenderType = commandDetails.CommandName + ".ResponseSender";
            var responsePayloadType = commandDetails.FqnResponseType;
 #>
-                private readonly List<Action<<#= wrappedRequestType #>>> <#= delegateList #> = new List<Action<<#= wrappedRequestType #>>>();
-                public event Action<<#= wrappedRequestType #>> On<#= commandDetails.CommandName #>Request
+                private readonly List<Action<<#= responseSenderType #>>> <#= delegateList #> = new List<Action<<#= responseSenderType #>>>();
+                public event Action<<#= responseSenderType #>> On<#= commandDetails.CommandName #>Request
                 {
                     add
                     {
@@ -155,7 +155,7 @@ namespace <#= qualifiedNamespace #>
 
                 internal void On<#= commandDetails.CommandName #>RequestInternal(<#= rawRequestType #> request)
                 {
-                    GameObjectDelegates.DispatchWithErrorHandling(new <#= wrappedRequestType #>(entityManager, entity, request), <#= delegateList #>, logger);
+                    GameObjectDelegates.DispatchWithErrorHandling(new <#= responseSenderType #>(entityManager, entity, request), <#= delegateList #>, logger);
                 }
 <# } #>
             }

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityGameObjectCommandHandlersGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityGameObjectCommandHandlersGenerator.tt
@@ -160,24 +160,24 @@ namespace <#= qualifiedNamespace #>
 <# } #>
             }
 
-            [InjectableId(InjectableType.CommandResponseHandler, <#= unityComponentDefinition.Id #>)]
-            internal class CommandResponseHandlerCreator : IInjectableCreator
+            [InjectableId(InjectableType.CommandResponseReceiver, <#= unityComponentDefinition.Id #>)]
+            internal class CommandResponseReceiverCreator : IInjectableCreator
             {
                 public IInjectable CreateInjectable(Entity entity, EntityManager entityManager, ILogDispatcher logDispatcher)
                 {
-                    return new CommandResponseHandler(entity, entityManager, logDispatcher);
+                    return new CommandResponseReceiver(entity, entityManager, logDispatcher);
                 }
             }
 
-            [InjectableId(InjectableType.CommandResponseHandler, <#= unityComponentDefinition.Id #>)]
+            [InjectableId(InjectableType.CommandResponseReceiver, <#= unityComponentDefinition.Id #>)]
             [InjectionCondition(InjectionCondition.RequireNothing)]
-            public class CommandResponseHandler : RequirableBase
+            public class CommandResponseReceiver : RequirableBase
             {
                 private Entity entity;
                 private readonly EntityManager entityManager;
                 private readonly ILogDispatcher logger;
 
-                public CommandResponseHandler(Entity entity, EntityManager entityManager, ILogDispatcher logger) : base(logger)
+                public CommandResponseReceiver(Entity entity, EntityManager entityManager, ILogDispatcher logger) : base(logger)
                 {
                     this.entity = entity;
                     this.entityManager = entityManager;

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityGameObjectComponentDispatcherGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityGameObjectComponentDispatcherGenerator.tt
@@ -85,7 +85,7 @@ namespace <#= qualifiedNamespace #>
             private const uint componentId = <#= unityComponentDefinition.Id #>;
             private static readonly InjectableId readerWriterInjectableId = new InjectableId(InjectableType.ReaderWriter, componentId);
 <# if (commandDetailsList.Count > 0) { #>
-            private static readonly InjectableId commandRequestHandlerInjectableId = new InjectableId(InjectableType.CommandRequestHandler, componentId);
+            private static readonly InjectableId commandRequestReceiverInjectableId = new InjectableId(InjectableType.CommandRequestReceiver, componentId);
             private static readonly InjectableId commandResponseHandlerInjectableId = new InjectableId(InjectableType.CommandResponseHandler, componentId);
 <# } #>
 
@@ -249,17 +249,17 @@ namespace <#= qualifiedNamespace #>
                     for (var i = 0; i < entities.Length; i++)
                     {
                         var injectableStore = entityToInjectableStore[entities[i]];
-                        if (!injectableStore.TryGetInjectablesForComponent(commandRequestHandlerInjectableId, out var commandRequestHandlers))
+                        if (!injectableStore.TryGetInjectablesForComponent(commandRequestReceiverInjectableId, out var commandRequestReceivers))
                         {
                             continue;
                         }
 
                         var commandRequestList = commandRequestLists[i];
-                        foreach (Requirable.CommandRequestHandler commandRequestHandler in commandRequestHandlers)
+                        foreach (Requirable.CommandRequestReceiver commandRequestReceiver in commandRequestReceivers)
                         {
                             foreach (var commandRequest in commandRequestList.Requests)
                             {
-                                commandRequestHandler.On<#= commandDetailsList[j].CommandName #>RequestInternal(commandRequest);
+                                commandRequestReceiver.On<#= commandDetailsList[j].CommandName #>RequestInternal(commandRequest);
                             }
                         }
                     }

--- a/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityGameObjectComponentDispatcherGenerator.tt
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.CodeGenerator/GdkCodeGenerator/Templates/UnityGameObjectComponentDispatcherGenerator.tt
@@ -86,7 +86,7 @@ namespace <#= qualifiedNamespace #>
             private static readonly InjectableId readerWriterInjectableId = new InjectableId(InjectableType.ReaderWriter, componentId);
 <# if (commandDetailsList.Count > 0) { #>
             private static readonly InjectableId commandRequestReceiverInjectableId = new InjectableId(InjectableType.CommandRequestReceiver, componentId);
-            private static readonly InjectableId commandResponseHandlerInjectableId = new InjectableId(InjectableType.CommandResponseHandler, componentId);
+            private static readonly InjectableId commandResponseReceiverInjectableId = new InjectableId(InjectableType.CommandResponseReceiver, componentId);
 <# } #>
 
             public override void MarkComponentsAddedForActivation(Dictionary<Unity.Entities.Entity, MonoBehaviourActivationManager> entityToManagers)
@@ -283,17 +283,17 @@ namespace <#= qualifiedNamespace #>
                     for (var i = 0; i < entities.Length; i++)
                     {
                         var injectableStore = entityToInjectableStore[entities[i]];
-                        if (!injectableStore.TryGetInjectablesForComponent(commandResponseHandlerInjectableId, out var commandResponseHandlers))
+                        if (!injectableStore.TryGetInjectablesForComponent(commandResponseReceiverInjectableId, out var commandResponseReceivers))
                         {
                             continue;
                         }
 
                         var commandResponseList = commandResponseLists[i];
-                        foreach (Requirable.CommandResponseHandler commandResponseHandler in commandResponseHandlers)
+                        foreach (Requirable.CommandResponseReceiver commandResponseReceiver in commandResponseReceivers)
                         {
                             foreach (var commandResponse in commandResponseList.Responses)
                             {
-                                commandResponseHandler.On<#= commandDetailsList[j].CommandName #>ResponseInternal(commandResponse);
+                                commandResponseReceiver.On<#= commandDetailsList[j].CommandName #>ResponseInternal(commandResponse);
                             }
                         }
                     }


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
Various sources confirm that `RequestResponder` is a quite awful name.

(Multiple user and some team members' feedback)

After a bit of discussion within internal documentation comments, here are suggestions on improvements for command-related names.

First commit: `RequestResponder` -> `ResponseSender`
Second commit: `RequestHandler` -> `RequestReceiver`
Third commit: `ResponseHandler` -> `ResponseReceiver`

#### Tests
Tested local deployments, everything works as expected

#### Documentation
Updated relevant documentation files, but some of them are WIP anyway.

Need to update the WIP docs when this PR goes in.

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.

@jessicafalk 
@jamiebrynes7 