### PR TITLE
Allow getting of EntityIds from EntityQuery results

### DIFF
--- a/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Commands/WorldCommands.cs
@@ -700,11 +700,6 @@ namespace Improbable.Gdk.Core.Commands
 
             public static Request CreateRequest(Improbable.Worker.Query.EntityQuery entityQuery, uint? timeoutMillis = null, Object context = null)
             {
-                if (entityQuery.ResultType is SnapshotResultType)
-                {
-                    Debug.LogWarning("Cannot safely access component data from entity query - this is a known issue. To protect its integrity, the worker will drop the request before sending.");
-                }
-
                 return new Request
                 {
                     EntityQuery = entityQuery,
@@ -718,7 +713,7 @@ namespace Improbable.Gdk.Core.Commands
             {
                 public StatusCode StatusCode { get; }
                 public string Message { get; }
-                public Dictionary<EntityId, Entity> Result { get; }
+                public EntityId[] EntityIds { get; }
                 public int ResultCount { get; }
                 public Request RequestPayload { get; }
                 public object Context { get; }
@@ -728,7 +723,7 @@ namespace Improbable.Gdk.Core.Commands
                 {
                     StatusCode = op.StatusCode;
                     Message = op.Message;
-                    Result = op.Result;
+                    EntityIds = op.Result?.Keys.ToArray();
                     ResultCount = op.ResultCount;
                     RequestPayload = req;
                     Context = context;

--- a/workers/unity/Packages/com.improbable.gdk.core/Systems/WorldCommandsSendSystem.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Systems/WorldCommandsSendSystem.cs
@@ -121,11 +121,6 @@ namespace Improbable.Gdk.Core
                 var entity = entityQuerySenderData.Entities[i];
                 foreach (var req in sender.RequestsToSend)
                 {
-                    if (req.EntityQuery.ResultType is SnapshotResultType)
-                    {
-                        continue;
-                    }
-
                     var reqId = connection.SendEntityQueryRequest(req.EntityQuery, req.TimeoutMillis);
                     entityQueryStorage.CommandRequestsInFlight.Add(reqId.Id,
                         new CommandRequestStore<WorldCommands.EntityQuery.Request>(entity, req, req.Context, req.RequestId));

--- a/workers/unity/Packages/com.improbable.gdk.core/Tests/Editmode/Systems/SpatialOSReceiveSystemTests.cs
+++ b/workers/unity/Packages/com.improbable.gdk.core/Tests/Editmode/Systems/SpatialOSReceiveSystemTests.cs
@@ -532,7 +532,7 @@ namespace Improbable.Gdk.Core.EditmodeTests.Systems
                 Assert.AreEqual(TestCommandRequestId, response.RequestId);
                 Assert.AreEqual(wrappedOp.Op.StatusCode, response.StatusCode);
                 Assert.AreEqual(wrappedOp.Op.Message, response.Message);
-                Assert.AreEqual(wrappedOp.Op.Result, response.Result);
+                Assert.AreEqual(wrappedOp.Op.Result?.Keys.ToArray(), response.EntityIds);
                 Assert.AreEqual(wrappedOp.Op.ResultCount, response.ResultCount);
             }
         }


### PR DESCRIPTION
**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
This has some uses (e.g. if users want to send commands to these entities) and it's still safe to access the entity ids.

#### Tests
Adjusted relevant tests, also tested locally, this code:
```csharp
        public void OnEnable()
        {
            worldCommandResponseHandler.OnEntityQueryResponse += OnEntityQueryResponse;
        }

        private void OnEntityQueryResponse(WorldCommands.EntityQuery.ReceivedResponse response)
        {
            Debug.Log($"Entity query response {response.StatusCode}");

            if (response.StatusCode == StatusCode.Success)
            {
                Debug.Log($"count: {response.ResultCount}");

                foreach (var responseEntityId in response.EntityIds)
                {
                    Debug.Log($"Result entity id: {responseEntityId.Id}");
                }
            }
        }
```

Produces these logs:
![image](https://user-images.githubusercontent.com/31209570/46421457-04ed1400-c72a-11e8-8d39-404eb8659cb5.png)


#### Documentation
Will update relevant docs if pr goes in:
- known issues?
- worldcommands docs in gdocs

#### Primary reviewers
If your change will take a long time to review, you can name at most two primary reviewers who are ultimately responsible for reviewing this request. @ mention them.
@paulbalaji 