### PR TITLE
UTY-1181 Adding plugin directories compatibility logic

### DIFF
--- a/workers/unity/Packages/com.improbable.gdk.tools/.DownloadCoreSdk/Program.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.DownloadCoreSdk/Program.cs
@@ -29,7 +29,7 @@ namespace Improbable
                 new Package(tempPath, "worker_sdk", "c-dynamic-x86_64-msvc_mt-win32", $"{nativeDependenciesPath}/Windows/x86_64", new List<string> {"include", "worker.lib"}),
                 new Package(tempPath, "worker_sdk", "c-dynamic-x86_64-gcc_libstdcpp-linux", $"{nativeDependenciesPath}/Linux/x86_64", new List<string> {"include"}),
                 new Package(tempPath, "worker_sdk", "c-bundle-x86_64-clang_libcpp-macos", $"{nativeDependenciesPath}/OSX", new List<string> {"include"}),
-                new Package(tempPath, "worker_sdk", "csharp_core", $"{managedDependenciesPath}/OSX"),
+                new Package(tempPath, "worker_sdk", "csharp_core", $"{managedDependenciesPath}/Common"),
                 new Package(tempPath, "schema", "standard_library", schemaStdLibDir),
                 new Package(tempPath, "tools", "schema_compiler-x86_64-win32", $"{tempPath}/schema_compiler", null, OSPlatform.Windows),
                 new Package(tempPath, "tools", "schema_compiler-x86_64-macos", $"{tempPath}/schema_compiler", null, OSPlatform.OSX),

--- a/workers/unity/Packages/com.improbable.gdk.tools/DownloadCoreSdk.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/DownloadCoreSdk.cs
@@ -27,10 +27,10 @@ namespace Improbable.Gdk.Tools
 
         private static readonly List<PluginDirectoryCompatibility> PluginsCompatibilityList = new List<PluginDirectoryCompatibility>
         {
-            new PluginDirectoryCompatibility("Assets/Plugins/Improbable/Core/OSX", false, new List<BuildTarget> { BuildTarget.StandaloneOSX }, null, true),
-            new PluginDirectoryCompatibility("Assets/Plugins/Improbable/Core/Linux", false, new List<BuildTarget> { BuildTarget.StandaloneLinuxUniversal }, null, true),
-            new PluginDirectoryCompatibility("Assets/Plugins/Improbable/Core/Windows", false, new List<BuildTarget> { BuildTarget.StandaloneWindows64 }, null, true),
-            new PluginDirectoryCompatibility("Assets/Plugins/Improbable/Sdk/Common", true, null, null, true),
+            PluginDirectoryCompatibility.PluginDirectoryIncludePlatforms("Assets/Plugins/Improbable/Core/OSX", new List<BuildTarget> { BuildTarget.StandaloneOSX }, true),
+            PluginDirectoryCompatibility.PluginDirectoryIncludePlatforms("Assets/Plugins/Improbable/Core/Linux", new List<BuildTarget> { BuildTarget.StandaloneLinuxUniversal }, true),
+            PluginDirectoryCompatibility.PluginDirectoryIncludePlatforms("Assets/Plugins/Improbable/Core/Windows", new List<BuildTarget> { BuildTarget.StandaloneWindows64 }, true),
+            PluginDirectoryCompatibility.PluginDirectoryExcludePlatforms("Assets/Plugins/Improbable/Sdk/Common", null, true),
         };
 
         [MenuItem(DownloadForceMenuItem, false, DownloadForcePriority)]
@@ -147,6 +147,9 @@ namespace Improbable.Gdk.Tools
             return exitCode == 0 ? DownloadResult.Success : DownloadResult.Error;
         }
 
