### PR TITLE
Revert "UTY-1181 Adding plugin directories compatibility logic (#445)"

### DIFF
--- a/workers/unity/Packages/com.improbable.gdk.tools/.DownloadCoreSdk/Program.cs
+++ b/workers/unity/Packages/com.improbable.gdk.tools/.DownloadCoreSdk/Program.cs
@@ -29,7 +29,7 @@ namespace Improbable
                 new Package(tempPath, "worker_sdk", "c-dynamic-x86_64-msvc_mt-win32", $"{nativeDependenciesPath}/Windows/x86_64", new List<string> {"include", "worker.lib"}),
                 new Package(tempPath, "worker_sdk", "c-dynamic-x86_64-gcc_libstdcpp-linux", $"{nativeDependenciesPath}/Linux/x86_64", new List<string> {"include"}),
                 new Package(tempPath, "worker_sdk", "c-bundle-x86_64-clang_libcpp-macos", $"{nativeDependenciesPath}/OSX", new List<string> {"include"}),
-                new Package(tempPath, "worker_sdk", "csharp_core", $"{managedDependenciesPath}/Common"),
+                new Package(tempPath, "worker_sdk", "csharp_core", $"{managedDependenciesPath}/OSX"),
                 new Package(tempPath, "schema", "standard_library", schemaStdLibDir),
                 new Package(tempPath, "tools", "schema_compiler-x86_64-win32", $"{tempPath}/schema_compiler", null, OSPlatform.Windows),
                 new Package(tempPath, "tools", "schema_compiler-x86_64-macos", $"{tempPath}/schema_compiler", null, OSPlatform.OSX),


### PR DESCRIPTION
This reverts commit 45d879250ad9e59dec28c8e7f219c2a4954eca95.

**Contributions**: We are not currently taking public contributions - see our [contributions](CONTRIBUTING.md) policy. However, we are accepting issues and we do want your [feedback](../README.md#give-us-feedback).

-------

#### Description
This reverts Plugin compatibility logic to initial state
#### Tests
Download logic goes back to initial state
#### Documentation
How is this documented (for example: release note, upgrade guide, feature page, in-code documentation)?
#### Primary reviewers