+        /// <summary>
+        ///     Sets plugin platform compatibility based on directory structure
+        /// </summary>
         private static void SetPluginsCompatibility()
         {
             foreach (var pluginDirectoryCompatibility in PluginsCompatibilityList)
@@ -184,7 +187,21 @@ namespace Improbable.Gdk.Tools
 
         private class PluginDirectoryCompatibility
         {
-            public PluginDirectoryCompatibility(string path,
+            public static PluginDirectoryCompatibility PluginDirectoryIncludePlatforms(string path,
+                List<BuildTarget> compatiblePlatforms,
+                bool editorCompatible)
+            {
+                return new PluginDirectoryCompatibility(path, false, compatiblePlatforms, null, editorCompatible);
+            }
+
+            public static PluginDirectoryCompatibility PluginDirectoryExcludePlatforms(string path,
+                List<BuildTarget> incompatiblePlatforms,
+                bool editorCompatible)
+            {
+                return new PluginDirectoryCompatibility(path, true, null, incompatiblePlatforms, editorCompatible);
+            }
+
+            private PluginDirectoryCompatibility(string path,
                 bool anyPlatformCompatible,
                 List<BuildTarget> compatiblePlatforms,
                 List<BuildTarget> incompatiblePlatforms,
@@ -192,16 +209,6 @@ namespace Improbable.Gdk.Tools
             {
                 Path = path;
                 AnyPlatformCompatible = anyPlatformCompatible;
-                if (anyPlatformCompatible && compatiblePlatforms != null)
-                {
-                    Debug.LogError($"Bad plugin compatibility configuration for  {path}. Compatible with any shouldn't be used with a list of compatible platforms");
-                }
-
-                if (!anyPlatformCompatible && incompatiblePlatforms != null)
-                {
-                    Debug.LogError($"Bad plugin compatibility configuration for  {path}. Not compatible with any shouldn't be used with a list of incompatible platforms");
-                }
-
                 CompatiblePlatforms = compatiblePlatforms ?? new List<BuildTarget>();
                 IncompatiblePlatforms = incompatiblePlatforms ?? new List<BuildTarget>();
                 EditorCompatible = editorCompatible;

--- a/workers/unity/Packages/com.improbable.gdk.tools/DownloadCoreSdk.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/DownloadCoreSdk.cs
@@ -30,7 +30,7 @@ namespace Improbable.Gdk.Tools
             new PluginDirectoryCompatibility("Assets/Plugins/Improbable/Core/OSX", false, new List<BuildTarget> { BuildTarget.StandaloneOSX }, null, true),
             new PluginDirectoryCompatibility("Assets/Plugins/Improbable/Core/Linux", false, new List<BuildTarget> { BuildTarget.StandaloneLinuxUniversal }, null, true),
             new PluginDirectoryCompatibility("Assets/Plugins/Improbable/Core/Windows", false, new List<BuildTarget> { BuildTarget.StandaloneWindows64 }, null, true),
-            new PluginDirectoryCompatibility("Assets/Plugins/Improbable/Sdk/OSX", true, null, null, true),
+            new PluginDirectoryCompatibility("Assets/Plugins/Improbable/Sdk/Common", true, null, null, true),
         };
 
         [MenuItem(DownloadForceMenuItem, false, DownloadForcePriority)]

--- a/workers/unity/Packages/com.improbable.gdk.tools/DownloadCoreSdk.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/DownloadCoreSdk.cs
@@ -27,10 +27,10 @@ namespace Improbable.Gdk.Tools
 
         private static readonly List<PluginDirectoryCompatibility> PluginsCompatibilityList = new List<PluginDirectoryCompatibility>
         {
-            PluginDirectoryCompatibility.PluginDirectoryIncludePlatforms("Assets/Plugins/Improbable/Core/OSX", new List<BuildTarget> { BuildTarget.StandaloneOSX }, true),
-            PluginDirectoryCompatibility.PluginDirectoryIncludePlatforms("Assets/Plugins/Improbable/Core/Linux", new List<BuildTarget> { BuildTarget.StandaloneLinuxUniversal }, true),
-            PluginDirectoryCompatibility.PluginDirectoryIncludePlatforms("Assets/Plugins/Improbable/Core/Windows", new List<BuildTarget> { BuildTarget.StandaloneWindows64 }, true),
-            PluginDirectoryCompatibility.PluginDirectoryExcludePlatforms("Assets/Plugins/Improbable/Sdk/Common", null, true),
+            PluginDirectoryCompatibility.CreateWithCompatiblePlatforms("Assets/Plugins/Improbable/Core/OSX", new List<BuildTarget> { BuildTarget.StandaloneOSX }, true),
+            PluginDirectoryCompatibility.CreateWithCompatiblePlatforms("Assets/Plugins/Improbable/Core/Linux", new List<BuildTarget> { BuildTarget.StandaloneLinuxUniversal }, true),
+            PluginDirectoryCompatibility.CreateWithCompatiblePlatforms("Assets/Plugins/Improbable/Core/Windows", new List<BuildTarget> { BuildTarget.StandaloneWindows64 }, true),
+            PluginDirectoryCompatibility.CreateAllCompatible("Assets/Plugins/Improbable/Sdk/Common"),
         };
 
         [MenuItem(DownloadForceMenuItem, false, DownloadForcePriority)]
@@ -45,8 +45,6 @@ namespace Improbable.Gdk.Tools
             }
 
             Download();
-            AssetDatabase.Refresh();
-            SetPluginsCompatibility();
         }
 
         private static void RemoveMarkerFile()
@@ -109,9 +107,7 @@ namespace Improbable.Gdk.Tools
                 return DownloadResult.AlreadyInstalled;
             }
 
-            DownloadResult result = Download();
-            SetPluginsCompatibility();
-            return result;
+            return Download();
         }
 
         /// <summary>
@@ -144,6 +140,8 @@ namespace Improbable.Gdk.Tools
                 EditorApplication.UnlockReloadAssemblies();
             }
 
+            AssetDatabase.Refresh();
+            SetPluginsCompatibility();
             return exitCode == 0 ? DownloadResult.Success : DownloadResult.Error;
         }
 
@@ -187,20 +185,24 @@ namespace Improbable.Gdk.Tools
 
         private class PluginDirectoryCompatibility
         {
-            public static PluginDirectoryCompatibility PluginDirectoryIncludePlatforms(string path,
+            public static PluginDirectoryCompatibility CreateWithCompatiblePlatforms(string path,
                 List<BuildTarget> compatiblePlatforms,
                 bool editorCompatible)
             {
                 return new PluginDirectoryCompatibility(path, false, compatiblePlatforms, null, editorCompatible);
             }
 
-            public static PluginDirectoryCompatibility PluginDirectoryExcludePlatforms(string path,
+            public static PluginDirectoryCompatibility CreateWithIncompatiblePlatforms(string path,
                 List<BuildTarget> incompatiblePlatforms,
                 bool editorCompatible)
             {
                 return new PluginDirectoryCompatibility(path, true, null, incompatiblePlatforms, editorCompatible);
             }
 
+            public static PluginDirectoryCompatibility CreateAllCompatible(string path)
+            {
+                return new PluginDirectoryCompatibility(path, true, null, incompatiblePlatforms, editorCompatible);
+            }
             private PluginDirectoryCompatibility(string path,
                 bool anyPlatformCompatible,
                 List<BuildTarget> compatiblePlatforms,

--- a/workers/unity/Packages/com.improbable.gdk.tools/DownloadCoreSdk.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/DownloadCoreSdk.cs
@@ -27,9 +27,10 @@ namespace Improbable.Gdk.Tools
 
         private static readonly List<PluginDirectoryCompatibility> PluginsCompatibilityList = new List<PluginDirectoryCompatibility>
         {
-            PluginDirectoryCompatibility.CreateWithCompatiblePlatforms("Assets/Plugins/Improbable/Core/OSX", new List<BuildTarget> { BuildTarget.StandaloneOSX }, true),
-            PluginDirectoryCompatibility.CreateWithCompatiblePlatforms("Assets/Plugins/Improbable/Core/Linux", new List<BuildTarget> { BuildTarget.StandaloneLinuxUniversal }, true),
-            PluginDirectoryCompatibility.CreateWithCompatiblePlatforms("Assets/Plugins/Improbable/Core/Windows", new List<BuildTarget> { BuildTarget.StandaloneWindows64 }, true),
+            PluginDirectoryCompatibility.CreateWithCompatiblePlatforms("Assets/Plugins/Improbable/Core/OSX", new List<BuildTarget> { BuildTarget.StandaloneOSX }, editorCompatible: true),
+            PluginDirectoryCompatibility.CreateWithCompatiblePlatforms("Assets/Plugins/Improbable/Core/Linux", new List<BuildTarget> { BuildTarget.StandaloneLinuxUniversal }, editorCompatible: true),
+            PluginDirectoryCompatibility.CreateWithCompatiblePlatforms("Assets/Plugins/Improbable/Core/Windows/x86_64", new List<BuildTarget> { BuildTarget.StandaloneWindows64 }, editorCompatible: true),
+            PluginDirectoryCompatibility.CreateWithCompatiblePlatforms("Assets/Plugins/Improbable/Core/Windows/x86", new List<BuildTarget> { BuildTarget.StandaloneWindows }, false),
             PluginDirectoryCompatibility.CreateAllCompatible("Assets/Plugins/Improbable/Sdk/Common"),
         };
 
@@ -140,9 +141,14 @@ namespace Improbable.Gdk.Tools
                 EditorApplication.UnlockReloadAssemblies();
             }
 
+            if (exitCode != 0)
+            {
+                return DownloadResult.Error;
+            }
+
             AssetDatabase.Refresh();
             SetPluginsCompatibility();
-            return exitCode == 0 ? DownloadResult.Success : DownloadResult.Error;
+            return DownloadResult.Success;
         }
 
         /// <summary>
@@ -201,8 +207,9 @@ namespace Improbable.Gdk.Tools
 
             public static PluginDirectoryCompatibility CreateAllCompatible(string path)
             {
-                return new PluginDirectoryCompatibility(path, true, null, incompatiblePlatforms, editorCompatible);
+                return new PluginDirectoryCompatibility(path, true, null, null, true);
             }
+
             private PluginDirectoryCompatibility(string path,
                 bool anyPlatformCompatible,
                 List<BuildTarget> compatiblePlatforms,


### PR DESCRIPTION
This PR adds a logic that allows us to mark plugins compatibility platform after download

**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
We use different plugins for different platforms and we need to mark their compatibility in order to avoid conflicts in Unity (i.e. iOS Worker DLL and non-iOS one). This PR adds a logic that marks plugins compatibility based on our plugin structure.
#### Tests
Run Download plugins in Unity and ensure that plugins are marked as expected.
#### Documentation
What would be a good place to document this?
